### PR TITLE
fix: prune 2.6k dead recording links, repopulate 86 via YouTube API

### DIFF
--- a/scripts/repopulate-recordings.ts
+++ b/scripts/repopulate-recordings.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env bun
+// Fills missing YouTube recording links in seed*.ts files using the YouTube Data API.
+// Only touches pieces that have ZERO existing youtube links — preserves curated ones.
+//
+// Usage:
+//   YOUTUBE_API_KEY=... bun run scripts/repopulate-recordings.ts            # all files
+//   YOUTUBE_API_KEY=... bun run scripts/repopulate-recordings.ts <substr>   # filter by filename
+//   YOUTUBE_API_KEY=... DRY_RUN=1 bun run scripts/repopulate-recordings.ts  # preview
+//   YOUTUBE_API_KEY=... LIMIT=50 bun run scripts/repopulate-recordings.ts   # stop after N inserts
+//
+// Cost: 100 quota units per search.list call. Default daily quota is 10,000.
+// With ~1700 pieces to fill, you'll need to either request a quota bump or run
+// over multiple days. The script resumes automatically (skips pieces that have a
+// youtube link from a prior run).
+
+import { Glob } from 'bun';
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { SeedPiece } from '../src/data/seed';
+
+const ROOT = resolve(import.meta.dir, '..');
+const YT_KEY = process.env.YOUTUBE_API_KEY;
+const DRY = process.env.DRY_RUN === '1';
+const LIMIT = parseInt(process.env.LIMIT || '0', 10);
+
+if (!YT_KEY) {
+  console.error('Missing YOUTUBE_API_KEY');
+  process.exit(1);
+}
+
+type Hit = { videoId: string; title: string; channel: string };
+
+async function ytSearch(query: string): Promise<Hit | null> {
+  const u = new URL('https://www.googleapis.com/youtube/v3/search');
+  u.searchParams.set('key', YT_KEY!);
+  u.searchParams.set('part', 'snippet');
+  u.searchParams.set('q', query);
+  u.searchParams.set('type', 'video');
+  u.searchParams.set('videoEmbeddable', 'true');
+  u.searchParams.set('maxResults', '5');
+  u.searchParams.set('safeSearch', 'none');
+  const r = await fetch(u);
+  if (!r.ok) {
+    const body = await r.text();
+    if (r.status === 403 && /quota/i.test(body)) {
+      console.error('\nQUOTA EXCEEDED — stopping. Resume tomorrow.');
+      process.exit(2);
+    }
+    console.error(`  search failed (${r.status}): ${body.slice(0, 200)}`);
+    return null;
+  }
+  const j = (await r.json()) as {
+    items?: { id?: { videoId?: string }; snippet?: { title?: string; channelTitle?: string } }[];
+  };
+  const item = j.items?.find((i) => i.id?.videoId);
+  if (!item?.id?.videoId || !item.snippet) return null;
+  return {
+    videoId: item.id.videoId,
+    title: item.snippet.title ?? '',
+    channel: item.snippet.channelTitle ?? '',
+  };
+}
+
+function scoreQueryForPiece(p: SeedPiece): string {
+  // Composer name + piece title + catalog number disambiguates similar titles.
+  const parts = [p.composer_name, p.title];
+  if (p.catalog_number) parts.push(p.catalog_number);
+  return parts.join(' ');
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'");
+}
+
+function insertYoutubeLink(src: string, pieceId: string, link: { url: string; label: string }): string | null {
+  // Find the piece block: `id: '<pieceId>'` or `"id": "<pieceId>"`.
+  const idRe = new RegExp(`["'\`]?id["'\`]?:\\s*['\"\`]${pieceId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['\"\`]`);
+  const m = idRe.exec(src);
+  if (!m) return null;
+  // From here, find `external_links` array opening `[`.
+  const tail = src.slice(m.index);
+  const extRe = /["'`]?external_links["'`]?:\s*\[/;
+  const em = extRe.exec(tail);
+  if (!em) return null;
+  const openIdx = m.index + em.index + em[0].length;
+  // Find matching `]` by bracket counting.
+  let depth = 1;
+  let i = openIdx;
+  for (; i < src.length; i++) {
+    if (src[i] === '[') depth++;
+    else if (src[i] === ']') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  if (depth !== 0) return null;
+  // Insert before `]`. Detect element indent and whether the array is empty.
+  const before = src.slice(openIdx, i);
+  const arrayEmpty = !/[^\s]/.test(before);
+  const elemIndentMatch = /\n([ \t]+)[\{"']/.exec(before);
+  const elemIndent = elemIndentMatch ? elemIndentMatch[1] : '      ';
+  const bracketIndent = elemIndent.replace(/[ \t]{2}$/, '');
+  const labelEsc = decodeEntities(link.label).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+  // Detect per-entry style: single-line `{ ... }` vs multi-line.
+  // Sniff the last preceding entry.
+  const multiLine = /\{\s*\n\s*["']?type/.test(before);
+
+  let entry: string;
+  if (multiLine) {
+    entry =
+      `{\n` +
+      `${elemIndent}  "type": "youtube",\n` +
+      `${elemIndent}  "url": "${link.url}",\n` +
+      `${elemIndent}  "label": "${labelEsc}"\n` +
+      `${elemIndent}}`;
+  } else {
+    entry = `{ "type": "youtube", "url": "${link.url}", "label": "${labelEsc}" }`;
+  }
+
+  if (arrayEmpty) {
+    const insertion = `\n${elemIndent}${entry}\n${bracketIndent}`;
+    return src.slice(0, i) + insertion + src.slice(i);
+  }
+
+  // Trim trailing whitespace/newlines before `]` and ensure prev entry's `}` is followed by `,`.
+  let j = i - 1;
+  while (j > openIdx && /\s/.test(src[j])) j--;
+  // j now points at a non-whitespace char (should be `}` or `,`).
+  const prevChar = src[j];
+  const cutAt = j + 1;
+  const head = src.slice(0, cutAt);
+  const rest = src.slice(i);
+  const sep = prevChar === ',' ? '' : ',';
+  return `${head}${sep}\n${elemIndent}${entry}\n${bracketIndent}${rest}`;
+}
+
+async function main() {
+  const filter = process.argv.slice(2).find((a) => !a.startsWith('--'));
+  const glob = new Glob('src/data/seed*.ts');
+  const files: string[] = [];
+  for await (const rel of glob.scan({ cwd: ROOT })) {
+    if (rel.endsWith('.test.ts')) continue;
+    if (filter && !rel.includes(filter)) continue;
+    files.push(rel);
+  }
+
+  let inserted = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const rel of files) {
+    const abs = resolve(ROOT, rel);
+    const mod = await import(abs);
+    let src = await readFile(abs, 'utf8');
+    let dirty = false;
+
+    for (const exportName of Object.keys(mod)) {
+      const val = mod[exportName];
+      if (!Array.isArray(val)) continue;
+      for (const piece of val as SeedPiece[]) {
+        if (!piece || typeof piece !== 'object' || !('external_links' in piece)) continue;
+        const hasYouTube = (piece.external_links ?? []).some((l) => l.type === 'youtube');
+        if (hasYouTube) {
+          skipped++;
+          continue;
+        }
+        if (LIMIT && inserted >= LIMIT) {
+          console.log(`\nLIMIT=${LIMIT} reached. Stopping.`);
+          if (dirty && !DRY) await writeFile(abs, src);
+          console.log(`Summary: +${inserted} inserted, ${skipped} skipped, ${failed} failed.`);
+          return;
+        }
+        const q = scoreQueryForPiece(piece);
+        if (DRY) {
+          console.log(`  (dry) would search: ${piece.id}  ${q}`);
+          inserted++;
+          continue;
+        }
+        const hit = await ytSearch(q);
+        if (!hit) {
+          console.log(`  MISS  ${piece.id}  (${q})`);
+          failed++;
+          continue;
+        }
+        const url = `https://www.youtube.com/watch?v=${hit.videoId}`;
+        const label = `${hit.channel} — ${hit.title}`.slice(0, 180);
+        console.log(`  +  ${piece.id}  ${url}  (${label})`);
+        if (!DRY) {
+          const next = insertYoutubeLink(src, piece.id, { url, label });
+          if (!next) {
+            console.error(`    WARN: could not insert into ${rel} for ${piece.id}`);
+            failed++;
+            continue;
+          }
+          src = next;
+          dirty = true;
+        }
+        inserted++;
+      }
+    }
+    if (dirty && !DRY) await writeFile(abs, src);
+  }
+
+  console.log(`\nDone. +${inserted} inserted, ${skipped} skipped (already had youtube), ${failed} failed.`);
+}
+
+await main();

--- a/scripts/validate-seed-urls.ts
+++ b/scripts/validate-seed-urls.ts
@@ -147,16 +147,44 @@ if (fix) {
     const abs = resolve(ROOT, file);
     let src = await readFile(abs, 'utf8');
     for (const f of list) {
-      // Match a single object-literal line like: { type: 'x', url: '<url>', label: '...' },?
-      // Escape URL for regex.
       const u = f.entry.link.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const re = new RegExp(`^[ \\t]*\\{[^\\n]*url:\\s*['\"\`]${u}['\"\`][^\\n]*\\},?\\s*\\n`, 'm');
-      const next = src.replace(re, '');
+      // Single-line: { type: 'x', url: '<url>', label: '...' },
+      const singleRe = new RegExp(`^[ \\t]*\\{[^\\n]*["'\`]?url["'\`]?:\\s*['\"\`]${u}['\"\`][^\\n]*\\},?\\s*\\n`, 'm');
+      let next = src.replace(singleRe, '');
+      if (next === src) {
+        // Multi-line: find the url line, walk backward to `{`, forward to matching `},` or `}`.
+        const urlLineRe = new RegExp(`^[ \\t]*["'\`]?url["'\`]?:\\s*['\"\`]${u}['\"\`],?\\s*$`, 'm');
+        const m = urlLineRe.exec(src);
+        if (m) {
+          // Walk back to opening `{` on its own line (possibly `      {`)
+          let start = src.lastIndexOf('{', m.index);
+          // back up to start-of-line
+          while (start > 0 && src[start - 1] !== '\n') start--;
+          // Walk forward to matching `}` by brace counting from the `{`.
+          let depth = 0;
+          let i = src.indexOf('{', m.index === start ? start : start);
+          // find the opening brace position
+          let openIdx = src.indexOf('{', start);
+          i = openIdx;
+          for (; i < src.length; i++) {
+            if (src[i] === '{') depth++;
+            else if (src[i] === '}') {
+              depth--;
+              if (depth === 0) { i++; break; }
+            }
+          }
+          // consume trailing `,` and newline
+          if (src[i] === ',') i++;
+          while (src[i] === ' ' || src[i] === '\t') i++;
+          if (src[i] === '\n') i++;
+          next = src.slice(0, start) + src.slice(i);
+        }
+      }
       if (next !== src) {
         removed++;
         src = next;
       } else {
-        console.error(`  WARN: could not match single-line entry for ${f.entry.link.url} in ${file}`);
+        console.error(`  WARN: could not match entry for ${f.entry.link.url} in ${file}`);
       }
     }
     await writeFile(abs, src);

--- a/src/data/seed-expansion-10.ts
+++ b/src/data/seed-expansion-10.ts
@@ -31,11 +31,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Romeo_and_Juliet,_Op.64_(Prokofiev,_Sergei)', label: 'IMSLP — Romeo and Juliet, Op. 64' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Romeo_and_Juliet_(Prokofiev)', label: 'Wikipedia — Romeo and Juliet (Prokofiev)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=M23BKo7PMUI', label: 'Claudio Abbado — Berlin Philharmonic (DG, 1996)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Wfxj7nBT_lI', label: 'Gustavo Dudamel — LA Philharmonic (2015)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2q95Y1wbkiC0JvUqRLROEl', label: 'Claudio Abbado / Berlin Philharmonic — Deutsche Grammophon' },
-      { type: 'internet_archive', url: 'https://archive.org/details/ProkofievRomeoAndJulietSuiteMravinskyLeningrad', label: 'Yevgeny Mravinsky / Leningrad Philharmonic — 1965 recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/330894126', label: 'Semyon Bychkov — Czech Philharmonic (Prague 2019)' },
     ],
     movements: [
       { name: 'I. Montagues and Capulets' },
@@ -75,12 +70,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/The_Young_Person%27s_Guide_to_the_Orchestra,_Op.34_(Britten,_Benjamin)', label: "IMSLP — The Young Person\'s Guide to the Orchestra, Op. 34" },
       { type: 'wikipedia', url: "https://en.wikipedia.org/wiki/The_Young_Person%27s_Guide_to_the_Orchestra", label: "Wikipedia — The Young Person\'s Guide to the Orchestra" },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8syNgbX3sFc', label: 'Benjamin Britten — London Symphony Orchestra (composer-conducted, 1963)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=pqLMPO8p8bQ', label: 'Leonard Bernstein — New York Philharmonic (with narration, 1963)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/09v6gKvRdovGHN40gTK8q1', label: 'Benjamin Britten / London Symphony Orchestra — Decca (composer-conducted)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrittenYoungPersonsGuideBritten1946', label: 'Original 1946 film soundtrack — Instruments of the Orchestra' },
     ],
   },
   {
@@ -118,14 +108,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quintet_in_C_major,_D.956_(Schubert,_Franz)', label: 'IMSLP — String Quintet in C major, D. 956' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quintet_(Schubert)', label: 'Wikipedia — String Quintet (Schubert)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=AAPH81LQCS4', label: 'Casals Festival — Marlboro Music (1959, historic)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=hRBv7xJiFOw', label: 'Alban Berg Quartet / Heinrich Schiff — EMI (1984)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/70s9AxZvJhMFl7mHnPvZmM', label: 'Isaac Stern / Yo-Yo Ma / Emanuel Ax / Jaime Laredo / Sharon Robinson — Sony' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1h4GG0nNFaVdQ34Y2h2m1g', label: 'Alban Berg Quartet / Heinrich Schiff — EMI Classics' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SchubertStringQuintetBudapestQuartet1952', label: 'Budapest String Quartet — Columbia Masterworks (1952)' },
-      { type: 'vimeo', url: 'https://vimeo.com/241847622', label: 'Quatuor Ebène / Gautier Capuçon — Verbier Festival 2017' },
     ],
     movements: [
       { name: 'I. Allegro ma non troppo' },
@@ -164,10 +147,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Clarinet_Quintet_in_A_major,_K.581_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP — Clarinet Quintet, K. 581' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Clarinet_Quintet_(Mozart)', label: 'Wikipedia — Clarinet Quintet (Mozart)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=ZvoCrzp4Jy8', label: 'Karl Leister / Berlin Philharmonic Chamber Players — DG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=G6ixFk9K-2s', label: 'Sabine Meyer / Berlin Philharmonic String Quartet — live recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4hcD9IZkJiZ6PBOMLF2AhP', label: 'Karl Leister / Berlin Philharmonic Chamber Players — Deutsche Grammophon' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MozartClaQuintetK581ReginaldKell1950', label: 'Reginald Kell / Busch Quartet — 1950 Decca recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/wienerphilharmoniker/mozart-clarinet-quintet-k581', label: 'Vienna Philharmonic Chamber Concert — live recording' },
     ],
     movements: [
@@ -205,12 +184,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Praeludium_in_D_minor,_BuxWV_140_(Buxtehude,_Dieterich)', label: 'IMSLP — Praeludium BuxWV 140' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Dieterich_Buxtehude', label: 'Wikipedia — Dieterich Buxtehude' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=TGBEqGHMLNE', label: 'Ton Koopman — Grote Kerk Maassluis (historical instrument)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=JB-RVTLR3Ko', label: 'Harald Vogel — Arp Schnitger organ, Norden' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6t1yUlh8ZFv8jmFUhpMo9k', label: 'Ton Koopman — Complete Organ Works (Novalis)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BuxtehudePraeludioBuxWV140Schweitzer', label: 'Albert Schweitzer — Buxtehude organ works (historic recording)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/rco-amsterdam/buxtehude-praeludium-buxwv-140-organ-concertgebouw', label: 'Concertgebouw organ recital — live recording' },
     ],
   },
@@ -251,11 +225,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Toccata,_Adagio_and_Fugue_in_C_major,_BWV_564_(Bach,_Johann_Sebastian)', label: 'IMSLP — Toccata, Adagio and Fugue BWV 564' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Toccata,_Adagio_and_Fugue_in_C_major,_BWV_564', label: 'Wikipedia — Toccata, Adagio and Fugue, BWV 564' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=HXPR_tJGHUo', label: 'Karl Richter — Munich Hochschule organ (1969 recording)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=M5dJKYT1rOc', label: 'Peter Hurford — Our Lady of Sion, Reading (Decca, 1978)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5z2CJNM03aOhJyG3VQGxWg', label: 'Karl Richter — Complete Organ Works (Archiv Produktion)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4QNRoQmzF04cNJKuJmumvA', label: 'Peter Hurford — Bach Organ Works (Decca)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BachBWV564ToccataAdagioFugueSchweitzer', label: 'Albert Schweitzer — Bach organ recordings (Zürich, 1935–36)' },
     ],
     movements: [
       { name: 'I. Toccata' },
@@ -291,13 +260,8 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Fantaisie,_Op.101_(Saint-Sa%C3%ABns,_Camille)', label: 'IMSLP — Fantaisie Op. 101' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Camille_Saint-Sa%C3%ABns', label: 'Wikipedia — Camille Saint-Saëns' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=QxM1y-s30rE', label: 'Olivier Latry — Notre-Dame de Paris (2014)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=TlYBa1glPYQ', label: 'Marie-Claire Alain — complete Saint-Saëns organ works' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0zNeKrUgKwWmMJaR4RVVW4', label: 'Olivier Latry — Saint-Saëns Organ Works (Deutsche Grammophon)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/rco-amsterdam/saint-saens-fantaisie-op101-organ-live', label: 'Concertgebouw organ — live recital recording' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SaintSaensOrganWorksPicardyBardon', label: 'Jean-Baptiste Robin — Saint-Saëns organ works (archive recording)' },
     ],
   },
   {
@@ -330,8 +294,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Aria_in_Classic_Style_(Grandjany,_Marcel)', label: 'IMSLP — Aria in Classic Style' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Marcel_Grandjany', label: 'Wikipedia — Marcel Grandjany' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=I6wt9XmFdwI', label: 'Emily Levin — Dallas Symphony principal harp' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8Rm2MxT4Krc', label: 'Hannah Roberts — Juilliard student recital' },
       { type: 'soundcloud', url: 'https://soundcloud.com/american-harp-society/grandjany-aria-in-classic-style-live', label: 'American Harp Society — live competition recording' },
       { type: 'vimeo', url: 'https://vimeo.com/305012847', label: 'International Harp Contest in Israel — semi-final round' },
     ],
@@ -364,12 +326,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/A_Ceremony_of_Carols,_Op.28_(Britten,_Benjamin)', label: 'IMSLP — A Ceremony of Carols, Op. 28' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/A_Ceremony_of_Carols', label: 'Wikipedia — A Ceremony of Carols' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3P3I0MxoFCQ', label: 'Choir of King\'s College Cambridge / Stephen Cleobury (Decca, 2008)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=mh0pGNVqEOk', label: 'Tenebrae / Nigel Short — live recording (Wigmore Hall)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2rnl2FZnzR9biR7z3Qhh9Z', label: "Choir of King\'s College Cambridge / Stephen Cleobury — Decca" },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrittenCeremonyOfCarolsMorleyColl1945', label: 'Morley College Choir (early recording, c.1945)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/bbc-radio-3/britten-ceremony-of-carols-op28', label: 'BBC Singers — BBC Radio 3 broadcast' },
     ],
   },
@@ -401,11 +358,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Au_Matin,_Op.22_(Tournier,_Marcel)', label: 'IMSLP — Au Matin, Op. 22' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Marcel_Tournier', label: 'Wikipedia — Marcel Tournier' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=1N3UtYbbUmk', label: 'Fabrice Pierre — live concert (Paris, 2018)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=fAoBa0wJl_c', label: 'Valérie Milot — Quebec harp recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2hfOIUuXHSwEVTv60Wq1wZ', label: 'Fabrice Pierre — French Harp Music (Naïve)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/paris-conservatoire-harp/tournier-au-matin-competition-2019', label: 'Paris Conservatoire Harp Competition — 2019 finalist recording' },
       { type: 'vimeo', url: 'https://vimeo.com/294857602', label: 'World Harp Congress — live round recording' },
     ],
@@ -440,11 +393,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Music_for_Strings,_Percussion_and_Celesta_(Bart%C3%B3k,_B%C3%A9la)', label: 'IMSLP — Music for Strings, Percussion and Celesta' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Music_for_Strings,_Percussion_and_Celesta', label: 'Wikipedia — Music for Strings, Percussion and Celesta' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=aA3V_1Qzb9Q', label: 'Fritz Reiner — Chicago Symphony Orchestra (RCA Living Stereo, 1958)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=j5JlVnBokmQ', label: 'Ivan Fischer — Budapest Festival Orchestra (2011)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0OiVxS5RoCmM7SFSPNrGun', label: 'Fritz Reiner / Chicago Symphony — RCA Living Stereo (Grammy Hall of Fame)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3dFbVl7gRxIvQFVcR6MViz', label: 'Georg Solti / Chicago Symphony — Decca' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BartokMusicStringsPercCelestaSacherBasel1937', label: 'Paul Sacher / Basel Chamber Orchestra — 1937 premiere recording' },
     ],
     movements: [
       { name: 'I. Andante tranquillo' },
@@ -481,13 +429,8 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Elegia_(Bottesini,_Giovanni)', label: 'IMSLP — Elegia (Bottesini)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Giovanni_Bottesini', label: 'Wikipedia — Giovanni Bottesini' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=bblWU-8Ufzw', label: 'Renaud Garcia-Fons — live performance (Paris, 2015)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=mhT2H8ZaJZk', label: 'Chi-chi Nwanoku — BBC Young Musician Competition (1984)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2cKgW1oH6V8gFh6cWwnTjX', label: 'Rinat Ibragimov — Bottesini: Music for Double Bass (Naxos)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/bbc-radio-3/bottesini-elegy-db-recital', label: 'Leon Bosch — BBC Radio 3 recital' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BottesiniElegiaDKarr1968', label: 'Gary Karr — historic recital recording (1968)' },
     ],
   },
   {
@@ -520,11 +463,7 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Gran_Duo_Concertante_(Bottesini,_Giovanni)', label: 'IMSLP — Gran Duo Concertante' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Giovanni_Bottesini', label: 'Wikipedia — Giovanni Bottesini' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=YaBQQaxuC-c', label: 'Vincenzo Mariozzi / Massimo Giorgi — live recording (Rome, 2017)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=9XfFxO8vDrQ', label: 'Francois Rabbath / Salvatore Accardo — live recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2cKgW1oH6V8gFh6cWwnTjX', label: 'Rinat Ibragimov / Kyoko Takezawa — Naxos Bottesini Collection' },
       { type: 'soundcloud', url: 'https://soundcloud.com/ard-competition/bottesini-gran-duo-ard-double-bass', label: 'ARD Munich Competition — double bass final (live)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BottesiniGranDuoConcertanteLiveRecital', label: 'Gary Karr / Arthur Haas — Carnegie Hall (1970s archive)' },
     ],
   },
   // === ORCHESTRAL ===
@@ -556,13 +495,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.8_in_B_minor,_D.759_(Schubert,_Franz)', label: 'IMSLP — Symphony No. 8 in B minor, D. 759' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._8_(Schubert)', label: 'Wikipedia — Symphony No. 8 (Schubert)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=M8N5nqBGF0E', label: 'Carlos Kleiber — Vienna Philharmonic (DG, 1979)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=LZgMdCQT7_4', label: 'Leonard Bernstein — Vienna Philharmonic' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0b8yBkELXoJv5B6Nzm1Kyw', label: 'Carlos Kleiber / Vienna Philharmonic — Deutsche Grammophon (legendary recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0GE4gvhFMJDvhb2Gf3NPIY', label: 'René Jacobs / Freiburger Barockorchester — Harmonia Mundi' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SchubertSymphony8UnfinishedFurtwaengler1950', label: 'Wilhelm Furtwängler / Vienna Philharmonic — 1950 broadcast' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -606,11 +539,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Concerto_No.2,_Op.83_(Brahms,_Johannes)', label: 'IMSLP — Piano Concerto No. 2, Op. 83' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Concerto_No._2_(Brahms)', label: 'Wikipedia — Piano Concerto No. 2 (Brahms)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Bt1OPHCHxY8', label: 'Emil Gilels / Reiner / Chicago Symphony — RCA Living Stereo (1958)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=mQZNtanEoU8', label: 'Martha Argerich / Claudio Abbado — Berlin Philharmonic' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0H7FNWWnuJOJrLzqb3kFkL', label: 'Emil Gilels / Reiner / Chicago Symphony — RCA Living Stereo' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4MDSA1oP7MCtWjcGKPUoEG', label: 'Martha Argerich / Claudio Abbado — Berlin Philharmonic (DG)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrahmsPianoConc2BackhausKnappertsbusch1952', label: 'Wilhelm Backhaus / Knappertsbusch — 1952 Decca recording' },
     ],
     movements: [
       { name: 'I. Allegro non troppo' },
@@ -650,10 +578,6 @@ export const expansionPieces10: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.5,_Op.64_(Tchaikovsky,_Pyotr)', label: 'IMSLP — Symphony No. 5, Op. 64' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._5_(Tchaikovsky)', label: 'Wikipedia — Symphony No. 5 (Tchaikovsky)' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=a_B02BZp-5Y', label: 'Evgeny Mravinsky — Leningrad Philharmonic (1960, DG)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=BnFBLBIH9sQ', label: 'Mariss Jansons — Oslo Philharmonic' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1lVL0j7QMpfvfLBsK7AQGl', label: 'Evgeny Mravinsky / Leningrad Philharmonic — Deutsche Grammophon (1960)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5bfSLYAfp0lKn2dMaF9jId', label: 'Mariss Jansons / Oslo Philharmonic — EMI Classics' },
-      { type: 'internet_archive', url: 'https://archive.org/details/TchaikovskySym5MravinskiLeningrad1938', label: 'Evgeny Mravinsky / Leningrad Philharmonic — 1938 recording' },
     ],
     movements: [
       { name: 'I. Andante — Allegro con anima' },
@@ -692,12 +616,6 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.75_in_D_minor,_Op.76_No.2_(Haydn,_Joseph)', label: 'IMSLP — String Quartet Op. 76 No. 2 "Fifths"' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._75_(Haydn)', label: 'Wikipedia — String Quartet No. 75, Op. 76 No. 2' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=cVQXYLlz4Vw', label: 'Kodály Quartet — complete Op. 76 (Naxos)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=oVYb_EGiqnk', label: 'Tokyo String Quartet — live performance' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7JiMnOV1pQ2YeKqlDQ3Fcw', label: 'Kodály Quartet — Haydn Op. 76 Quartets (Naxos)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/HaydnOp76QuartetsHungarianQuartet1958', label: 'Hungarian String Quartet — 1958 recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/wigmore-hall/haydn-string-quartet-op76-fifths-live', label: 'Belcea Quartet — Wigmore Hall live recording' },
     ],
     movements: [
@@ -737,11 +655,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.6,_Sz.114_(Bart%C3%B3k,_B%C3%A9la)', label: 'IMSLP — String Quartet No. 6, Sz. 114' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._6_(Bart%C3%B3k)', label: 'Wikipedia — String Quartet No. 6 (Bartók)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=h7T7KqC9FNo', label: 'Emerson String Quartet — Deutsche Grammophon (complete quartets)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3v9FijZI6pQ', label: 'Takács Quartet — Wigmore Hall live' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3mEqnLbf7FdlBr0jLuBqf8', label: 'Emerson String Quartet — Deutsche Grammophon (Grammy Award)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1REX7mU5PqLiSa4QkJPRhE', label: 'Takács Quartet — Hyperion Records' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BartokSQ6JuilliardString1950', label: 'Juilliard String Quartet — 1950 recording' },
     ],
     movements: [
       { name: 'I. Mesto — Vivace' },
@@ -781,11 +694,7 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Suite_gothique,_Op.25_(Bo%C3%ABllmann,_L%C3%A9on)', label: 'IMSLP — Suite gothique, Op. 25' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Suite_gothique', label: 'Wikipedia — Suite gothique' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=aMeMaEPsLEI', label: 'Olivier Latry — Notre-Dame de Paris (live performance)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=FGXPXV75CoQ', label: 'Pierre Pincemaille — Saint-Denis Basilica' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1hxsEDDDfKuHMBVmIlwHjn', label: 'Olivier Latry — French Organ Music (Deutsche Grammophon)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/rco-amsterdam/boellmann-suite-gothique-live-recital', label: 'Ben van Oosten — Netherlands Organ concert recording' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BoellmannSuiteGothiqueRecital1960s', label: 'Marie-Claire Alain — French organ recording' },
     ],
     movements: [
       { name: 'I. Introduction-Choral' },
@@ -824,11 +733,7 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Esquisses_byzantines_(Mulet,_Henri)', label: 'IMSLP — Esquisses byzantines (incl. Tu es Petra)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Henri_Mulet', label: 'Wikipedia — Henri Mulet' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=eLlTr5N2JTY', label: 'Olivier Latry — Cathédrale Notre-Dame de Paris (2018)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=OzNRkdGIywY', label: 'Thierry Escaich — Saint-Étienne-du-Mont Paris (live)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3sMkJDJNMRl3bqHGD9SCQW', label: 'Thierry Escaich — French Organ Music (Sony Classical)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/paris-conservatoire-organ/mulet-tu-es-petra-live-recital', label: 'International Organ Competition — recital recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/215837480', label: 'Wayne Marshall — Leeds Town Hall (2017 recital)' },
     ],
   },
 
@@ -861,11 +766,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Impromptu-Caprice,_Op.9_(Piern%C3%A9,_Gabriel)', label: 'IMSLP — Impromptu-Caprice, Op. 9' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Gabriel_Piern%C3%A9', label: 'Wikipedia — Gabriel Pierné' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=qPmN84Bmy3Y', label: 'Yolanda Kondonassis — live recital performance' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=JYGi7t0Ke7M', label: 'Catrin Finch — BBC Proms recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2EFLJiZAXFYg7MWCDoGaRR', label: 'Yolanda Kondonassis — Harp (Telarc)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/american-harp-society/pierne-impromptu-caprice-competition', label: 'American Harp Society National Competition — semi-final round' },
       { type: 'vimeo', url: 'https://vimeo.com/189654023', label: 'International Harp Contest in Israel — round recording' },
     ],
@@ -900,13 +801,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Zyklus_(Stockhausen,_Karlheinz)', label: 'IMSLP — Zyklus' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Zyklus_(Stockhausen)', label: 'Wikipedia — Zyklus (Stockhausen)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=HPlNQ21_VCo', label: 'Christoph Caskel — premiere performance (Darmstadt, 1959)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Tp6JdgMRMCI', label: 'Colin Currie — Aldeburgh Music (2015, live)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2Iu1nV3cF0p53G3kMO1A22', label: 'Max Neuhaus — Stockhausen: Percussion Works (Columbia Masterworks)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/ircam-paris/stockhausen-zyklus-solo-perc-live', label: 'IRCAM — live performance recording (Paris)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/StockhausenZyklusChristophCaskel1961', label: 'Christoph Caskel — Deutsche Grammophon, 1961' },
     ],
   },
 
@@ -939,13 +834,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Sonata_Rom%C3%A1ntica_(Ponce,_Manuel)', label: 'IMSLP — Sonata Romántica' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Manuel_Ponce', label: 'Wikipedia — Manuel Ponce' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=A0hBqjp30KY', label: 'Andrés Segovia — DG studio recording (historic)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3hTGqK8BPiI', label: 'Ana Vidovic — live recital performance' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4X5XPX5pGVGT1bw5bkFvFI', label: 'Andrés Segovia — The Complete Mercury Masters (DG)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5MFqRbTl8YnZi5kMKLDkSi', label: 'Julian Bream — Ponce Guitar Works (RCA)' },
-      { type: 'vimeo', url: 'https://vimeo.com/304892711', label: 'Guitar Foundation of America Competition — semi-final recital' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -982,13 +871,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Tres_piezas_espa%C3%B1olas_(Rodrigo,_Joaqu%C3%ADn)', label: 'IMSLP — Tres piezas españolas' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Joaqu%C3%ADn_Rodrigo', label: 'Wikipedia — Joaquín Rodrigo' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3bQcJp4T2Lw', label: 'Andrés Segovia — DG studio recording (1958)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=HMa3B7SyiJE', label: 'David Russell — live performance (Gramophone Award-winning guitarist)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2tqkEZaMjV3oiN3QgJ4mAO', label: 'David Russell — Rodrigo: Guitar Music (Telarc, Gramophone Award)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6BXUQX7hekJBm4SIbVrOJX', label: 'Pepe Romero — Rodrigo: Piezas para guitarra (Philips)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/RodrigoTresPiezasSegovia1958', label: 'Andrés Segovia — 1958 Deutsche Grammophon recording' },
     ],
     movements: [
       { name: 'I. Fandango' },
@@ -1026,11 +909,7 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Intermezzo_and_Tarantella,_Op.9_(Gli%C3%A8re,_Reinhold)', label: 'IMSLP — Intermezzo and Tarantella, Op. 9' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Reinhold_Gliere', label: 'Wikipedia — Reinhold Glière' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=vJ5n8k1jb5c', label: 'Rinat Ibragimov — BBC Young Musician Competition (live)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=hPb3Wp5ZxNE', label: 'Chi-chi Nwanoku — live recital performance (London)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2cKgW1oH6V8gFh6cWwnTjX', label: 'Rinat Ibragimov — Double Bass Works (Naxos)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/ard-competition/gliere-intermezzo-tarantella-ard-double-bass', label: 'ARD International Music Competition — double bass round (live)' },
       { type: 'vimeo', url: 'https://vimeo.com/224789115', label: 'BBC Young Musician — double bass category final' },
     ],

--- a/src/data/seed-expansion-11.ts
+++ b/src/data/seed-expansion-11.ts
@@ -37,13 +37,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.8_in_F_major,_Op.93_(Beethoven,_Ludwig_van)', label: 'IMSLP — Symphony No. 8, Op. 93' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._8_(Beethoven)', label: 'Wikipedia — Symphony No. 8 (Beethoven)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=NdcpkHUKJ_4', label: 'Carlos Kleiber — Vienna Philharmonic (DG, 1979)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3OFuQPFqFbA', label: 'Nikolaus Harnoncourt — Chamber Orchestra of Europe (Teldec, 1991)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1LiOHO3h8ORGbQvpDiIhfK', label: 'Carlos Kleiber / Vienna Philharmonic — Deutsche Grammophon' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7LvCjTHFWMMGHqepCqFiQN', label: 'Nikolaus Harnoncourt / Chamber Orchestra of Europe — Teldec' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BeethovenSymphony8ToscaniniNBC', label: 'Arturo Toscanini / NBC Symphony Orchestra — 1939 broadcast recording' },
     ],
     movements: [
       { name: 'I. Allegro vivace e con brio' },
@@ -90,11 +84,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Pini_di_Roma_(Respighi,_Ottorino)', label: 'IMSLP — Pini di Roma' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Pines_of_Rome', label: 'Wikipedia — Pines of Rome (Respighi)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=L9tHYHLOhLY', label: 'Riccardo Muti — Philadelphia Orchestra (EMI, 1984)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=EGgBWJxX5N4', label: 'Arturo Toscanini — NBC Symphony Orchestra (RCA, 1953)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5VGlMuPitVNeEkl3mKqxmX', label: 'Riccardo Muti / Philadelphia Orchestra — EMI Classics' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3sJZOEgFHQ2ZcJBi5r8r0X', label: 'Charles Dutoit / Orchestre Symphonique de Montréal — Decca' },
-      { type: 'internet_archive', url: 'https://archive.org/details/RespighiPinesOfRomeToscanini1953', label: 'Arturo Toscanini / NBC Symphony — RCA Victor 1953 broadcast' },
     ],
     movements: [
       { name: 'I. I pini di Villa Borghese' },
@@ -139,14 +128,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.9_in_C_major,_D.944_(Schubert,_Franz)', label: 'IMSLP — Symphony No. 9, D. 944' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._9_(Schubert)', label: 'Wikipedia — Schubert Symphony No. 9' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=uZBSBYiPT0A', label: 'Carlos Kleiber — Vienna Philharmonic (DG, 1978)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=BFCa0CkX2GE', label: 'Günter Wand — Berlin Philharmonic (RCA, 2001)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4d4Mjul1OXNLXQE6DwmxcE', label: 'Carlos Kleiber / Vienna Philharmonic — Deutsche Grammophon' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5bEKFNOT1ueStyvnXWKlkq', label: 'Nikolaus Harnoncourt / Royal Concertgebouw — Teldec' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SchubertSymphony9FurtwaenglerBerlin', label: 'Wilhelm Furtwängler / Berlin Philharmonic — 1951 studio recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/112233445', label: 'Franz Welser-Möst — Cleveland Orchestra (Vimeo broadcast, 2015)' },
     ],
     movements: [
       { name: 'I. Andante — Allegro ma non troppo' },
@@ -193,11 +175,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.4,_Op.90_(Mendelssohn,_Felix)', label: 'IMSLP — Symphony No. 4, Op. 90' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._4_(Mendelssohn)', label: 'Wikipedia — Mendelssohn Symphony No. 4' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=pnPVwYdXInI', label: 'Claudio Abbado — Berlin Philharmonic (DG, 2000)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=o7G1FXMQ6bk', label: 'John Eliot Gardiner — Orchestre Révolutionnaire et Romantique (DG Archiv, 1993)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/01KCh7xAe5z1Y6p2tXf6gQ', label: 'Claudio Abbado / Berlin Philharmonic — Deutsche Grammophon' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3JrFB6jFqKPHkXI5HhBT0V', label: 'Herbert von Karajan / Berlin Philharmonic — DG Galleria' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MendelssohnSymphony4ItalianToscanini', label: 'Arturo Toscanini / NBC Symphony — 1954 broadcast' },
       { type: 'soundcloud', url: 'https://soundcloud.com/orchestral-classics/mendelssohn-symphony-4-italian', label: 'Orchestral Classics — Italian Symphony highlights' },
     ],
     movements: [
@@ -245,11 +222,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.1_(Mahler,_Gustav)', label: 'IMSLP — Symphony No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._1_(Mahler)', label: 'Wikipedia — Mahler Symphony No. 1' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=cqd4hRHBJqI', label: 'Leonard Bernstein — Concertgebouw Orchestra (DG, 1987)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=pFBOEEo03bg', label: 'Claudio Abbado — Berlin Philharmonic (DG, 1993)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7fBv6rLYSmSMB9DLzmDUSe', label: 'Leonard Bernstein / Concertgebouw — Deutsche Grammophon' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0r0WtPjXVIeEZ4MmEFSvIz', label: 'Georg Solti / Chicago Symphony Orchestra — Decca' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MahlerSymphony1BrunoWalterNBCSymphony', label: 'Bruno Walter / NBC Symphony Orchestra — 1954 broadcast' },
       { type: 'vimeo', url: 'https://vimeo.com/228819345', label: 'Gustavo Dudamel — Simón Bolívar Symphony Orchestra (Vimeo)' },
     ],
     movements: [
@@ -295,13 +267,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Quintet_in_F_minor_(Franck,_César)', label: 'IMSLP — Piano Quintet in F minor' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Quintet_(Franck)', label: 'Wikipedia — Franck Piano Quintet' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=fM5K3JE5SP0', label: 'Arthur Rubinstein — Guarneri Quartet (RCA, 1966)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=qn4bJj3cXoE', label: 'Imogen Cooper — Takács Quartet (BBC Proms, 2014)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3pGX0qO3vSbqe2wy3fR7vH', label: 'Arthur Rubinstein / Guarneri Quartet — RCA Red Seal' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5nK8tGXF9XYVZqzqIGkqcL', label: 'Pierre-Laurent Aimard / Arditti Quartet — Teldec' },
-      { type: 'internet_archive', url: 'https://archive.org/details/FranckPianoQuintetCortotCasals', label: 'Alfred Cortot / Capet Quartet — 1928 historic recording' },
     ],
     movements: [
       { name: 'I. Molto moderato quasi lento — Allegro' },
@@ -347,11 +313,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.15,_Op.132_(Beethoven,_Ludwig_van)', label: 'IMSLP — String Quartet No. 15, Op. 132' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._15_(Beethoven)', label: 'Wikipedia — Beethoven String Quartet Op. 132' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=vGPAHzx6bx0', label: 'Busch Quartet — (Columbia, 1936)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=nAfIdAHqHNY', label: 'Takács Quartet — (Decca, 2002)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5nX8BkBz6GTx8VJkR4PxCG', label: 'Takács Quartet — Decca' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4V0aNz7W2FEzjWzqHDFYJq', label: 'Alban Berg Quartet — EMI Classics' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BeethovenOp132BuschQuartet1936', label: 'Busch Quartet — 1936 Columbia recording' },
     ],
     movements: [
       { name: 'I. Assai sostenuto — Allegro' },
@@ -399,11 +360,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Trio_No.2,_Op.66_(Mendelssohn,_Felix)', label: 'IMSLP — Piano Trio No. 2, Op. 66' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Trio_No._2_(Mendelssohn)', label: 'Wikipedia — Mendelssohn Piano Trio No. 2' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=7TyEXSoH8rk', label: 'Beaux Arts Trio (Philips, 1969)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Np9ib3pHfDM', label: 'Florestan Trio (Hyperion, 2001)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3TnWHy5BsP4EfbIqstD9gX', label: 'Beaux Arts Trio — Philips Classics' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6nXhH2K0MXFqWMPiqovmKd', label: 'Florestan Trio — Hyperion Records' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MendelssohnPianoTrioNo2Historical', label: 'Cortot / Thibaud / Casals — 1927 historic recording' },
     ],
     movements: [
       { name: 'I. Allegro energico e con fuoco' },
@@ -450,11 +406,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Sextet_No.2,_Op.36_(Brahms,_Johannes)', label: 'IMSLP — String Sextet No. 2, Op. 36' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Sextet_No._2_(Brahms)', label: 'Wikipedia — Brahms String Sextet No. 2' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=ELEKBvfqLfA', label: 'Berlin Philharmonic Octet — (DG, 1975)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=LWYjEBMkdTs', label: 'Ensemble Wien-Berlin (Sony, 1993)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2LWovUKHkflLwnbFZCBMPL', label: 'Berlin Philharmonic Octet — Deutsche Grammophon' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0kqRn3sFgwVRYEjmMqN0SB', label: 'Academy of St Martin in the Fields Chamber Ensemble — Chandos' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrahmsStringSextetNo2Historical', label: 'Pro Arte Quartet / members — 1930s historic recording' },
     ],
     movements: [
       { name: 'I. Allegro non troppo' },
@@ -499,13 +450,6 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.1,_Op.14_(Vierne,_Louis)', label: 'IMSLP — Organ Symphony No. 1, Op. 14' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._1_(Vierne)', label: 'Wikipedia — Vierne Organ Symphony No. 1' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=fRYPMcbNn6k', label: 'Olivier Latry — Notre-Dame de Paris (DG, 2012)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=7GqL3TnKBpg', label: 'Marie-Claire Alain — Freiburg Cathedral (Erato, 1989)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2tJBKzFP8qhPBzJpVc7rox', label: 'Olivier Latry — Deutsche Grammophon (Notre-Dame)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0GBpTcNWy2bBXWv6EJJ5nm', label: 'Ben van Oosten — MDG (Choir organ, Cavaillé-Coll)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/VierneOrganSymphony1Historical', label: 'Marcel Dupré — Notre-Dame de Paris (1940s broadcast)' },
     ],
     movements: [
       { name: 'I. Allegro vivace' },
@@ -551,13 +495,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Suite_médiévale,_Op.56_(Langlais,_Jean)', label: 'IMSLP — Suite Médiévale, Op. 56' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Jean_Langlais', label: 'Wikipedia — Jean Langlais' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=F8Vp4lsxPKI', label: 'Jean Langlais — Sainte-Clotilde, Paris (Solstice, 1979)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=TLNnOrJSKXw', label: 'Ann Labounsky — Duquesne University Chapel (2010)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1yvCJWFRXM3Z7RPNnrGzrb', label: 'Marie-Bernadette Dufourcet — Fuga Libera Records' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4sNTCONUPcHzYvVBUOUgTr', label: 'Jean Langlais — Solstice / Jade (Sainte-Clotilde recordings)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/LanglaisSuiteMediavaleLanglaisPerforms', label: 'Jean Langlais — historical broadcast, Sainte-Clotilde 1962' },
     ],
     movements: [
       { name: 'I. Prélude' },
@@ -603,13 +541,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Concierto_serenata_(Rodrigo,_Joaquín)', label: 'IMSLP — Concierto Serenata' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Concierto_serenata', label: 'Wikipedia — Concierto Serenata (Rodrigo)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=sFoWwQ7C4Co', label: 'Nicanor Zabaleta — Spanish Radio Orchestra (RCA, 1969)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=vMcqfopISSI', label: 'Xavier de Maistre — Vienna Philharmonic (Decca, 2010)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7mJ4jC5fCKyQf6dV8UxGPb', label: 'Nicanor Zabaleta / Berlin Philharmonic — DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6sM2yFlkxH5NLBfbnuInJm', label: 'Xavier de Maistre / Vienna Philharmonic — Decca' },
-      { type: 'internet_archive', url: 'https://archive.org/details/RodrigoConciertoserenataZabaleta', label: 'Nicanor Zabaleta — archive broadcast, 1960s' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -647,13 +579,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Trittico_(Nelhybel,_Vaclav)', label: 'IMSLP — Trittico (Nelhybel)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Vaclav_Nelhybel', label: 'Wikipedia — Vaclav Nelhybel' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=5tJGeLrPcJ8', label: 'Percussion ensemble — Eastman School of Music (2009)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=H6mBFTkVHzo', label: 'Indiana University Percussion Ensemble (2017)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4wQ5mJnxVgCHsXFV0nRkEW', label: 'Oberlin Percussion Group — Oberlin Music Press' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2tBwzQGCJeNc5XHrH9pZLU', label: 'Nexus Percussion Ensemble — CBC Records' },
-      { type: 'internet_archive', url: 'https://archive.org/details/NelhybelTritticoPremiere', label: 'Premiere recording — archive, New York 1965' },
     ],
     movements: [
       { name: 'I. Moderato' },
@@ -697,13 +623,6 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/5_Bagatelles_(Walton,_William)', label: 'IMSLP — Five Bagatelles' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Five_Bagatelles_(Walton)', label: 'Wikipedia — Five Bagatelles (Walton)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=WXZBGrS4SiI', label: 'Julian Bream — RCA Recital (1976)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=NeU_KcKzPlw', label: 'Craig Ogden — Hyperion recital (2005)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6oaCoSVaXJ4F8YzIXGAqzN', label: 'Julian Bream — RCA Red Seal' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1TZCB0FvqbP3D6q7TiYkJi', label: 'Craig Ogden — Hyperion Records' },
-      { type: 'internet_archive', url: 'https://archive.org/details/WaltonFiveBagatellesBreamBBC', label: 'Julian Bream — BBC broadcast premiere, 1972' },
     ],
     movements: [
       { name: 'I. Allegretto' },
@@ -742,13 +661,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Royal_Winter_Music_(Henze,_Hans_Werner)', label: 'IMSLP — Royal Winter Music' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Royal_Winter_Music', label: 'Wikipedia — Royal Winter Music (Henze)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=HwqPrRcBYFk', label: 'Julian Bream — RCA Recital (1977)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=VD7pLa8Y3jU', label: 'David Russell — BBC broadcast (2001)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4XcLnnwEJyQyBbSHJ5Cb0B', label: 'Julian Bream — RCA Red Seal' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0v4WKJ8eBzr0EKe7P2h5gO', label: 'David Russell — Telarc Guitar Recital' },
-      { type: 'internet_archive', url: 'https://archive.org/details/HenzeRoyalWinterMusicBreamAldeburgh', label: 'Julian Bream — Aldeburgh Festival premiere broadcast, 1976' },
     ],
     movements: [
       { name: 'I. Richard Gloucester, Duke of Gloucester' },
@@ -797,11 +710,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Sonata_in_G_minor_(Eccles,_Henry)', label: 'IMSLP — Eccles Sonata in G minor (original violin)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Henry_Eccles', label: 'Wikipedia — Henry Eccles' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=hSa2SNbnmTU', label: 'Gary Karr — Harmon Lewis, piano (Delos, 1978)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=uiQKv5gVIFY', label: 'Catalin Rotaru — ISB Competition recital (2016)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3NOrqbwFwHLz9Nkq4gW3mV', label: 'Gary Karr — Delos Records' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5Xe9TH1t0RhzPqcyGPwm8q', label: 'Edgar Meyer — Sony Classical (double bass recital)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/EcclesSonataGminorGaryKarr', label: 'Gary Karr — live recital archive, 1970s' },
     ],
     movements: [
       { name: 'I. Largo' },
@@ -846,13 +754,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Praeludium_in_E_minor,_BuxWV_142_(Buxtehude,_Dieterich)', label: 'IMSLP — Praeludium BuxWV 142' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Dieterich_Buxtehude', label: 'Wikipedia — Dieterich Buxtehude' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=XMRLRUBQqao', label: 'Harald Vogel — Stellwagen organ, Stralsund (MDG, 1999)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=DlxVj1m3GgY', label: 'Masaaki Suzuki — Shirakawa Hall organ, Nagoya (BIS, 2000)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0VoYdMmUABkm4y6y4z3mGg', label: 'Harald Vogel — MDG Gold' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6JZ3pISSNbGfDjJGJpGS6V', label: 'Masaaki Suzuki — BIS Records' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BuxtehudePraeludiumBuxWV142', label: 'E. Power Biggs — Buxtehude organ works (CBS, 1960s)' },
     ],
   },
   // KEPT: Handel Harp Concerto Op. 4 No. 6
@@ -891,13 +793,6 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Organ_Concerto_in_B-flat_major,_Op.4_No.6,_HWV_294_(Handel,_George_Frideric)', label: 'IMSLP — Concerto Op. 4 No. 6, HWV 294' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Organ_Concertos,_Op._4_(Handel)', label: 'Wikipedia — Handel Op. 4 Concertos' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=pJaKzN7PCFY', label: 'Marielle Nordmann — Les Arts Florissants (Erato, 1987)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8wY3FtZv4RU', label: 'Naoko Yoshino — Academy of St Martin in the Fields (Philips, 1995)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4dJhC8GkIJnVvJMEQy3uCA', label: 'Marielle Nordmann / Les Arts Florissants — Erato' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5mQdH9fgCBdVbwGNMoQxBT', label: 'Naoko Yoshino / ASMF — Philips Classics' },
-      { type: 'internet_archive', url: 'https://archive.org/details/HandelHarpConcertoOp4No6Laskine', label: 'Lily Laskine — archive broadcast recording' },
     ],
     movements: [
       { name: 'I. Andante allegro' },
@@ -934,13 +829,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Impromptu-Caprice,_Op.9_(Pierné,_Gabriel)', label: 'IMSLP — Impromptu-Caprice, Op. 9' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Gabriel_Pierné', label: 'Wikipedia — Gabriel Pierné' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=bFCuiyFDSeA', label: 'Isabelle Moretti — Paris Conservatoire harp recital (2012)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=k2u4X_MuXGc', label: 'Yolanda Kondonassis — Telarc recital recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5VX3sUAEJbRqxFnuMfP7cW', label: 'Isabelle Moretti — Naïve Records' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4AXTMbRhLivBbf3VVwGq12', label: 'Yolanda Kondonassis — Telarc' },
-      { type: 'internet_archive', url: 'https://archive.org/details/PierneImpromtuCapriceHarp', label: 'Archive: Grandjany — harp recital (1940s)' },
     ],
   },
   // KEPT: Takemitsu Rain Tree
@@ -972,13 +861,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Rain_Tree_(Takemitsu,_Tōru)', label: 'IMSLP — Rain Tree' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Tōru_Takemitsu', label: 'Wikipedia — Tōru Takemitsu' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=sBqTJ7VQpuE', label: 'Nexus Percussion Ensemble (CBC, 1984)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=5w1EFWtEkeo', label: 'SLAGW Percussion Ensemble (Stockholm, 2018)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2LtAhEoKg9LQFR8iiSMPKf', label: 'Peter Sadlo / Munich Philharmonic Percussion — Sony Classical' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6n6mXSaFJtbWVqpGP24Kqt', label: 'Ensemble Nexus — CBC Records' },
-      { type: 'internet_archive', url: 'https://archive.org/details/TakemitsuRainTreeNHK', label: 'Nexus Percussion — NHK broadcast recording, 1982' },
     ],
   },
   // KEPT: Bartók Sonata for Two Pianos and Percussion
@@ -1010,13 +893,6 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Sonata_for_Two_Pianos_and_Percussion,_Sz.110_(Bartók,_Béla)', label: 'IMSLP — Sonata for Two Pianos and Percussion, Sz. 110' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonata_for_Two_Pianos_and_Percussion_(Bartók)', label: 'Wikipedia — Bartók Sonata for Two Pianos and Percussion' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Bk15VgSvHO8', label: 'Martha Argerich / Stephen Kovacevich — Proms BBC (2013)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=dJXzPXcj7tM', label: 'Martha Argerich / Nelson Freire — DG Recital (1998)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7aDqt52RI4zHpwE9rjXgjq', label: 'Martha Argerich / Stephen Bishop Kovacevich — Philips' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3fz1xpQCBkVzfSmzaJo5JX', label: 'Kontarsky / Kontarsky — Deutsche Grammophon' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BartokSonata2PianoPercBBC1937', label: 'Bartók and Ditta Pásztory (pianos) — Basel premiere 1937 recording' },
     ],
     movements: [
       { name: 'I. Assai lento — Allegro molto' },
@@ -1055,11 +931,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Sonatina_meridional_(Ponce,_Manuel)', label: 'IMSLP — Sonatina Meridional' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Manuel_Ponce', label: 'Wikipedia — Manuel Ponce' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=JeLBSMYGlkw', label: 'Andrés Segovia — live recording (1970s)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=rWn0XFUONoE', label: 'Pepe Romero — Philips Guitar Collection (1998)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0f5U2hJAqkTDSUEJLlq8Yx', label: 'Pepe Romero — Philips Classics' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6Q8hPTCKr2c7fEhFVujB8G', label: 'David Russell — Telarc Guitar Recital' },
-      { type: 'internet_archive', url: 'https://archive.org/details/PonceSonatinaSegoviaArchive', label: 'Andrés Segovia — broadcast archive, 1940s' },
     ],
     movements: [
       { name: 'I. Campo (Allegretto)' },
@@ -1096,13 +967,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Double_Bass_Concerto_in_E_major_(Dittersdorf,_Carl_Ditters_von)', label: 'IMSLP — Double Bass Concerto in E major' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Carl_Ditters_von_Dittersdorf', label: 'Wikipedia — Carl Ditters von Dittersdorf' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=AVTU2U1FJQA', label: 'Catalin Rotaru — International Society of Bassists Competition winner (2016)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=JrpO1vF3dR8', label: 'Thomas Martin — English Chamber Orchestra (CBS, 1981)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2r3bSTvbUL1VMGj0nJGYMa', label: 'Klaus Stoll — Deutsche Grammophon' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5SG0dXjXNQsIbxaUmpkNTX', label: 'Thomas Martin / English Chamber Orchestra — CBS Masterworks' },
-      { type: 'internet_archive', url: 'https://archive.org/details/DittersdorfDBConcertoClassical', label: 'Archive broadcast — double bass concerto collection' },
     ],
     movements: [
       { name: 'I. Moderato' },
@@ -1139,13 +1004,7 @@ export const expansionPieces11: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Concerto_for_Double_Bass_and_Orchestra_(Zimmermann,_Bernd_Alois)', label: 'IMSLP — Zimmermann Double Bass Concerto' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Bernd_Alois_Zimmermann', label: 'Wikipedia — Bernd Alois Zimmermann' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=9kVUg2RlHts', label: 'Klaus Stoll — SWR Symphony Orchestra (1970s broadcast)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=ZwxLTGmAZhM', label: 'Nabil Shehata — Bavarian Radio Symphony Orchestra (BR Klassik, 2012)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3kpmrqwP9Y8RX3TiM3EXnb', label: 'Klaus Stoll — Wergo Records' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7jw8e1Qhf0VHbR6V2wFzNT', label: 'Nabil Shehata / BR Symphony — Bavarian Radio Klassik' },
-      { type: 'internet_archive', url: 'https://archive.org/details/ZimmermannDBConcertoStoll', label: 'Klaus Stoll — Cologne premiere broadcast archive' },
     ],
   },
   // KEPT: Fauré Requiem
@@ -1186,11 +1045,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Requiem,_Op.48_(Fauré,_Gabriel)', label: 'IMSLP — Requiem, Op. 48' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Requiem_(Fauré)', label: 'Wikipedia — Fauré Requiem' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=_5eXp-SGSLY', label: 'Michel Corboz — Ensemble Vocal de Lausanne (Erato, 1990)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=s3FjLLFEuXQ', label: 'John Rutter — Cambridge Singers (Collegium Records, 1984)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4p4hzQyBcUMx1DhWd0xGaZ', label: 'Michel Corboz / Ensemble Vocal de Lausanne — Erato / Warner' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1IHqY7nNqC6EpVnvFXJGQH', label: 'John Rutter / Cambridge Singers — Collegium Records' },
-      { type: 'internet_archive', url: 'https://archive.org/details/FaureRequiemCluytensNS', label: 'André Cluytens / Orchestre de la Société des Concerts — 1962 archive' },
     ],
     movements: [
       { name: 'I. Introit et Kyrie' },

--- a/src/data/seed-expansion-12.ts
+++ b/src/data/seed-expansion-12.ts
@@ -44,11 +44,6 @@ export const expansionPieces12: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Concerto_for_Orchestra,_Sz.116_(Bart%C3%B3k,_B%C3%A9la)', label: 'IMSLP — Concerto for Orchestra, Sz. 116' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Concerto_for_Orchestra_(Bart%C3%B3k)', label: 'Wikipedia — Concerto for Orchestra (Bartók)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Zn5m2kkXK0s', label: 'Fritz Reiner / Chicago Symphony Orchestra — RCA Living Stereo (1955)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=cPkO5dCB18M', label: 'Iván Fischer / Budapest Festival Orchestra — Philips (1997)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5MsROKzekDJJPgxFMN8fDO', label: 'Fritz Reiner / Chicago Symphony Orchestra — RCA Living Stereo' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6Gy16DvqNsxlU30aJrMT7W', label: 'Iván Fischer / Budapest Festival Orchestra — Philips' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BartokConcertoForOrchestraKoussevitzkyBSO1944', label: 'Serge Koussevitzky / Boston Symphony Orchestra — World Premiere broadcast (1944)' },
     ],
     movements: [
       { name: 'I. Introduzione — Andante non troppo; Allegro vivace' },
@@ -87,13 +82,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.5_in_E-flat_major,_Op.82_(Sibelius,_Jean)', label: 'IMSLP — Symphony No. 5, Op. 82' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._5_(Sibelius)', label: 'Wikipedia — Symphony No. 5 (Sibelius)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=q3KXLXL8QRE', label: 'Colin Davis / London Symphony Orchestra — Philips (1976)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=lAiHQVpBqc0', label: 'Osmo Vänskä / Minnesota Orchestra — BIS (2011)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4xQoxMX1vMKoQ6NiGT0G5T', label: 'Colin Davis / London Symphony Orchestra — Philips' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5eXwrNuYBgDVjh3L5G5bG3', label: 'Paavo Järvi / Gothenburg Symphony Orchestra — Deutsche Grammophon' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SibeliusSymphony5BeechamRPO1955', label: 'Thomas Beecham / Royal Philharmonic Orchestra — 1955 studio recording' },
     ],
     movements: [
       { name: 'I. Tempo molto moderato — Largamente — Allegro moderato — Presto' },
@@ -130,13 +119,8 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/M%C3%A1_vlast_(Smetana,_Bed%C5%99ich)', label: 'IMSLP — Má vlast (Smetana)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/The_Moldau', label: 'Wikipedia — The Moldau (Vltava)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=nKSqR1dn3bI', label: 'Rafael Kubelík / Czech Philharmonic — Supraphon (1990 Prague Spring Concert)' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=l4zkc7KEvYM', label: 'Václav Neumann / Czech Philharmonic — Complete Má vlast (1982)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0DFNQl9k4JJGzWqhyxclsR', label: 'Rafael Kubelík / Czech Philharmonic — Supraphon (1990)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0FpvCXNj9kPUxN0JDHPzSM', label: 'George Szell / Cleveland Orchestra — Epic/Sony' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SmetanaMaVlastTalichCzechPhilharmonic1941', label: 'Václav Talich / Czech Philharmonic — Historic 1941 recording' },
     ],
   },
 // Schumann Symphony No. 4
@@ -168,13 +152,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.4_in_D_minor,_Op.120_(Schumann,_Robert)', label: 'IMSLP — Symphony No. 4, Op. 120' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._4_(Schumann)', label: 'Wikipedia — Symphony No. 4 (Schumann)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=XKRkHTiIFJw', label: 'Carlos Kleiber / Vienna Philharmonic — 1979 broadcast (1851 version)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=SJSk3VzVCNs', label: 'Leonard Bernstein / Vienna Philharmonic — Deutsche Grammophon (1984)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1EiOIaVwi4Nf4DWvbklzh4', label: 'Leonard Bernstein / Vienna Philharmonic — Deutsche Grammophon (1984)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4ybkFe2JAj5k0xGqBLBs4E', label: 'Christian Thielemann / Wiener Philharmoniker — Deutsche Grammophon' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SchumannSymphony4FurtwanglerBPO1953', label: 'Wilhelm Furtwängler / Berlin Philharmonic — 1953 studio recording' },
     ],
     movements: [
       { name: 'I. Ziemlich langsam — Lebhaft' },
@@ -220,12 +198,6 @@ export const expansionPieces12: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.41_in_C_major,_K.551_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP — Symphony No. 41 "Jupiter", K. 551' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._41_(Mozart)', label: 'Wikipedia — Symphony No. 41 (Mozart)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=SiX3z_quf54', label: 'Karl Böhm / Berlin Philharmonic — Deutsche Grammophon (1961)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=IqQ3EyCTEOw', label: 'Charles Mackerras / Prague Chamber Orchestra — Telarc (1988)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=9Q5LhFBFBOA', label: 'René Jacobs / Akademie für Alte Musik Berlin — Harmonia Mundi (2009)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0s9G7KHIjFnMSdLFNOjqfG', label: 'Karl Böhm / Berlin Philharmonic — Deutsche Grammophon (1961)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6QcFiQRHtgPD3oCYDgRHHO', label: 'René Jacobs / Akademie für Alte Musik Berlin — Harmonia Mundi (2009)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/mozart-symphony-41-jupiter-bruno-walter', label: 'Bruno Walter / Columbia Symphony Orchestra — historic broadcast recording' },
     ],
     movements: [
       { name: 'I. Allegro vivace' },
@@ -271,14 +243,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.5_in_B-flat_major,_Op.100_(Prokofiev,_Sergei)', label: 'IMSLP — Symphony No. 5, Op. 100' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._5_(Prokofiev)', label: 'Wikipedia — Symphony No. 5 (Prokofiev)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8RMRqE0FPDU', label: 'Yevgeny Mravinsky / Leningrad Philharmonic — Melodiya (1961)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=mM4FdMtLfCE', label: 'Valery Gergiev / Mariinsky Orchestra — Philips (2004)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3DXzORSFKUU', label: 'Seiji Ozawa / Boston Symphony Orchestra — Deutsche Grammophon (1987)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5GzqRQl9VHI6yHMqHJ9J8T', label: 'Valery Gergiev / Mariinsky Orchestra — Philips (2004)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1UKMOBpJGXfK6rIY1RHKPX', label: 'Seiji Ozawa / Boston Symphony Orchestra — Deutsche Grammophon (1987)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/prokofiev-symphony-5-mravinsky-leningrad-1961', label: 'Yevgeny Mravinsky / Leningrad Philharmonic — 1961 historic broadcast' },
     ],
     movements: [
       { name: 'I. Andante' },
@@ -327,13 +292,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.7_in_F_major,_Op.59_No.1_(Beethoven,_Ludwig_van)', label: 'IMSLP — String Quartet Op. 59 No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._7_(Beethoven)', label: 'Wikipedia — String Quartet Op. 59 No. 1 (Beethoven)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=SHMi6N1PGAI', label: 'Emerson String Quartet — Deutsche Grammophon (1997)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=yiTjGXVRKP4', label: 'Budapest String Quartet — CBS/Sony (1952 studio recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4dCpAFQyX0hwDW1Kpf8hKw', label: 'Emerson String Quartet — Deutsche Grammophon (1997)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7nk0noCuYYiIRMd5Z8Uqyh', label: 'Alban Berg Quartett — EMI (1980)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BeethovenOp59No1BudapestStringQuartet1952', label: 'Budapest String Quartet — 1952 historic recording' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -371,13 +330,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.2_in_D_major_(Borodin,_Alexander)', label: 'IMSLP — String Quartet No. 2 (Borodin)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._2_(Borodin)', label: 'Wikipedia — String Quartet No. 2 (Borodin)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=KeK8mBHoMOA', label: 'Borodin Quartet — EMI (1982)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=l-gRFGjCfU8', label: 'Emerson String Quartet — Deutsche Grammophon (live)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5JYFfpJLSNR4nKXwgSPOe8', label: 'Borodin Quartet — EMI Classics (1982)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6Q1KWnFREtN0lh23Vs0pzZ', label: 'Brodsky Quartet — Chandos (1991)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BorodinStringQuartet2BudapestQuartet1956', label: 'Budapest String Quartet — 1956 historic studio recording' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -415,13 +368,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Quartet_No.1_in_G_minor,_Op.25_(Brahms,_Johannes)', label: 'IMSLP — Piano Quartet No. 1, Op. 25' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Quartet_No._1_(Brahms)', label: 'Wikipedia — Piano Quartet No. 1 (Brahms)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=YpJxPl0nqUo', label: 'Menahem Pressler / Emerson String Quartet — Deutsche Grammophon (2012)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=KSmNfWUDzAo', label: 'Maurizio Pollini / Quartetto Italiano — Deutsche Grammophon (1979)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0O2LBNeyMK8dCHuvgqKlte', label: 'Menahem Pressler / Emerson String Quartet — Deutsche Grammophon (2012)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5R7mVcnlr8tYHbqEiH3RO4', label: 'Maurizio Pollini / Quartetto Italiano — Deutsche Grammophon (1979)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrahmsOp25IstominSternRoseBernstein1964', label: 'Istomin/Stern/Rose/Bernstein — Sony (1964 live recording)' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -465,14 +412,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Trio_No.5_in_D_major,_Op.70_No.1_(Beethoven,_Ludwig_van)', label: 'IMSLP — Piano Trio Op. 70 No. 1 "Ghost"' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Trio_No._5_(Beethoven)', label: 'Wikipedia — Piano Trio No. 5 "Ghost" (Beethoven)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=nJCmk3rxo_0', label: 'Vladimir Ashkenazy / Itzhak Perlman / Lynn Harrell — EMI (1981)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=v8tX2K-wkgQ', label: 'Beaux Arts Trio — Philips (1966)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=2KQHiGPV5jE', label: 'Florestan Trio — Hyperion (2007)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3u7EBbO1LkuELpBBMVB8cM', label: 'Vladimir Ashkenazy / Perlman / Harrell — EMI (1981)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5IECLfSVTFAnGkjGR7f15T', label: 'Florestan Trio — Hyperion (2007)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/beethoven-ghost-trio-op70-casals-istomin-stern-rose', label: 'Casals / Istomin / Stern / Rose — historic festival recording' },
     ],
     movements: [
       { name: 'I. Allegro vivace e con brio' },
@@ -517,13 +457,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Clarinet_Sonata_No.1_in_F_minor,_Op.120_No.1_(Brahms,_Johannes)', label: 'IMSLP — Clarinet Sonata Op. 120 No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Clarinet_Sonatas_(Brahms)', label: 'Wikipedia — Clarinet Sonatas (Brahms)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=qcEFr2Bt8xM', label: 'Sabine Meyer / Bruno Canino — EMI (1989)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=9W1nGtQFRNs', label: 'Karl Leister / Christoph Eschenbach — Deutsche Grammophon (1979)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=vWJBl5j1ots', label: 'Richard Stoltzman / Richard Goode — RCA (1995)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5FbXBuXJBLHIPBOt1PLsG8', label: 'Sabine Meyer / Bruno Canino — EMI (1989)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7c1jJxZhE0wSOe9qYakHMP', label: 'Richard Stoltzman / Richard Goode — RCA (1995)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/classical-music/brahms-clarinet-sonata-op120-1', label: 'Brahms Clarinet Sonata No. 1 — excerpt' },
     ],
     movements: [
@@ -573,12 +507,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Organ_Sonata_No.1_in_G_major,_Op.28_(Elgar,_Edward)', label: 'IMSLP — Organ Sonata No. 1, Op. 28' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Organ_Sonata_No._1_(Elgar)', label: 'Wikipedia — Organ Sonata No. 1 (Elgar)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8fL8fGq0PSU', label: 'Thomas Trotter — Decca (1994)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=M3M0MnXMkDQ', label: 'Christopher Herrick — Hyperion (1993)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4YnMdMFIVOOgdnFU2vIWZH', label: 'Thomas Trotter — Decca (1994)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7KFl7LCE18vBb3MHlKMJtP', label: 'Christopher Herrick — Hyperion Records (1993)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/elgar-society/elgar-organ-sonata-op28-trotter', label: 'Thomas Trotter — Live recital recording' },
     ],
     movements: [
@@ -617,12 +546,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Toccata,_Fugue_and_Hymn_on_%22Ave_Maris_Stella%22,_Op.28_(Peeters,_Flor)', label: 'IMSLP — Toccata, Fugue and Hymn, Op. 28' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Flor_Peeters', label: 'Wikipedia — Flor Peeters' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=pVkjGl8WKBA', label: 'Ton Koopman — Novalis (live recital)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=YBxPsxaMiZk', label: 'Ben van Oosten — Dabringhaus und Grimm (2003)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4HbHOCJNdN3MqcC0cWpbIm', label: 'Ben van Oosten — Dabringhaus und Grimm (2003)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2rh0OJT6p1IDXpIXX0Oqrn', label: 'Marie-Claire Alain — Erato complete organ works' },
       { type: 'soundcloud', url: 'https://soundcloud.com/organ-music/peeters-toccata-fugue-hymn-ave-maris-stella', label: 'Student recital — Royal Flemish Conservatory' },
     ],
     movements: [
@@ -659,13 +583,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Les_Corps_glorieux_(Messiaen,_Olivier)', label: 'IMSLP — Les Corps Glorieux' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Les_Corps_glorieux', label: 'Wikipedia — Les Corps Glorieux (Messiaen)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=6uh5fZ2rnSk', label: 'Olivier Latry — Deutsche Grammophon (2013)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=1WkUJ5Y9hEI', label: 'Jennifer Bate — Unicorn-Kanchana (1988)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6X6d2OmZBi4LoIGCxEOB3s', label: 'Olivier Latry — Deutsche Grammophon complete Messiaen organ works' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0HJrRWixYKy2TjBiBGFjkZ', label: 'Jennifer Bate — Unicorn-Kanchana Messiaen organ cycle' },
-      { type: 'internet_archive', url: 'https://archive.org/details/messiaen-corps-glorieux-pierre-cochereau-notre-dame', label: 'Pierre Cochereau — Notre-Dame de Paris historic broadcast' },
     ],
     movements: [
       { name: 'I. Subtilité des Corps Glorieux' },
@@ -714,13 +632,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Concert-St%C3%BCck,_Op.39_(Piern%C3%A9,_Gabriel)', label: 'IMSLP — Concertstück, Op. 39' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Gabriel_Piern%C3%A9#Works', label: 'Wikipedia — Gabriel Pierné works' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=U7NhmSFHFqw', label: 'Marielle Nordmann — Erato harp concertos' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=YTwcWnDKBiI', label: 'Susanna Mildonian — BIS (1998)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=K8b9Yh7Hfas', label: 'Isabelle Moretti — harp recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2M5aNqq9y3fC8dXj04ZRjQ', label: 'Susanna Mildonian — BIS harp concertos (1998)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3rK1e5u4pClPq2bBHNgLVT', label: 'Isabelle Moretti — French harp concertos' },
       { type: 'soundcloud', url: 'https://soundcloud.com/classical-harp/pierne-concertstuck-nordmann', label: 'Marielle Nordmann — Concertstück excerpt' },
     ],
   },
@@ -757,13 +669,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Harp_Sonata_in_E_minor,_Op.167_(Reinecke,_Carl)', label: 'IMSLP — Harp Sonata "Undine", Op. 167' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Carl_Reinecke', label: 'Wikipedia — Carl Reinecke' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=lA5vhm9dVGQ', label: 'Nicanor Zabaleta — Deutsche Grammophon (1979)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=WnqTLBZCe7s', label: 'Isabelle Moretti — Alpha Classics recital (2009)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3YmE0sK6nQ7LqmqIJVxWPl', label: 'Nicanor Zabaleta — Deutsche Grammophon (1979)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6XeQ3YaNKYBqZ4TkM1NaO2', label: 'Marielle Nordmann — Erato harp recital' },
-      { type: 'internet_archive', url: 'https://archive.org/details/ReineckeHarpSonataUndineZabaleta', label: 'Nicanor Zabaleta — Archival broadcast recording' },
     ],
     movements: [
       { name: 'I. Allegro agitato' },
@@ -801,12 +707,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Sonatine_en_trio_(Damase,_Jean-Michel)', label: 'IMSLP — Sonatine en Trio' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Jean-Michel_Damase', label: 'Wikipedia — Jean-Michel Damase' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3hV9dEF7kQo', label: 'Ensemble Calliopée — Paris recital' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=yT5fzM3UmFQ', label: 'Solistes des Berliner Philharmoniker — chamber concert' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5kRb0ZoJFP9wNBfYNKTM3H', label: 'Ensemble Calliopée — Zig-Zag Territoires' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1r9xKYJVfZb3MN2uHyCsXT', label: 'Emmanuel Pahud / Marie-Pierre Langlamet / Emmanuel Pahud trio — DG' },
       { type: 'soundcloud', url: 'https://soundcloud.com/conservatoire-paris/damase-sonatine-en-trio-conservatoire', label: 'Conservatoire National Supérieur de Paris — student recital' },
     ],
     movements: [
@@ -849,13 +750,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Concerto_for_Marimba_and_String_Orchestra_(S%C3%A9journ%C3%A9,_Emmanuel)', label: 'IMSLP — Concerto for Marimba (Séjourné)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Emmanuel_S%C3%A9journ%C3%A9', label: 'Wikipedia — Emmanuel Séjourné' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=AJBJv_0fT5k', label: 'Katarzyna Myćka / Bamberg Symphony — Sony Classical (ICMA Award recording)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8pJAJvdUAZo', label: 'Jean Geoffroy — Zig-Zag Territoires (2007)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2eG8PjOkbPn8YXL6VNqzN1', label: 'Katarzyna Myćka / Bamberg Symphony — Sony Classical (ICMA Award)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0GAtGnqBv07xJHsBGjJOKr', label: 'Jean Geoffroy — Zig-Zag Territoires (2007)' },
-      { type: 'vimeo', url: 'https://vimeo.com/247381059', label: 'Fumito Nunoya — ARD International Music Competition finalist recital' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -892,12 +787,6 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Funny_Marimba_(Živković,_Nebojša_Jovan)', label: 'IMSLP — Funny Marimba' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Nebojs%CC%8Ca_Jovan_Z%CC%8Civkovic%CC%81', label: 'Wikipedia — Nebojša Jovan Živković' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=J5tXh3rP8Ys', label: 'Katarzyna Myćka — solo recital (2009)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=UPqn4zXHLcg', label: 'Simon Aldrich — NMC Recordings (competition performance)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3fJ0xG4RTH1YLaD1OB9rTe', label: 'Katarzyna Myćka — Sony Classical' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0TJaXHNTYlXX0Mxp1nFMxj', label: 'Various soloists — Marimba Festival anthology' },
       { type: 'soundcloud', url: 'https://soundcloud.com/marimba-competition/zivkovic-funny-marimba-competition', label: 'International Marimba Competition finalist — competition recording' },
     ],
     movements: [
@@ -946,13 +835,6 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/5_Preludes_(Villa-Lobos,_Heitor)', label: 'IMSLP — Five Preludes (Villa-Lobos)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Five_Preludes_(Villa-Lobos)', label: 'Wikipedia — Five Preludes (Villa-Lobos)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=B7pQytF2FG0', label: 'Julian Bream — RCA (1977)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=JO1bwfxEi34', label: 'John Williams — Sony Classical (1990)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=HtovW3bSgm4', label: 'Xuefei Yang — EMI Classics (2009)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4sFnZmIkqkBPAqVLrWXYLw', label: 'Julian Bream — RCA guitar recital (1977)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2Lk2XLh2KFfAV9jbAtPmVH', label: 'John Williams — Sony Classical guitar recital' },
       { type: 'soundcloud', url: 'https://soundcloud.com/classical-guitar/villa-lobos-prelude-1-yang', label: 'Xuefei Yang — Prelude No. 1 excerpt' },
     ],
   },
@@ -986,13 +868,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Guitar_Sonata_No.3_(Ponce,_Manuel_Mar%C3%ADa)', label: 'IMSLP — Guitar Sonata No. 3 "Guitarra"' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Manuel_Ponce#Guitar_music', label: 'Wikipedia — Manuel Ponce guitar works' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=qLBMkG2rh6E', label: 'Narciso Yepes — Deutsche Grammophon (1978)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=PtpAChJUZmA', label: 'Anders Miolin — BIS (1997)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Gv0kCeUBEJo', label: 'Manuel Barrueco — EMI Classics (1989)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5tDf1pxVzn01Sh2s1hH4w7', label: 'Narciso Yepes — Deutsche Grammophon guitar recital (1978)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2YD8dFMYx0Bxj1FNQWR4OA', label: 'Manuel Barrueco — EMI Classics guitar sonatas' },
       { type: 'soundcloud', url: 'https://soundcloud.com/classical-guitar/ponce-sonata-guitarra-miolin', label: 'Anders Miolin — Ponce Sonata excerpt' },
     ],
     movements: [
@@ -1031,13 +907,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Guitar_Sonata_(Omaggio_a_Boccherini),_Op.77_(Castelnuovo-Tedesco,_Mario)', label: 'IMSLP — Guitar Sonata Op. 77 "Omaggio a Boccherini"' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Mario_Castelnuovo-Tedesco#Guitar_sonata', label: 'Wikipedia — Mario Castelnuovo-Tedesco guitar works' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=F6a1E1ZhEQs', label: 'Julian Bream — RCA (1958)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=kEL5XdF4z4U', label: 'Eliot Fisk — Orfeo (1988)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=HWPn5fkU0FE', label: 'Manuel Barrueco — guitar recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/47OhFtKnJZE1JW1XGQrOaj', label: 'Julian Bream — RCA Castelnuovo-Tedesco guitar sonata (1958)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3WzNVw6l7B1d0BrBXMI0Kx', label: 'Eliot Fisk — Orfeo guitar recital (1988)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/classical-guitar/castelnuovo-tedesco-sonata-barrueco', label: 'Manuel Barrueco — Sonata Op. 77 excerpt' },
     ],
     movements: [
@@ -1084,14 +954,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Fantasia_on_Norma_(Bottesini,_Giovanni)', label: 'IMSLP — Fantasia on Norma (Bottesini)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Giovanni_Bottesini#Solo_works', label: 'Wikipedia — Giovanni Bottesini solo works' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Dm_L2_kbFQQ', label: 'Gary Karr — double bass recital' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=TXwrfyMrVnQ', label: 'Rinat Ibragimov — Bottesini Fantasia on Norma' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=CdT3Ef7BwG4', label: 'Rodion Azarkhin — double bass showpieces' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0OLlP9nVgM6b8FD8xkSwBr', label: 'Gary Karr — double bass Bottesini collection' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2fxBQe6bOdLtaU8LFr9sWT', label: 'Rinat Ibragimov — Bottesini opera fantasies' },
-      { type: 'internet_archive', url: 'https://archive.org/details/bottesini-fantasia-norma-koussevitzky-historic', label: 'Serge Koussevitzky — historic double bass recording' },
     ],
   },
 
@@ -1127,13 +990,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Double_Bass_Concerto_in_D_major_(Hoffmeister,_Franz_Anton)', label: 'IMSLP — Double Bass Concerto in D major (Hoffmeister)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Franz_Anton_Hoffmeister', label: 'Wikipedia — Franz Anton Hoffmeister' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=0SvCLz7bHe0', label: 'Gary Karr / Zimbler Sinfonietta — Decca (1968)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=rTsPFUGXTQQ', label: 'Dominik Wagner — Oehms Classics (2017)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1aTpNYWpF2GzNQpN5CDOTs', label: 'Gary Karr — Decca Archiv (historic recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2oQtpCkwkOZ7vF7kZ1Xk8n', label: 'Dominik Wagner — Oehms Classics (2017)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/HoffmeisterDBConcertoKarrZimbler1968', label: 'Gary Karr / Zimbler Sinfonietta — Decca (1968 landmark recording)' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -1170,13 +1027,7 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Double_Bass_Concerto_(Pichl,_V%C3%A1clav)', label: 'IMSLP — Double Bass Concerto (Pichl)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/V%C3%A1clav_Pichl', label: 'Wikipedia — Václav Pichl' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=p4pFjPNvn8E', label: 'Duncan McTier — Nimbus (1992)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=KQ8F8YkGmLY', label: 'Nils Börnig — MDG (2006)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6g3WXBqNzTF5TI5POp1Q8k', label: 'Duncan McTier — Nimbus Records (1992)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4iRL5G2Fku5RKXt2VH2a8j', label: 'Nils Börnig — MDG Gold (2006)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/PichlDBConcertoMcTierNimbus1992', label: 'Duncan McTier — Nimbus Records (1992) archival' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },

--- a/src/data/seed-expansion-13.ts
+++ b/src/data/seed-expansion-13.ts
@@ -34,12 +34,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Fantasia_on_a_Theme_by_Thomas_Tallis_(Vaughan_Williams,_Ralph)', label: 'IMSLP -- Fantasia on a Theme by Thomas Tallis' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Fantasia_on_a_Theme_by_Thomas_Tallis', label: 'Wikipedia -- Fantasia on a Theme by Thomas Tallis' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=08n3b_sRFnQ', label: 'Adrian Boult / London Philharmonic Orchestra -- EMI (1972)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=XMUBuSJVwKk', label: 'Andrew Davis / BBC Symphony Orchestra -- BBC Proms' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4xbdIGqJ0T8pBeCf6RFiQT', label: 'Adrian Boult / London Philharmonic Orchestra -- EMI' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2WMSSmfJk1JO0aFWRkPIlL', label: 'Neville Marriner / Academy of St Martin -- Philips' },
-      { type: 'internet_archive', url: 'https://archive.org/details/VaughanWilliamsTallisFanatasiaBoult1936', label: 'Adrian Boult / Queen\'s Hall Orchestra -- 1936 (historic)' },
-      { type: 'vimeo', url: 'https://vimeo.com/218409354', label: 'Sakari Oramo / BBC Symphony Orchestra -- Proms 2017' },
     ],
   },
 
@@ -78,13 +72,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.1_in_D_major,_Op.25_(Prokofiev,_Sergei)', label: 'IMSLP -- Symphony No. 1 "Classical", Op. 25' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._1_(Prokofiev)', label: 'Wikipedia -- Symphony No. 1 (Prokofiev)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=kf6Sn3fKTMM', label: 'Valery Gergiev / Mariinsky Orchestra -- Philips' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=s4bFvCAWWDs', label: 'Herbert von Karajan / Berlin Philharmonic -- DG (1968)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4V2Lj0X2fHXfMQalHJp3Z4', label: 'Valery Gergiev / Mariinsky Orchestra -- Philips' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0jM3f1e4HVvN7LJkWkJ5Kp', label: 'Carlos Kleiber / Vienna Philharmonic -- DG (Gramophone Award)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/ProkofievClassicalSymphonyMunchBSO1956', label: 'Charles Munch / Boston Symphony Orchestra -- 1956 recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/mariinsky/prokofiev-symphony-1-classical', label: 'Mariinsky Orchestra -- live broadcast recording' },
     ],
     movements: [
@@ -126,10 +114,6 @@ export const expansionPieces13: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.7_in_E_major_(Bruckner,_Anton)', label: 'IMSLP -- Symphony No. 7 in E major' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._7_(Bruckner)', label: 'Wikipedia -- Symphony No. 7 (Bruckner)' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=rCvOXwgOvOo', label: 'Herbert von Karajan / Vienna Philharmonic -- DG (1989)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=CfqlV-bR6gI', label: 'Sergiu Celibidache / Munich Philharmonic -- EMI (1993)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2ZF2TLhsZAqwx1bTW2EYjX', label: 'Herbert von Karajan / Vienna Philharmonic -- DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7BM7sBJh4M3z0oFkTyoWaH', label: 'Sergiu Celibidache / Munich Philharmonic -- EMI' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrucknerSymphony7FurtwanglerBerlin1951', label: 'Wilhelm Furtwangler / Berlin Philharmonic -- 1951 recording' },
       { type: 'vimeo', url: 'https://vimeo.com/401823048', label: 'Christoph Eschenbach / Orchestre de Paris -- live' },
     ],
     movements: [
@@ -168,13 +152,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.1_in_B-flat_major,_Op.38_(Schumann,_Robert)', label: 'IMSLP -- Symphony No. 1 "Spring", Op. 38' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._1_(Schumann)', label: 'Wikipedia -- Symphony No. 1 (Schumann)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=lrOVJzY3-EQ', label: 'Leonard Bernstein / Vienna Philharmonic -- DG (1985)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=FRfLjG0JHko', label: 'Nikolaus Harnoncourt / Chamber Orchestra of Europe -- Teldec' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1SuM3W4QX0cLHMFiCfBqJC', label: 'Leonard Bernstein / Vienna Philharmonic -- DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6dAfbXf7WJdqW6oC5JY3K7', label: 'Georg Szell / Cleveland Orchestra -- Sony Classical' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SchumannSymphony1SpringFurtwangler1953', label: 'Wilhelm Furtwangler / Berlin Philharmonic -- 1953 recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/hr-sinfonieorchester/schumann-symphony-1-spring', label: 'HR-Sinfonieorchester Frankfurt -- broadcast recording' },
     ],
     movements: [
@@ -213,13 +191,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.3_in_A_minor,_Op.56_(Mendelssohn,_Felix)', label: 'IMSLP -- Symphony No. 3 "Scottish", Op. 56' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._3_(Mendelssohn)', label: 'Wikipedia -- Symphony No. 3 (Mendelssohn)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=t6bpjNHs-YA', label: 'Claudio Abbado / London Symphony Orchestra -- DG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=7oGEGVBh4bQ', label: 'John Eliot Gardiner / Vienna Philharmonic -- DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3IQmhB2lLRhLVpxZLqnVPL', label: 'Claudio Abbado / London Symphony Orchestra -- DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0F8pQ4xnRthP4vNfXBsJeI', label: 'Riccardo Muti / Philadelphia Orchestra -- EMI' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MendelssohnScottishSymphonyHarrisCBC1953', label: 'Antal Dorati / Minneapolis Symphony Orchestra -- 1953 recording' },
       { type: 'vimeo', url: 'https://vimeo.com/335820977', label: 'Robin Ticciati / Scottish Chamber Orchestra -- live' },
     ],
     movements: [
@@ -261,13 +233,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.2_(Jan%C3%A1%C4%8Dek,_Leo%C5%A1)', label: 'IMSLP -- String Quartet No. 2 (Janacek)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._2_(Jan%C3%A1%C4%8Dek)', label: 'Wikipedia -- String Quartet No. 2 (Janacek)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=s3GXM1CKwK0', label: 'Kronos Quartet -- Nonesuch Records (1988)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3WXc-rEifQA', label: 'Takacs Quartet -- Decca (Gramophone Award)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3mWPPrG98WlCVeF9fxSGQF', label: 'Takacs Quartet -- Decca (Gramophone Award recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2yWbGFkUwXzHpYBBDEd4IC', label: 'Emerson String Quartet -- DG' },
-      { type: 'internet_archive', url: 'https://archive.org/details/JanacekKreutzerSonataSmetanaQtet1958', label: 'Smetana Quartet -- 1958 broadcast recording (historic)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/belcea-quartet/janacek-string-quartet-2', label: 'Belcea Quartet -- live recital recording' },
     ],
     movements: [
@@ -309,12 +275,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.5,_Sz.102_(Bart%C3%B3k,_B%C3%A9la)', label: 'IMSLP -- String Quartet No. 5, Sz. 102' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._5_(Bart%C3%B3k)', label: 'Wikipedia -- String Quartet No. 5 (Bartok)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Wj8_q7N90oA', label: 'Emerson String Quartet -- DG (Grammy Award)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=qSQFQQNLrLU', label: 'Hagen Quartet -- DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3m5iPR8tQX0EWb7FJh8JmM', label: 'Emerson String Quartet -- DG (Grammy Award, complete quartets)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4LsVdSwC7nfOsLaRuJpnYQ', label: 'Takacs Quartet -- Decca (Gramophone Award)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BartokQuartet5KolischQtet1940', label: 'Kolisch Quartet -- 1940 recording (historic premiere ensemble)' },
-      { type: 'vimeo', url: 'https://vimeo.com/276845130', label: 'Calder Quartet -- Ojai Music Festival live recording' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -353,14 +313,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.15_in_G_major,_D.887_(Schubert,_Franz)', label: 'IMSLP -- String Quartet in G major, D. 887' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._15_(Schubert)', label: 'Wikipedia -- String Quartet No. 15 (Schubert)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=bJvQkxWRFyQ', label: 'Alban Berg Quartet -- EMI (1984)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=7UGQG7d3AHI', label: 'Quatuor Mosaiques -- Auvidis (period instruments)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6g3q5IeU4ZgGj9nBU2JTnH', label: 'Alban Berg Quartet -- EMI (Gramophone Award)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1X8LWPi5Xc9qdp9XKiY4t0', label: 'Endellion Quartet -- Warner Classics' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SchubertQuartetG887BudapestQtet1953', label: 'Budapest String Quartet -- 1953 recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/295183724', label: 'Artemis Quartet -- Wigmore Hall live' },
     ],
     movements: [
       { name: 'I. Allegro molto moderato' },
@@ -400,10 +353,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quintet_No.4_in_G_minor,_K.516_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP -- String Quintet K. 516' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quintet_No._4_(Mozart)', label: 'Wikipedia -- String Quintet No. 4 (Mozart)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=HGNMWWyVKRo', label: 'Grumiaux Trio with Gerecz and Lesueur -- Philips (1973)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=9PBxXi3_-Ss', label: 'Quatuor Mosaiques with Wolfram Christ -- Auvidis (1994)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3HF9mCn3fJxHE5Y6RhNWtL', label: 'Grumiaux Trio with Gerecz and Lesueur -- Philips' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MozartStringQuintetK516BudapestQtet1948', label: 'Budapest String Quartet -- 1948 radio broadcast' },
       { type: 'soundcloud', url: 'https://soundcloud.com/conservatoireparis/mozart-quintet-g-minor-k516', label: 'Paris Conservatoire -- live recital recording' },
     ],
     movements: [
@@ -444,11 +393,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Clarinet_Quintet,_Op.115_(Brahms,_Johannes)', label: 'IMSLP -- Clarinet Quintet, Op. 115' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Clarinet_Quintet_(Brahms)', label: 'Wikipedia -- Clarinet Quintet (Brahms)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=mHYwxYY4opA', label: 'Karl Leister / Amadeus Quartet -- DG (1969)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=5w4aQ3yJO38', label: 'Martin Frost / Escher String Quartet -- BIS Records' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7oXQLFP5j0d8VbK9UJHbW0', label: 'Karl Leister / Amadeus Quartet -- DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3nhFfXwIjVWnSGKhqSnCf2', label: 'Martin Frost / Escher String Quartet -- BIS (Gramophone Award)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrahmsClarintetQuintetMuhlfeld1900', label: 'Richard Muhlfeld / Joachim Quartet -- historically associated recording' },
       { type: 'vimeo', url: 'https://vimeo.com/288453901', label: 'Sharon Kam / Jerusalem Quartet -- live recital' },
     ],
     movements: [
@@ -487,13 +431,6 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.12_in_F_major,_Op.96_(Dvo%C5%99%C3%A1k,_Anton%C3%ADn)', label: 'IMSLP -- String Quartet No. 12 "American", Op. 96' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/American_String_Quartet_(Dvo%C5%99%C3%A1k)', label: 'Wikipedia -- American String Quartet (Dvorak)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=7aV5uyV5EfQ', label: 'Emerson String Quartet -- DG (1995)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=PIjmCXjYk1A', label: 'Talich Quartet -- Calliope Records' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3rMMJbxzxO2PbHU5RjsYM4', label: 'Emerson String Quartet -- DG (Grammy Award)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3t6BTlDCJLzJYHFKGkSjDT', label: 'Takacs Quartet -- Decca (Gramophone Award)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/DvorakAmericanQuartetBudapest1948', label: 'Budapest String Quartet -- 1948 recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/parker-quartet/dvorak-american-quartet-op96', label: 'Parker Quartet -- Boston Conservatory live recital' },
     ],
     movements: [
@@ -537,11 +474,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/11_Chorale_Preludes,_Op.122_(Brahms,_Johannes)', label: 'IMSLP -- Eleven Chorale Preludes, Op. 122' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Eleven_Chorale_Preludes_(Brahms)', label: 'Wikipedia -- Eleven Chorale Preludes (Brahms)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Yl6tFB0grHo', label: 'Ton Koopman -- Erato (1991)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=sVJRu90kTL4', label: 'Thomas Trotter -- Hyperion (Birmingham Town Hall)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2S7qVhJqHNxjCq7LmIBJpM', label: 'Ton Koopman -- Erato (complete organ works)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0XHxhcfpAQCkGb3qI5F4kj', label: 'Thomas Trotter -- Hyperion (Gramophone Award)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrahmsChoralePreludes122HelmutWalcha', label: 'Helmut Walcha -- historic recording (St. Pierre-aux-Jesuites)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/rcco-organ/brahms-chorale-preludes-op122', label: 'Royal Canadian College of Organists -- recital recording' },
     ],
   },
@@ -574,12 +506,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Praeludium_in_D_minor,_BuxWV_140_(Buxtehude,_Dietrich)', label: 'IMSLP -- Praeludium in D minor, BuxWV 140' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Dietrich_Buxtehude', label: 'Wikipedia -- Dietrich Buxtehude' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=b_PXHkpvMeI', label: 'Ton Koopman -- Erato (Arp Schnitger organ, Groningen)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Gd7PPcEbkJ8', label: 'Harald Vogel -- MDG (1993, Arp Schnitger organ)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3lXH9CuPJkqYlvJPGTW2M5', label: 'Ton Koopman -- Erato (complete Buxtehude organ works)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BuxtehudeOrganWorksVogelSchnitger', label: 'Harald Vogel -- MDG (period organ recording)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/organ-heritage/buxtehude-praeludium-buxwv140', label: 'Lubeck Marienkirche -- historic organ reconstruction recording' },
     ],
   },
@@ -614,10 +541,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphonie-Passion,_Op.23_(Dupr%C3%A9,_Marcel)', label: 'IMSLP -- Symphonie-Passion, Op. 23' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Marcel_Dupr%C3%A9', label: 'Wikipedia -- Marcel Dupre' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=QEHcuVH3O9A', label: 'Ben van Oosten -- MDG (St. Ouen, Rouen)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=KoByVMlZxMY', label: 'Pierre Cochereau -- ORTF recording (Notre-Dame de Paris)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4bOJ4U7kToqNrBPX5hQqam', label: 'Ben van Oosten -- MDG (Cavaille-Coll organ, St. Ouen)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/DupreSymphoniePassionMarcelDupre', label: 'Marcel Dupre -- own historic recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/orgue-saint-ouen/dupre-symphonie-passion-op23', label: 'Live performance -- Cavaille-Coll organ, Saint-Ouen, Rouen' },
     ],
     movements: [
@@ -656,13 +579,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Livre_du_Saint-Sacrement_(Messiaen,_Olivier)', label: 'IMSLP -- Livre du Saint-Sacrement' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Livre_du_Saint-Sacrement', label: 'Wikipedia -- Livre du Saint-Sacrement' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=bqZT3_XVQE4', label: 'Olivier Latry -- DG (Notre-Dame de Paris)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=GnOw8DFXGAY', label: 'Jennifer Bate -- Unicorn-Kanchana (Beauvais Cathedral)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4V8BoLPRWR9Z1lP7UEHUJT', label: 'Olivier Latry -- DG (complete)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5S8R7LdFpFcrjJ6ZGN7PLg', label: 'Jennifer Bate -- Unicorn-Kanchana (Grammy-nominated)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MessiaenLivreSaintSacrementBate1985', label: 'Jennifer Bate -- Unicorn-Kanchana (premiere recording 1985)' },
       { type: 'vimeo', url: 'https://vimeo.com/347291849', label: 'Naji Hakim -- Sainte-Trinite, Paris (Messiaen\'s own organ)' },
     ],
   },
@@ -698,14 +615,8 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Harp_Concerto,_Op.25_(Ginastera,_Alberto)', label: 'IMSLP -- Harp Concerto, Op. 25' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Harp_Concerto_(Ginastera)', label: 'Wikipedia -- Harp Concerto (Ginastera)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=XGgwpuB3BxQ', label: 'Xavier de Maistre / Simon Rattle / Berlin Philharmonic -- Euroarts' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=nIyijW_GKHA', label: 'Yolanda Kondonassis / Jose Serebrier -- Telarc (1997)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2JoBiSM3GN1YWf7WMjNSsC', label: 'Yolanda Kondonassis / Jose Serebrier -- Telarc' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6fpGRNDhFfhW7jBiqFjV5h', label: 'Xavier de Maistre / Mariss Jansons / Bavarian Radio Symphony -- Sony' },
       { type: 'soundcloud', url: 'https://soundcloud.com/juilliard/ginastera-harp-concerto-juilliard', label: 'Juilliard School -- student concerto competition performance' },
-      { type: 'vimeo', url: 'https://vimeo.com/331048762', label: 'Emily Levin / Dallas Symphony Orchestra -- live broadcast' },
     ],
     movements: [
       { name: 'I. Allegro giusto' },
@@ -742,13 +653,6 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Suite_for_Harp,_Op.83_(Britten,_Benjamin)', label: 'IMSLP -- Suite for Harp, Op. 83' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Suite_for_Harp_(Britten)', label: 'Wikipedia -- Suite for Harp (Britten)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Cr0c2Lm2sXI', label: 'Osian Ellis -- Decca (1970, world premiere recording)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3mBVOdkT_4A', label: 'Xavier de Maistre -- Sony Classical' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5T0TfxChCjlqmVcfBv5HMt', label: 'Osian Ellis -- Decca (premiere recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1JhXV3eVHrXXA2cHn6mQbX', label: 'Xavier de Maistre -- Sony Classical' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrittenSuiteHarpEllisAldeburgh1969', label: 'Osian Ellis -- Aldeburgh Festival premiere broadcast (1969)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/rncm-harp/britten-suite-for-harp-op83', label: 'RNCM Harp -- student competition recording' },
     ],
     movements: [
@@ -790,10 +694,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Concertino_for_Harp_and_Orchestra_(Tailleferre,_Germaine)', label: 'IMSLP -- Harp Concertino (Tailleferre)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Germaine_Tailleferre', label: 'Wikipedia -- Germaine Tailleferre' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=k5GepFcg3_U', label: 'Isabelle Moretti / Leonard Slatkin -- Erato' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=bKVrm5sFvPA', label: 'Marie-Pierre Langlamet / Orchestre de Paris -- DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5ckxbL6FYy4bSBFxH3bQsN', label: 'Isabelle Moretti / Leonard Slatkin -- Erato' },
-      { type: 'internet_archive', url: 'https://archive.org/details/TailleferreConcertinoHarpPierlotLSO', label: 'Pierre Pierlot / London Symphony Orchestra -- 1940s recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/cnsm-paris/tailleferre-concertino-harp', label: 'CNSM Paris -- student concerto recital' },
     ],
     movements: [
@@ -834,13 +734,8 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Rebonds_(Xenakis,_Iannis)', label: 'IMSLP -- Rebonds (Xenakis)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Iannis_Xenakis', label: 'Wikipedia -- Iannis Xenakis' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=RRdLxH7G5aU', label: 'Robyn Schulkowsky -- Neuma Records (world premiere recording)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Z8N3tFKVxJc', label: 'Steven Schick -- Mode Records (2002)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3OFlPrH0Xh3r5S5p5t1Jf2', label: 'Steven Schick -- Mode Records (complete percussion works)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/ard-competition/xenakis-rebonds-ard-percussion', label: 'ARD Competition finalist -- Munich 2017' },
-      { type: 'vimeo', url: 'https://vimeo.com/282074139', label: 'Colin Currie -- Queen Elizabeth Hall, London Sinfonietta' },
     ],
   },
 
@@ -873,12 +768,7 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/John_Psathas', label: 'Wikipedia -- John Psathas' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8HuNkXLIeoc', label: 'Evelyn Glennie -- world premiere recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=TfGo2R8vUSQ', label: 'Colin Currie -- live recital (London)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2T4dVONjhvBG7kZpN4y2ID', label: 'Evelyn Glennie -- Orange Records (premiere recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4jPXd4HVNMkb8HBhIbixwA', label: 'Colin Currie -- NMC Recordings' },
       { type: 'soundcloud', url: 'https://soundcloud.com/john-psathas-composer/view-from-olympus-demo', label: 'John Psathas official -- composer recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/197630834', label: 'International Marimba Competition finalist -- Stuttgart 2014' },
     ],
   },
 
@@ -911,10 +801,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Kaija_Saariaho', label: 'Wikipedia -- Kaija Saariaho' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=n8fkBMJCdl4', label: 'Kroumata Ensemble -- premiere performance (Salzburg 1995)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=VT3_zqtMpL8', label: 'Colin Currie -- live performance with electronics' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1bRjFqRzFMqO8Q24nVFaW0', label: 'Kroumata Percussion -- BIS Records' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5O1BwPicMO3YkQUKj2dAYH', label: 'Colin Currie -- NMC Recordings' },
       { type: 'soundcloud', url: 'https://soundcloud.com/ircam-paris/saariaho-six-japanese-gardens', label: 'IRCAM Paris -- original electronics archive' },
       { type: 'vimeo', url: 'https://vimeo.com/314206792', label: 'International Percussion Competition -- Salzburg 2018 finalist' },
     ],
@@ -959,13 +845,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Sonata_rom%C3%A1ntica_(Ponce,_Manuel)', label: 'IMSLP -- Sonata romantica (Ponce)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Manuel_Ponce', label: 'Wikipedia -- Manuel Ponce' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=4hKGlIcr7F4', label: 'Andres Segovia -- Decca (1950s studio recording)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Ggf91GJqCus', label: 'David Russell -- Telarc (Grammy Award recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5VWZQ8h8wSr2g8xGE7iXxq', label: 'David Russell -- Telarc (Grammy Award, Best Instrumental Solo)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7vt6NQZR2yqI94zJHH5PkF', label: 'Pepe Romero -- Philips (complete Ponce guitar works)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/PonceSonataRomanticaSegovia1954', label: 'Andres Segovia -- 1954 recording (historic)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/rcm-guitar/ponce-sonata-romantica', label: 'Royal College of Music -- guitar recital' },
     ],
     movements: [
@@ -1004,14 +884,8 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Tango_en_Ska%C3%AF_(Dyens,_Roland)', label: 'IMSLP -- Tango en Skai' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Roland_Dyens', label: 'Wikipedia -- Roland Dyens' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=QUNe3L4MVpk', label: 'Roland Dyens -- Accord Records (composer performance)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Vz5Ae_SMKZ8', label: 'Ana Vidovic -- Naxos (2007)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3vvKrGYoXTLlJfzHWv0fM2', label: 'Roland Dyens -- Accord Records (composer performed)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1R3VHnGH8T6FnZ2p8kLcCq', label: 'Ana Vidovic -- Naxos' },
       { type: 'soundcloud', url: 'https://soundcloud.com/rcm-guitar/dyens-tango-en-skai-student', label: 'Royal College of Music -- guitar student recital' },
-      { type: 'vimeo', url: 'https://vimeo.com/152448927', label: 'Juanjo Moscardini -- live guitar recital, Buenos Aires' },
     ],
   },
 
@@ -1043,12 +917,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/El_Maestro_(Milan,_Luis)', label: 'IMSLP -- El Maestro (Luis de Milan)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Luis_de_Mil%C3%A1n', label: 'Wikipedia -- Luis de Milan' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=0S2DpAXqUmM', label: 'John Williams -- CBS Masterworks (1975)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=MJFbzRJ-Sjg', label: 'Julian Bream -- RCA Red Seal' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4qLh4l0s4t6LJD5B3e4B2K', label: 'John Williams -- Sony Classical (Pavane and Renaissance music)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MilanPavaneLuteVihuelas1950', label: 'Andres Segovia -- 1950s Decca recording (historic)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/rncm-guitar/milan-pavane-renaissance', label: 'RNCM Guitar -- Renaissance music recital' },
     ],
   },
@@ -1084,12 +953,7 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Double_Bass_Concerto_in_D_major_(Sperger,_Johann_Matthias)', label: 'IMSLP -- Double Bass Concerto in D major (Sperger)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Johann_Matthias_Sperger', label: 'Wikipedia -- Johann Matthias Sperger' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=hPJRGm8YK2s', label: 'Klaus Trumpf / Sudwestfunk Chamber Orchestra -- MDG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Ec5bP5pCbAE', label: 'Nils Bornig / Georg Mais / Orchestra -- Naxos (2003)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6c8BqpQiP8VbLXKkPwAVFJ', label: 'Nils Bornig / Georg Mais -- Naxos (complete Sperger concertos)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SpergerDBConcertoTrumpfMDG', label: 'Klaus Trumpf / Sudwestfunk Chamber Orchestra -- MDG archival' },
       { type: 'soundcloud', url: 'https://soundcloud.com/isb-doublebass/sperger-concerto-d-major-student', label: 'International Society of Bassists -- student concerto recording' },
     ],
     movements: [

--- a/src/data/seed-expansion-14.ts
+++ b/src/data/seed-expansion-14.ts
@@ -39,13 +39,7 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.94_in_G_major_%22Surprise%22_(Haydn,_Joseph)', label: 'IMSLP — Symphony No. 94 "Surprise" (Haydn)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._94_(Haydn)', label: 'Wikipedia — Symphony No. 94 "Surprise" (Haydn)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=MWIzI3kF0Vg', label: 'Frans Brüggen / Orchestra of the 18th Century — period instruments' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=f4CXsLMJgos', label: 'Leonard Bernstein / New York Philharmonic — CBS' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3xF7qfOc7Y77Ku0bK1yXI2', label: 'Nikolaus Harnoncourt / Concertgebouw Orchestra — Teldec' },
-      { type: 'internet_archive', url: 'https://archive.org/details/HaydnSymphony94SurpriseBeecham', label: 'Thomas Beecham / Royal Philharmonic — 1958 (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/haydn-symphony-94-period', label: 'Trevor Pinnock / English Concert — Archiv' },
     ],
   },
 
@@ -86,10 +80,6 @@ export const expansionPieces14: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.2,_Op.36_(Beethoven,_Ludwig_van)', label: 'IMSLP — Symphony No. 2, Op. 36 (Beethoven)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._2_(Beethoven)', label: 'Wikipedia — Symphony No. 2 (Beethoven)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=C3nxyS8wf8o', label: 'Carlos Kleiber / Bavarian State Orchestra — DG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=hRfNaXBb-n0', label: 'Herbert von Karajan / Berlin Philharmonic — DG 1963' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5g2C4zEb4zEjb9Tf4nfT0P', label: 'Nikolaus Harnoncourt / Chamber Orchestra of Europe — Teldec' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BeethovenSymphony2ToscaninNBC1939', label: 'Arturo Toscanini / NBC Symphony — 1939 (historic)' },
       { type: 'vimeo', url: 'https://vimeo.com/289141073', label: 'Paavo Järvi / Deutsche Kammerphilharmonie Bremen — live' },
     ],
   },
@@ -125,10 +115,6 @@ export const expansionPieces14: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.1,_Op.55_(Elgar,_Edward)', label: 'IMSLP — Symphony No. 1, Op. 55 (Elgar)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._1_(Elgar)', label: 'Wikipedia — Symphony No. 1 (Elgar)' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=_9RT2nHD6CQ', label: 'Leonard Slatkin / BBC Symphony Orchestra — BBC' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=B-XAqHlz2VQ', label: 'Colin Davis / BBC Symphony Orchestra — Philips' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5dKgY7tAFfnhbvSxUyHzfW', label: 'Andrew Davis / BBC Symphony Orchestra — Teldec' },
-      { type: 'internet_archive', url: 'https://archive.org/details/ElgarSymphony1Boult1975', label: 'Adrian Boult / London Philharmonic — 1975 (Elgar specialist)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/elgar-symphony-1-sakari', label: 'Sakari Oramo / BBC Symphony — BBC Proms' },
     ],
   },
 
@@ -162,11 +148,6 @@ export const expansionPieces14: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Siegfried_Idyll,_WWV_103_(Wagner,_Richard)', label: 'IMSLP — Siegfried Idyll, WWV 103 (Wagner)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Siegfried_Idyll', label: 'Wikipedia — Siegfried Idyll' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=AePOHRNiHkA', label: 'Herbert von Karajan / Berlin Philharmonic — DG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Bj3KsHxvFEg', label: 'Daniel Barenboim / Berlin Philharmonic — live Salzburg' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4sFCO5LUGAhP3C9eafIhiK', label: 'Herbert von Karajan / Berlin Philharmonic — DG' },
-      { type: 'internet_archive', url: 'https://archive.org/details/WagnerSiegfriedIdyllFurtwangler1950', label: 'Wilhelm Furtwängler / Berlin Philharmonic — 1950 (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/wagner-siegfried-idyll-chamber', label: 'Chamber version — original 13-instrument scoring' },
     ],
   },
 
@@ -199,12 +180,6 @@ export const expansionPieces14: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._3_(Copland)', label: 'Wikipedia — Symphony No. 3 (Copland)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=DhFEa6t2Y10', label: 'Aaron Copland / London Symphony Orchestra — CBS (composer conducting)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=VHMpvM5JQZY', label: 'Leonard Bernstein / New York Philharmonic — CBS' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1LxA7dpRuK1mJlLUKR7jNP', label: 'Aaron Copland / London Symphony Orchestra — Sony Classical' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0dDWMVr2P6nqYXQVGU8yqQ', label: 'Marin Alsop / Colorado Symphony — Naxos' },
-      { type: 'internet_archive', url: 'https://archive.org/details/CoplandThirdSymphonyKoussevitzky1946', label: 'Serge Koussevitzky / Boston Symphony — 1946 premiere recording' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/copland-symphony-3-bernstein', label: 'Leonard Slatkin / Saint Louis Symphony — live' },
     ],
   },
 
@@ -239,12 +214,6 @@ export const expansionPieces14: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Trio_in_B-flat_major,_D.581_(Schubert,_Franz)', label: 'IMSLP — String Trio D. 581 (Schubert)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Trio_in_B-flat_major_(Schubert)', label: 'Wikipedia — String Trio D. 581 (Schubert)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=wWEbWG5Fy7Q', label: 'Grumiaux Trio — Philips' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=qJmX3n9kNpY', label: 'Hagen Quartet members — live recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4m9bLN5K8zKtnT3oLcAaDp', label: 'Grumiaux Trio — Philips' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SchubertStringTrioD581', label: 'Archive recording of early performance' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/schubert-string-trio-d581', label: 'Belcea Quartet members — live chamber recital' },
     ],
   },
 
@@ -278,11 +247,6 @@ export const expansionPieces14: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Trio_in_B-flat_major,_Op.97_(Beethoven,_Ludwig_van)', label: 'IMSLP — Piano Trio Op. 97 "Archduke" (Beethoven)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Trio_No._7_(Beethoven)', label: 'Wikipedia — Piano Trio Op. 97 "Archduke"' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=KjiZwbLr3nE', label: 'Daniel Barenboim / Itzhak Perlman / Jacqueline du Pré — EMI (1970 legendary)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=FsL_bWxIOMI', label: 'Emanuel Ax / Itzhak Perlman / Yo-Yo Ma — live Carnegie Hall' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1h1xXNLmCIQJPCQDT3i8j8', label: 'Beaux Arts Trio — Philips' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BeethovenArchdukeTrio1950Casadesus', label: 'Robert Casadesus / Jascha Heifetz / Emanuel Feuermann — 1941 (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/beethoven-archduke-trio-live', label: 'Kalichstein-Laredo-Robinson Trio — live recital' },
     ],
   },
 
@@ -316,11 +280,6 @@ export const expansionPieces14: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_No.2,_Op.51_No.2_(Brahms,_Johannes)', label: 'IMSLP — String Quartet No. 2, Op. 51 (Brahms)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._2_(Brahms)', label: 'Wikipedia — String Quartet No. 2 (Brahms)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=g0CjJRKxhEA', label: 'Emerson String Quartet — DG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=FTX1VLw-oQs', label: 'Quatuor Ebène — live Wigmore Hall' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0VVWt6Y1mOkqTUg5kUQYBP', label: 'Emerson String Quartet — DG' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrahmsStringQuartet2Op51BudapestSQ', label: 'Budapest String Quartet — 1952 (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/brahms-sq2-live', label: 'Belcea Quartet — live recital' },
     ],
   },
 
@@ -353,12 +312,6 @@ export const expansionPieces14: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Quartet,_Op.47_(Schumann,_Robert)', label: 'IMSLP — Piano Quartet Op. 47 (Schumann)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Quartet,_Op._47_(Schumann)', label: 'Wikipedia — Piano Quartet Op. 47 (Schumann)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=2WYX2_ZRFDU', label: 'Martha Argerich / members of the Berlin Philharmonic — DG live' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=lkHLiGAcqv4', label: 'Yefim Bronfman / Emerson String Quartet — DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0yc0bJ9sS5sj2TqFwKkGWY', label: 'Domus / Richard Lester — Hyperion' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/schumann-piano-quartet-live', label: 'Quatuor Ebène / Pierre-Laurent Aimard — Verbier Festival' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SchumannPianoQuartetOp47Serkin1941', label: 'Rudolf Serkin / Busch Chamber Players — 1941 (historic)' },
     ],
   },
 
@@ -392,11 +345,6 @@ export const expansionPieces14: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Sonata_No.1,_Op.13_(Fauré,_Gabriel)', label: 'IMSLP — Violin Sonata No. 1, Op. 13 (Fauré)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Sonata_No._1_(Fauré)', label: 'Wikipedia — Violin Sonata No. 1 (Fauré)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Pf-4EbI8Mgw', label: 'Renaud Capuçon / Nicholas Angelich — DG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=4hK4EGwJe_w', label: 'Isabelle Faust / Alexander Melnikov — Harmonia Mundi' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5H6nALvgXz2jyEfnQDFo1f', label: 'Renaud Capuçon / Nicholas Angelich — Deutsche Grammophon' },
-      { type: 'internet_archive', url: 'https://archive.org/details/FaureViolinSonata1ThibaudCortot1927', label: 'Jacques Thibaud / Alfred Cortot — 1927 (historic)' },
-      { type: 'vimeo', url: 'https://vimeo.com/418744231', label: 'Hilary Hahn / Valentina Lisitsa — live recital' },
     ],
   },
 
@@ -430,13 +378,7 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Introduction_and_Allegro_(Ravel,_Maurice)', label: 'IMSLP — Introduction and Allegro (Ravel)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Introduction_and_Allegro_(Ravel)', label: 'Wikipedia — Introduction and Allegro (Ravel)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=YbDIJ3DBCAE', label: 'Marielle Nordmann (harp) / Ensemble Intercontemporain — DG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=5wBo9FtKxaM', label: 'Marie-Pierre Langlamet (harp) / Berlin Philharmonic soloists — live' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1GQPBixjE8f6rQvEdAPaLT', label: 'Lily Laskine (harp) / Jean-Pierre Rampal / Melos Ensemble — CBS' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/ravel-intro-allegro-harp-live', label: 'Sivan Magen (harp) — Queen Elisabeth Competition recording' },
-      { type: 'internet_archive', url: 'https://archive.org/details/RavelIntroductionAllegroLaskine1960', label: 'Lily Laskine (harp) / Melos Ensemble — 1960 (historic)' },
     ],
   },
 
@@ -469,11 +411,6 @@ export const expansionPieces14: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Conte_fantastique_(Caplet,_André)', label: 'IMSLP — Conte fantastique (Caplet)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Conte_fantastique_(Caplet)', label: 'Wikipedia — Conte fantastique (Caplet)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=R6R34CJh_8k', label: 'Isabelle Moretti (harp) / Ensemble Danel — live' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=NVwg4C6kFqs', label: 'Marie-Pierre Langlamet (harp) / Soloists of the Berlin Philharmonic' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5b6BJ5h0g2RbFvxlTVhiXz', label: 'Isabelle Moretti (harp) / Quatuor Danel — Mirare' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/caplet-conte-fantastique', label: 'Lavinia Meijer (harp) / Amsterdam String Quartet — live recital' },
       { type: 'vimeo', url: 'https://vimeo.com/289414782', label: 'Sivan Magen (harp) / ATOS Trio — recital recording' },
     ],
   },
@@ -506,13 +443,7 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Harp_Concerto_in_C_minor_(Renié,_Henriette)', label: 'IMSLP — Harp Concerto in C minor (Renié)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Henriette_Renié', label: 'Wikipedia — Henriette Renié' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=XxOJQqS4Lm8', label: 'Marielle Nordmann (harp) / Orchestre de Paris — live' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=tqKOkpJVfV0', label: 'Isabelle Moretti (harp) / Orchestre de Toulouse — live' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1V9C8qJBt5gTU7bnJn4v3M', label: 'Marielle Nordmann — Erato' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/renie-harp-concerto', label: 'Florentine Mulsant — conservatoire competition' },
-      { type: 'vimeo', url: 'https://vimeo.com/267891043', label: 'Sivan Magen — live recital excerpt' },
     ],
   },
 
@@ -547,12 +478,6 @@ export const expansionPieces14: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Organ_Symphony_No.5,_Op.47_(Vierne,_Louis)', label: 'IMSLP — Organ Symphony No. 5, Op. 47 (Vierne)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Organ_Symphony_No._5_(Vierne)', label: 'Wikipedia — Organ Symphony No. 5 (Vierne)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=DX6bsFQ2hKY', label: 'Ben van Oosten — Cavaillé-Coll organ, St. Sulpice — MDG' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=iq0Eq8M4y0c', label: 'Olivier Latry — organ of Notre-Dame de Paris — live' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4VqLR2HLvqZKvlNbPWbPZb', label: 'Ben van Oosten — MDG' },
-      { type: 'internet_archive', url: 'https://archive.org/details/VierneOrganSymphony5Cochereau', label: 'Pierre Cochereau — Notre-Dame de Paris — 1964 (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/vierne-organ-symphony-5-live', label: 'Thomas Trotter — live recital' },
     ],
   },
 
@@ -584,13 +509,6 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Fantasy_and_Fugue_on_%27Ad_nos,_ad_salutarem_undam%27_(Liszt,_Franz)', label: 'IMSLP — Fantasy and Fugue on Ad nos (Liszt)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Fantasy_and_Fugue_on_%22Ad_nos,_ad_salutarem_undam%22', label: 'Wikipedia — Fantasy and Fugue on Ad nos' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=g0JUobGBAmw', label: 'Simon Preston — organ of Westminster Abbey — Archiv' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=klBgkHfC_4s', label: 'Olivier Latry — organ of Notre-Dame de Paris — live' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3htFQwGMgkBpA76Jd83kfH', label: 'Simon Preston — Archiv / DG' },
-      { type: 'internet_archive', url: 'https://archive.org/details/LisztAdNosOrganFantasy', label: 'Helmut Walcha — Grosse Orgel, Jakobikirche Hamburg — archive recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/288751603', label: 'Thierry Escaich — recital' },
     ],
   },
 
@@ -622,13 +540,7 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/6_Pièces_(Franck,_César)', label: 'IMSLP — Six Pièces including Prélude, Fugue et Variation (Franck)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/César_Franck', label: 'Wikipedia — César Franck (organ works)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=H3tB1tSMxME', label: 'Marie-Claire Alain — organ of Sainte-Clotilde, Paris — Erato' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=wBPBD7xvzaw', label: 'Olivier Latry — organ of Notre-Dame de Paris — DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5aqMmfKbFd7NWFbBQVhNIJ', label: 'Marie-Claire Alain — Erato' },
-      { type: 'internet_archive', url: 'https://archive.org/details/FranckPreludeFugueVariationCochereau', label: 'Pierre Cochereau — Notre-Dame de Paris — 1956 (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/franck-prelude-fugue-variation', label: 'Thomas Trotter — recital recording' },
     ],
   },
 
@@ -664,11 +576,6 @@ export const expansionPieces14: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Capricho_árabe_(Tárrega,_Francisco)', label: 'IMSLP — Capricho Árabe (Tárrega)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Francisco_Tárrega', label: 'Wikipedia — Francisco Tárrega' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=rw7A-a9C50s', label: 'Andrés Segovia — historic studio recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=zCzJLmfAm7I', label: 'Pepe Romero — Philips' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0ZEZFbVe7IXsXRl3CdJYZ8', label: 'Julian Bream — EMI' },
-      { type: 'internet_archive', url: 'https://archive.org/details/TarregaCaprichoClaudioArrau1953', label: 'Andrés Segovia — 1952 studio (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/tarrega-capricho-arabe-live', label: 'Ana Vidović — live recital' },
     ],
   },
 
@@ -702,11 +609,6 @@ export const expansionPieces14: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Un_sueño_en_la_floresta_(Barrios_Mangoré,_Agustín)', label: 'IMSLP — Un Sueño en la Floresta (Barrios Mangoré)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Agustín_Barrios', label: 'Wikipedia — Agustín Barrios Mangoré' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=H7kKjECBPb4', label: 'John Williams — Sony Classical' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=r_g7_l5Xq7E', label: 'Sergio Assad — Nonesuch' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5vXf8VRpS5WlN0HcYl3TiK', label: 'John Williams — Sony Classical' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BarriosSuenoenFlorestaNarvaez1960', label: 'Archive recording of early Barrios performance' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/barrios-sueno-floresta-guitar', label: 'Manuel Barrueco — live recital' },
     ],
   },
 
@@ -738,13 +640,7 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Variations_on_a_Theme_of_Mozart,_Op.9_(Sor,_Fernando)', label: 'IMSLP — Variations on a Theme of Mozart, Op. 9 (Sor)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Fernando_Sor', label: 'Wikipedia — Fernando Sor' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=VUbaMJYV28s', label: 'Andrés Segovia — historic studio recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=9VsXi6crGAc', label: 'David Russell — live recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6UQc44fJl0qgp1G3xVPFfx', label: 'Andrés Segovia — Deutsche Grammophon Archive' },
-      { type: 'internet_archive', url: 'https://archive.org/details/SorVariationsMozartSegovia1953', label: 'Andrés Segovia — 1953 studio recording (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/sor-op9-guitar-live', label: 'Marco Ramelli — student competition recording' },
     ],
   },
 
@@ -776,13 +672,6 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/12_Études_(Villa-Lobos,_Heitor)', label: 'IMSLP — 12 Études (Villa-Lobos)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/12_Études_(Villa-Lobos)', label: 'Wikipedia — 12 Études (Villa-Lobos)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=IHJUnVVfEmw', label: 'Julian Bream — EMI (complete set)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=ZM7RBpIPTOc', label: 'Göran Söllscher — DG' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4KCpFBGFCGGzBNRb6v0B7w', label: 'Julian Bream — EMI' },
-      { type: 'internet_archive', url: 'https://archive.org/details/VillaLobos12EtudesSegovia1960', label: 'Andrés Segovia — 1960 studio (historic)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/villa-lobos-12-etudes-guitar', label: 'Xuefei Yang — live recital' },
     ],
   },
 
@@ -816,11 +705,6 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Percussion_Concerto_(Schwantner)', label: 'Wikipedia — Percussion Concerto (Schwantner)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Yrb91dqWHHM', label: 'Evelyn Glennie / Leonard Slatkin / NSO — world premiere' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=JkHl7Tc7Z6g', label: 'Colin Currie / BBC Symphony Orchestra — BBC Proms' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3sE6nEBqJmvM3e5X1sN8tF', label: 'Evelyn Glennie / Leonard Slatkin — RCA Red Seal' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/schwantner-percussion-concerto', label: 'Martin Grubinger / Vienna Philharmonic — live' },
       { type: 'vimeo', url: 'https://vimeo.com/362471830', label: 'Simon Rattle / Simone Rubino — BBC Proms 2018' },
     ],
   },
@@ -856,10 +740,6 @@ export const expansionPieces14: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.2_(Mahler,_Gustav)', label: 'IMSLP — Symphony No. 2 "Resurrection" (Mahler)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._2_(Mahler)', label: 'Wikipedia — Symphony No. 2 "Resurrection" (Mahler)' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=sHsFIv8VA7w', label: 'Leonard Bernstein / New York Philharmonic — CBS (legendary 1987)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=wxZ_FkUhIrA', label: 'Simon Rattle / City of Birmingham Symphony — EMI' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3nQkV7X7VWBzHHNBOsBaZH', label: 'Leonard Bernstein / New York Philharmonic — Sony Classical' },
-      { type: 'internet_archive', url: 'https://archive.org/details/MahlerSymphony2ResurrectionKlemperer1962', label: 'Otto Klemperer / Philharmonia Orchestra — 1962 (historic EMI)' },
-      { type: 'vimeo', url: 'https://vimeo.com/421847059', label: 'Andris Nelsons / Boston Symphony Orchestra — live' },
     ],
   },
 
@@ -891,12 +771,6 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Marimba_Spiritual', label: 'Wikipedia — Marimba Spiritual' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=uX0oCxaVLGE', label: 'Keiko Abe — premiere performance (Tokyo)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Ge7iJw7q0Wk', label: 'Katarzyna Myćka — ARD Competition recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5LN7jQ2fKjPOXgFO0D2R4f', label: 'Keiko Abe — Denon' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/miki-marimba-spiritual-live', label: 'Ivan Trevino — live performance' },
-      { type: 'vimeo', url: 'https://vimeo.com/184274120', label: 'Young-Gun Park — Leysin International Marimba Competition finalist' },
     ],
   },
 
@@ -929,11 +803,6 @@ export const expansionPieces14: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Keiko_Abe', label: 'Wikipedia — Keiko Abe' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=NxTaKNiZ-eU', label: 'Keiko Abe — composer performing, live recital' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=M_KZJk87Ick', label: 'Katarzyna Myćka — live recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1fpHs4q03ROxqm4Fhz5VnX', label: 'Keiko Abe — Denon' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/abe-wind-bamboo-grove', label: 'Mari Yoshida — competition recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/203981827', label: 'Ivan Trevino — competition semi-final' },
     ],
   },
 
@@ -974,13 +843,7 @@ export const expansionPieces14: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Double_Bass_Concerto_No.2_(Bottesini,_Giovanni)', label: 'IMSLP — Double Bass Concerto No. 2 (Bottesini)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Giovanni_Bottesini', label: 'Wikipedia — Giovanni Bottesini' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=r2W6XDqXBdk', label: 'Gary Karr / Harmon Lewis — legendary Karr recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=AX0LS8_7Nf4', label: 'Rinat Ibragimov / LSO — BBC' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6k2iXZpJnvSZ1qXN8BqwNO', label: 'Gary Karr / Slovak Philharmonic — Delos' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BottesiniConcertoNo2Bass', label: 'Historic recording — early 20th century' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/bottesini-concerto-2-db', label: 'Dominic Seldis — live recital' },
     ],
   },
 

--- a/src/data/seed-expansion-15.ts
+++ b/src/data/seed-expansion-15.ts
@@ -30,11 +30,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Wind_Quintet,_Op.43_(Nielsen,_Carl)', label: 'IMSLP — Wind Quintet Op. 43 (Nielsen)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Wind_Quintet_(Nielsen)', label: 'Wikipedia — Wind Quintet (Nielsen)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=jnNNMz0hUh8', label: 'Berlin Philharmonic Wind Quintet — complete performance' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=V_MiT1IXFL8', label: 'Athena Wind Quintet — complete Op. 43' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3P0vMRBJQv3ACvJUJdanKW', label: 'Nash Ensemble — Hyperion recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7klpZRzYH5GFHQ6jQCXvF2', label: 'Ensemble Wien-Berlin — DG recording' },
-      { type: 'internet_archive', url: 'https://archive.org/details/NielsenWindQuintetOp43', label: 'Copenhagen Wind Quintet — historic Danish Radio recording' },
     ],
   },
 
@@ -57,10 +52,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quintet_No.2,_Op.111_(Brahms,_Johannes)', label: 'IMSLP — String Quintet No. 2 Op. 111 (Brahms)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quintet_No._2_(Brahms)', label: 'Wikipedia — String Quintet No. 2 (Brahms)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=kN1KSf83nmI', label: 'Hagen Quartet with Veronika Hagen — complete Op. 111' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=RvVNfK7qF7U', label: 'Emerson String Quartet with Paul Neubauer — live performance' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1GPAS7EUgPqUgXgxJqLrdQ', label: 'Isaac Stern Chamber Music Collection — Brahms Quintets (Sony Classical)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrahmsStringQuintetOp111', label: 'Budapest String Quartet — historic studio recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/talich-quartet/brahms-string-quintet-op111', label: 'Talich Quartet — studio recording' },
     ],
   },
@@ -82,12 +73,7 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-mozart-pq-schirmer', publisher: 'G. Schirmer', editor: 'Standard edition', year: 1950, description: 'Practical American performing edition; widely available and used in conservatories.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Quartet_No.1_in_G_minor,_K.478_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP — Piano Quartet K. 478 (Mozart)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Quartet_No._1_(Mozart)', label: 'Wikipedia — Piano Quartet No. 1 (Mozart)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8C-mpMNBTGs', label: 'Mitsuko Uchida / Ensemble — Philips recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=XnEOLMBmgcw', label: 'Murray Perahia with members of the Amadeus Quartet' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4R1ZEJelR3f8u5oVMFH7bA', label: 'Mitsuko Uchida / Violin, Viola, Cello — Philips (Gramophone Award)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Mozart-PianoQuartetK478-Hephzibah-Menuhin', label: 'Hephzibah Menuhin — historic chamber recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/mozarteum-salzburg/mozart-piano-quartet-k478', label: 'Mozarteum Salzburg ensemble — concert recording' },
     ],
     movements: [
@@ -115,10 +101,6 @@ export const expansionPieces15: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quintet_in_C_major,_Op.29_(Beethoven,_Ludwig_van)', label: 'IMSLP — String Quintet Op. 29 (Beethoven)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quintet_in_C_major_(Beethoven)', label: 'Wikipedia — String Quintet in C major (Beethoven)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=LKJMzpnqYCM', label: 'Alban Berg Quartet with Thomas Kakuska — complete Op. 29' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4kWxg6qxhbA2kTNVJf4E4B', label: 'Grumiaux Trio — Philips (classic recording)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BeethovenStringQuintetOp29', label: 'Busch Chamber Players — historic 1930s recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/quartetto-italiano/beethoven-string-quintet-op29', label: 'Quintetto Borciani — competition recording' },
     ],
     movements: [
@@ -149,13 +131,6 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-franck-ch1-kalmus', publisher: 'Kalmus', editor: 'Study edition', year: 1970, description: 'Affordable reprint edition widely used in American organ study.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/3_Chorals_(Franck,_C%C3%A9sar)', label: 'IMSLP — Three Chorals (Franck)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Three_Chorals_(Franck)', label: 'Wikipedia — Three Chorals (Franck)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=XMfEXPt2Cag', label: 'Marie-Claire Alain — Grand Orgue de Saint-Séverin, Paris' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=6EyqBmLfmK4', label: 'Olivier Latry — Notre-Dame de Paris (before fire)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6X4Ow1AvY5UyPHOoEsTf1r', label: 'Marie-Claire Alain — Complete Organ Works (Erato)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2VFqJtqF6jK4JVCqHkS3WM', label: 'Olivier Latry — Franck Three Chorals, Notre-Dame de Paris (DG)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/FranckThreeChoralsMarcelDupre', label: 'Marcel Dupré — historic 1950s recording, student of Franck tradition' },
     ],
   },
 
@@ -175,13 +150,7 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-dupre-pass-dover', publisher: 'Dover Publications', editor: 'Reprint', year: 1995, description: 'Affordable reprint edition making the complete Op. 31 accessible to students.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Passacaille,_Op.31_(Dupr%C3%A9,_Marcel)', label: 'IMSLP — Passacaille Op. 31 (Dupré)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Marcel_Dupr%C3%A9', label: 'Wikipedia — Marcel Dupré' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=iWLSmxU7v6g', label: 'Marie-Claire Alain — Passacaille in B minor, Op. 31' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=dUJzLbgbYT4', label: 'Olivier Latry — Cavaillé-Coll organ, Paris' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5J5DwNnzAWzw9QwNoUAJFh', label: 'Ben van Oosten — Dupré Complete Organ Works (MDG)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/DuprePassacailleOp31', label: 'Marcel Dupré himself — 1957 recording on the Cavaillé-Coll of Saint-Sulpice' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/organ-dupre-passacaille', label: 'David Briggs — cathedral recording' },
     ],
   },
 
@@ -201,13 +170,7 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-buxtehude-pg-hansen', publisher: 'Hansen / Bärenreiter', editor: 'Klaus Beckmann', year: 1998, description: 'Practical performing edition with informed ornament realisations and critical notes.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Praeludium_in_G_minor,_BuxWV_149_(Buxtehude,_Dietrich)', label: 'IMSLP — Praeludium BuxWV 149 (Buxtehude)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Dieterich_Buxtehude', label: 'Wikipedia — Dieterich Buxtehude' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=PCybgZL7fkw', label: 'Harald Vogel — north-German Baroque organ, Pellworm' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=sBt7dLLsQNM', label: 'Masaaki Suzuki — Marienkirche Lübeck historic organ' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4Ng8VaTiknPv5GcjAI3YFx', label: 'Harald Vogel — Complete Buxtehude Organ Works (MDG)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Buxtehude-OrganWorks-Heiller', label: 'Anton Heiller — classic mid-century Buxtehude recording' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/buxtehude-buxwv149-preludium', label: 'Anna Lapwood — live recital, Cambridge' },
     ],
   },
 
@@ -230,12 +193,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Prelude_and_Fugue_in_E_minor,_BWV_548_(Bach,_Johann_Sebastian)', label: 'IMSLP — Prelude and Fugue BWV 548 (Bach)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Prelude_and_Fugue_in_E_minor,_BWV_548', label: 'Wikipedia — Prelude and Fugue BWV 548 "The Wedge"' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=l9_oR3dNxEs', label: 'Helmut Walcha — Grosse Katharinenkirche Frankfurt (historic studio recording)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=TQSEcifKReM', label: 'Anna Lapwood — Pembroke College Chapel, Cambridge' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6h9LKQJR3P2Xmj4CikADfP', label: 'Helmut Walcha — Complete Bach Organ Works (Archiv Produktion / DG)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2V3HZmkfMFeMDHoR5RK9TQ', label: 'Peter Hurford — Bach Organ Works (Decca / Argo)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BachOrganWorksBWV548-E.PowerBiggs', label: 'E. Power Biggs — Columbia Masterworks (historic 1950s recording)' },
-      { type: 'vimeo', url: 'https://vimeo.com/423657120', label: 'Thomas Trotter — Birmingham Town Hall organ, recital video' },
     ],
   },
 
@@ -257,13 +214,6 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-britten-sh-boosey', publisher: 'Boosey & Hawkes', editor: 'Study edition', year: 1988, description: 'Study edition in wider circulation; preferred by many teachers for its layout.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Suite_for_Harp,_Op.83_(Britten,_Benjamin)', label: 'IMSLP — Suite for Harp Op. 83 (Britten)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Suite_for_Harp_(Britten)', label: 'Wikipedia — Suite for Harp (Britten)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=GjMNAYHfVQA', label: 'Osian Ellis — premiere recording (original dedicatee)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=YhJxRtAaOlQ', label: 'Catrin Finch — BBC Wales performance' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5gFqdHPGJTJuTkrfn2ILLm', label: 'Osian Ellis — Decca recording (premiere)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4vCAjPHKvwvFHIV0SvnSbS', label: 'Marisa Robles — Chandos recording' },
-      { type: 'internet_archive', url: 'https://archive.org/details/BrittenSuiteForHarpOsianEllis', label: 'Osian Ellis — original Decca broadcast (historic)' },
       { type: 'vimeo', url: 'https://vimeo.com/318456712', label: 'Lavinia Meijer — Britten Suite for Harp, concert film' },
     ],
     movements: [
@@ -292,12 +242,7 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-faure-ih-schirmer', publisher: 'G. Schirmer', editor: 'American edition', year: 1970, description: 'Widely used American edition for harp students and professionals.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Impromptu,_Op.86_(Faur%C3%A9,_Gabriel)', label: 'IMSLP — Impromptu Op. 86 (Fauré)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Gabriel_Fauré', label: 'Wikipedia — Gabriel Fauré' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=F0uTNLlGM4k', label: 'Marielle Nordmann — Fauré Impromptu Op. 86' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=YmKQ7qV4z1I', label: 'Xavier de Maistre — solo harp recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3kpAUVVoVrHgE0Kq8V6YDi', label: 'Xavier de Maistre — Sony Classical harp recital' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1A6fCzMUqTJX5dRSV8N4iC', label: 'Marielle Nordmann — Erato recording' },
       { type: 'soundcloud', url: 'https://soundcloud.com/ecm-records/faure-impromptu-harp', label: 'Tara Minassian — conservatoire prize recording' },
     ],
   },
@@ -318,12 +263,6 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-zabel-lf-century', publisher: 'Century Music Publishing', editor: 'Reprint', year: 1960, description: 'Inexpensive reprint edition used extensively in harp studios.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/La_Fontaine_(Zabel,_Albert)', label: 'IMSLP — La Fontaine (Zabel)' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Albert_Zabel', label: 'Wikipedia — Albert Zabel' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=c3mLEtqyLKw', label: 'Marielle Nordmann — Zabel La Fontaine, recital' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=fD8Vhd7P3bQ', label: 'Elena Golovinskaya — student competition recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5n7oVwfNBjJ9aE7vaMV5Dc', label: 'Marielle Nordmann — French Harp Music (Erato)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/harp-music-zabel-fontaine', label: 'Paris Conservatoire student — prize-winning examination recording' },
     ],
   },
 
@@ -345,11 +284,6 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-kopetzki-ofa-edition49', publisher: 'Edition 49', editor: 'Original edition', year: 2002, description: 'Kopetzki\'s own publisher; the authoritative and only available edition.' },
     ],
     external_links: [
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=AZOGSbKLKrY', label: 'Martin Grubinger — solo snare drum recital, Vienna' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=XrWn2NNvP9Y', label: 'ARD Competition semifinal — snare drum round' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5hUq6OarfQAbsMrTjQJNBs', label: 'Martin Grubinger — Percussion Works (DG Archiv recording)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/kopetzki-one-for-all-drum', label: 'International Percussion Competition — finalist recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/274569832', label: 'Vanessa Tomlinson — solo recital film, Brisbane' },
     ],
   },
 
@@ -372,13 +306,7 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-brouwer-edn-editions-hortus', publisher: 'Editions Hortus', editor: 'Facsimile edition', year: 2000, description: 'Facsimile of the autograph manuscript; valuable for studying Brouwer\'s notational intentions.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/El_Decamer%C3%B3n_Negro_(Brouwer,_Leo)', label: 'IMSLP — El Decamerón Negro (Brouwer)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Leo_Brouwer', label: 'Wikipedia — Leo Brouwer' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=vhAkRrKPBtg', label: 'Sharon Isbin — Guitar Passions (recording)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=yfTgFY7M4UA', label: 'Xuefei Yang — BBC recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6dsPPwNyLAU7ZBbVrRxLZ2', label: 'Sharon Isbin — Guitar Passions (Warner Classics)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5gBSGkH7zXnK4EH27uEkTq', label: 'Xuefei Yang — China (EMI Classics)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/brouwer-decameron-negro', label: 'Alirio Díaz — veteran Venezuelan guitarist, Caracas recital' },
       { type: 'vimeo', url: 'https://vimeo.com/301457834', label: 'Pablo Sáinz Villegas — GFA International Competition, concert film' },
     ],
     movements: [
@@ -405,14 +333,7 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-piazzolla-hdt-henle', publisher: 'Henle Verlag', editor: 'Critical edition', year: 2017, description: 'New critical edition with performance notes; the current scholarly standard.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Histoire_du_Tango_(Piazzolla,_Astor)', label: 'IMSLP — Histoire du Tango (Piazzolla)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Histoire_du_Tango', label: 'Wikipedia — Histoire du Tango' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Wj3RNiHOjEM', label: 'Sharon Bezaly / Göran Söllscher — BIS recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=wZkBqPXYQkA', label: 'Emmanuel Pahud / Thomas Dunford — complete suite' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6EHEIQ5xzFN0k2jLYHCxCL', label: 'Sharon Bezaly / Göran Söllscher — BIS (Grammy-nominated)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3fBMJxHWqzD3NZH0bLDCiz', label: 'Emmanuel Pahud / Thomas Dunford — Warner Classics' },
-      { type: 'internet_archive', url: 'https://archive.org/details/PiazzollaHistoireDuTango', label: 'Piazzolla ensemble — Buenos Aires broadcast recording' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/piazzolla-histoire-tango', label: 'Julieta Laso / Jorge Alvárez — Argentine duo, recital recording' },
     ],
     movements: [
       { name: 'I. Bordel 1900' },
@@ -444,12 +365,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Double_Bass_Concerto,_Op.3_(Koussevitzky,_Serge)', label: 'IMSLP — Double Bass Concerto Op. 3 (Koussevitzky)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Double_Bass_Concerto_(Koussevitzky)', label: 'Wikipedia — Double Bass Concerto (Koussevitzky)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=jwB5bIj_A7I', label: 'Rinat Ibragimov / Royal Philharmonic Orchestra — BBC concert' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=4Tq3XTFPZ3U', label: 'Gary Karr / Harmon Lewis — celebrated studio recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3Fvb0RhOb8rNbQCHIAYHts', label: 'Gary Karr — Koussevitzky Concerto (Delos International)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0k6j3hRcEYl4bgHWMrdvLI', label: 'Nicki Selin Aydogan — BBC Young Musician double bass finalist' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Koussevitzky-BassConcerto-Karr', label: 'Gary Karr — historic Delos recording (definitive 20th-century recording)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/koussevitzky-bass-concerto', label: 'Xavier Foley — Young Concert Artists, Carnegie Hall debut' },
       { type: 'vimeo', url: 'https://vimeo.com/412875631', label: 'Maxim Vengerov (bass) — Tchaikovsky Competition masterclass excerpt' },
     ],
     movements: [
@@ -483,11 +398,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.2,_Op.61_(Schumann,_Robert)', label: 'IMSLP — Symphony No. 2 Op. 61 (Schumann)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._2_(Schumann)', label: 'Wikipedia — Schumann Symphony No. 2' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Cs-0wuQxzVU', label: 'Claudio Abbado / Berlin Philharmonic — live concert' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=GRWh5SFl2Ms', label: 'Paavo Järvi / Deutsche Kammerphilharmonie Bremen — recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2hBmqyMtRLp8kc88UCCFcU', label: 'Paavo Järvi / Deutsche Kammerphilharmonie — RCA Red Seal' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5cFuBPiCFqwxwqLUVLUOqM', label: 'Harnoncourt / Concertgebouw Orchestra — Teldec' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Schumann-Symphony2-Furtwangler', label: 'Wilhelm Furtwängler / Berlin Philharmonic — 1953 (historic)' },
     ],
     movements: [
       { name: 'I. Sostenuto assai — Allegro ma non troppo' },
@@ -514,14 +424,7 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-ravel-mmlo-eulenburg', publisher: 'Eulenburg', editor: 'Study score', year: 1965, description: 'Pocket study score widely used for analysis and conducting preparation.' },
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Ma_m%C3%A8re_l%27Oye_(Ravel,_Maurice)', label: 'IMSLP — Ma mère l\'Oye (Ravel)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Ma_m%C3%A8re_l%27Oye', label: 'Wikipedia — Ma mère l\'Oye (Ravel)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=_gpOrB8sPkg', label: 'Pierre Boulez / Berlin Philharmonic — DG recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=7G4X7ljRsMQ', label: 'Charles Dutoit / Orchestre Symphonique de Montréal — Decca' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5kxHCijMdGf7LFeFw9NbWT', label: 'Charles Dutoit / Orchestre Symphonique de Montréal — Decca (Gramophone Award)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0SyF4l89A9pX3mV7rFIBOM', label: 'Claudio Abbado / London Symphony Orchestra — DG' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Ravel-MaMereLoye-Ansermet', label: 'Ernest Ansermet / Orchestre de la Suisse Romande — Decca (historic)' },
-      { type: 'vimeo', url: 'https://vimeo.com/328754901', label: 'Gustavo Dudamel / Simón Bolívar Symphony — concert film' },
     ],
     movements: [
       { name: 'Prélude' },
@@ -554,11 +457,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Quintet,_Op.44_(Schumann,_Robert)', label: 'IMSLP — Piano Quintet Op. 44 (Schumann)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Quintet_(Schumann)', label: 'Wikipedia — Piano Quintet Op. 44 (Schumann)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=uxbYf1O6XMQ', label: 'Mitsuko Uchida / Takács Quartet — Decca recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8g8cA-mFNzA', label: 'Martha Argerich / Hagen Quartet — live concert' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2a8D6PEqAnbw6VhsYGpMKq', label: 'Mitsuko Uchida / Takács Quartet — Decca (Gramophone Award)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1b2IwkZV01J8DWJkNxlP3h', label: 'Martha Argerich / Hagen Quartet — live concert (DG)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Schumann-PianoQuintet-Cortot-Budapest', label: 'Alfred Cortot / Budapest String Quartet — 1935 (historic recording)' },
       { type: 'vimeo', url: 'https://vimeo.com/371245680', label: 'Yuja Wang / Emerson String Quartet — Verbier Festival film' },
     ],
     movements: [
@@ -587,10 +485,6 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-stout-tmd-alfred', publisher: 'Alfred Music', editor: 'Distributed edition', year: 1990, description: 'Widely distributed American edition used in conservatoires.' },
     ],
     external_links: [
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Oy4JqB1mkKU', label: 'Evelyn Glennie — Two Mexican Dances, live recital' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=IRFUz9JTnK0', label: 'Keiko Abe — marimba recital, Tokyo' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5VnAtGTgKL7UgsMxRBsiFM', label: 'Evelyn Glennie — Marimba Recital (RCA Red Seal)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/stout-two-mexican-dances', label: 'Ithaca College Marimba Ensemble — competition recording' },
       { type: 'vimeo', url: 'https://vimeo.com/389542110', label: 'World Marimba Competition finalist — Stout Two Mexican Dances' },
     ],
     movements: [
@@ -614,10 +508,6 @@ export const expansionPieces15: SeedPiece[] = [
       { id: 'e-abe-dcb-mallet', publisher: 'Mallet Works Music', editor: 'Original edition', year: 1992, description: 'Original publisher\'s edition; the authoritative performing text.' },
     ],
     external_links: [
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=VZ0v0xUt6vc', label: 'Keiko Abe — composer-performed recording, Tokyo' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=3K3MdLNGNTQ', label: 'Shoko Suga — marimba recital, NHK broadcast' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2bVMB5EgYG7MrQxEt8vTPU', label: 'Keiko Abe — Marimba Spiritual (Denon)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/keiko-abe-dream-cherry-blossoms', label: 'Svet Stoyanov — competition performance, World Marimba Competition' },
       { type: 'vimeo', url: 'https://vimeo.com/310857923', label: 'Sumire Yoshihara — Dream of the Cherry Blossoms, recital film' },
     ],
   },
@@ -642,12 +532,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Guitar_Concerto,_W501_(Villa-Lobos,_Heitor)', label: 'IMSLP — Guitar Concerto W.501 (Villa-Lobos)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Guitar_Concerto_(Villa-Lobos)', label: 'Wikipedia — Guitar Concerto (Villa-Lobos)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=JB7wDVDxnN0', label: 'Andrés Segovia — premiere-era recording (original dedicatee)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=nRUr01hO-dc', label: 'Julian Bream / André Previn / RCA Victor Symphony — historic recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0RNUwHFjY0D6OjSRvnBmzq', label: 'Sharon Isbin / Minnesota Orchestra — Grammy Award recording (Warner)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2jAGXkMjCVExrJBgLNK0SC', label: 'Julian Bream / André Previn / RCA Victor Symphony — RCA (historic)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/VillaLobos-GuitarConcerto-Segovia', label: 'Andrés Segovia — 1960s broadcast recording (composer\'s dedicatee)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/villalobos-guitar-concerto', label: 'Pablo Sáinz Villegas / Orquesta Nacional de España — live concert' },
     ],
     movements: [
       { name: 'I. Allegro preciso' },
@@ -679,11 +563,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.4_in_E-flat_major_(Bruckner,_Anton)', label: 'IMSLP — Symphony No. 4 "Romantic" (Bruckner)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._4_(Bruckner)', label: 'Wikipedia — Bruckner Symphony No. 4 "Romantic"' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=9vBBCYMcBEE', label: 'Carlos Kleiber / Concertgebouw Orchestra — legendary live concert' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=Q3FPD6oAl6c', label: 'Harnoncourt / Vienna Philharmonic — Teldec recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3B3Ou1tJoUVpovSVjMnDmV', label: 'Günter Wand / Berlin Philharmonic — RCA Red Seal recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/6rVz8Gx1ynJp5T0hWHMTh3', label: 'Harnoncourt / Vienna Philharmonic — Teldec (Gramophone Award)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Bruckner-Symphony4-Furtwangler', label: 'Wilhelm Furtwängler / Berlin Philharmonic — 1951 (historic)' },
       { type: 'soundcloud', url: 'https://soundcloud.com/berliner-philharmoniker/bruckner-symphony-4', label: 'Simon Rattle / Berlin Philharmonic — Digital Concert Hall' },
     ],
     movements: [
@@ -713,12 +592,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.8,_Op.88_(Dvo%C5%99%C3%A1k,_Anton%C3%ADn)', label: 'IMSLP — Symphony No. 8 Op. 88 (Dvořák)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._8_(Dvo%C5%99%C3%A1k)', label: 'Wikipedia — Dvořák Symphony No. 8' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=LBRFLEfhHW4', label: 'Carlos Kleiber / Vienna Philharmonic — famous live recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=8wOG6SaH2IM', label: 'Jiří Bělohlávek / Czech Philharmonic — Supraphon recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/72EtU2ynMiRVWHM8tXSEMy', label: 'Jiří Bělohlávek / Czech Philharmonic — Decca (definitive Czech recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3SqPJFVYJe4yoIpvv8uPCW', label: 'Paavo Järvi / Czech Philharmonic — Supraphon' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Dvorak-Symphony8-Kubelik', label: 'Rafael Kubelík / Bavarian Radio Symphony — DG (historic)' },
-      { type: 'vimeo', url: 'https://vimeo.com/481234512', label: 'Semyon Bychkov / Czech Philharmonic — concert film, Prague' },
     ],
     movements: [
       { name: 'I. Allegro con brio' },
@@ -748,10 +621,6 @@ export const expansionPieces15: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.6_(Mahler,_Gustav)', label: 'IMSLP — Symphony No. 6 "Tragic" (Mahler)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._6_(Mahler)', label: 'Wikipedia — Mahler Symphony No. 6 "Tragic"' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=4XbHLFkg_Mw', label: 'Claudio Abbado / Berlin Philharmonic — legendary recording' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=bX_IjvfvNEo', label: 'Andris Nelsons / Gewandhausorchester Leipzig — live concert' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2UHgvvEb9OpiJmMHibR4hP', label: 'Claudio Abbado / Berlin Philharmonic — DG (Gramophone Award recording)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1OdpAHpf3IVlULVfCfJV0Y', label: 'Andris Nelsons / Gewandhausorchester — DG (Grammy Award)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Mahler-Symphony6-Barbirolli', label: 'John Barbirolli / New Philharmonia Orchestra — 1967 (historic EMI)' },
       { type: 'vimeo', url: 'https://vimeo.com/558312907', label: 'Klaus Mäkelä / Oslo Philharmonic — concert film' },
     ],
     movements: [
@@ -782,13 +651,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Concierto_del_Sur_(Ponce,_Manuel)', label: 'IMSLP — Concierto del Sur (Ponce)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Concierto_del_Sur', label: 'Wikipedia — Concierto del Sur (Ponce)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=LrNPSmFNe7w', label: 'Andrés Segovia — premiere recording (original dedicatee)' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=HiEbAvpO8Xk', label: 'Narciso Yepes / Rafael Frühbeck de Burgos — Deutsche Grammophon' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5pkGKl8gvQ1TXlS8c4gH12', label: 'Narciso Yepes / Frühbeck de Burgos — DG recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1Pxq6n5QJDvO6Z15y9r1qL', label: 'Xuefei Yang / BBC Symphony — debut concerto recording (EMI)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/Ponce-ConciertoDelSur-Segovia', label: 'Andrés Segovia — 1950s broadcast recording (composer\'s dedicatee)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/ponce-concierto-del-sur', label: 'Pablo Sáinz Villegas — GFA Competition winner recording' },
-      { type: 'vimeo', url: 'https://vimeo.com/421654098', label: 'Thibaut Garcia — International Guitar Competition, Paris concert film' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },

--- a/src/data/seed-expansion-2.ts
+++ b/src/data/seed-expansion-2.ts
@@ -435,16 +435,6 @@ export const expansionPieces2: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/3_Chorals_(Franck,_C%C3%A9sar)",
-        "label": "IMSLP — Three Chorales"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Three_Chorals_(Franck)",
-        "label": "Wikipedia — Franck Three Chorales"
-      }
     ]
   },
   {
@@ -479,11 +469,6 @@ export const expansionPieces2: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Octet,_Op.20_(Mendelssohn,_Felix)",
-        "label": "IMSLP — editions available"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Octet_(Mendelssohn)",
@@ -789,11 +774,6 @@ export const expansionPieces2: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Adagio_for_Strings_(Barber,_Samuel)",
-        "label": "IMSLP — score available"
-      },
       {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=izQsgE0L450",

--- a/src/data/seed-expansion-3.ts
+++ b/src/data/seed-expansion-3.ts
@@ -40,6 +40,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Concerto_No._1_(Chopin)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=ZR9HayZcZ2o",
+        "label": "EuroArtsChannel — Evgeny Kissin: Chopin - Piano Concerto No. 1, Op 11 (Tel Aviv, 2011)"
       }
     ]
   },
@@ -82,6 +87,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Concerto_No._2_(Chopin)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=ucEoszfu9_E",
+        "label": "Peter Chen 2.0 — Yuja Wang: Chopin Piano Concerto No. 2 in F minor Op. 21 [HD]"
       }
     ]
   },
@@ -124,6 +134,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Concerto_(Schumann)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=cRNWaTJW-24",
+        "label": "DW Classical Music — Schumann: Piano Concerto | Martha Argerich, Riccardo Chailly & Gewandhausorchester Leipzig"
       }
     ]
   },
@@ -158,14 +173,14 @@ export const expansionPieces3: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Piano_Sonata_No.11,_K.331/300i_(Mozart,_Wolfgang_Amadeus)",
-        "label": "IMSLP"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Sonata_No._11_(Mozart)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=SQh1zztmpEk",
+        "label": "TzviErez — Mozart: ALLA TURCA from Sonata No. 11 in A major, K.331 | Tzvi Erez"
       }
     ]
   },
@@ -196,6 +211,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Violin_Concerto_No._1_(Prokofiev)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=ozvTHD63di8",
+        "label": "Prok Prok — Prokofiev Violin Concerto No. 1 in D Major, Op. 19 (Fischer)"
       }
     ]
   },
@@ -241,6 +261,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Symphony_No._3_(Beethoven)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=DWwppYEEdcI",
+        "label": "DW Classical Music — Beethoven: Symphony No. 3 Eroica | Michael Boder & ORF Vienna Radio Symphony Orchestra"
       }
     ]
   },
@@ -279,6 +304,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Symphony_No._7_(Beethoven)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Rd0HnxWm5CY",
+        "label": "DW Classical Music — Beethoven: Symphony No. 7 | Bernard Haitink & the Royal Concertgebouw Orchestra"
       }
     ]
   },
@@ -317,6 +347,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Symphony_No._9_(Beethoven)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=ChygZLpJDNE",
+        "label": "engchi93 — Beethoven Symphony No. 9 - Mvt. 4 - Barenboim/West-Eastern Divan Orchestra"
       }
     ]
   },
@@ -410,6 +445,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Ein_deutsches_Requiem",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=ZXU9vqVdudM",
+        "label": "hr-Sinfonieorchester – Frankfurt Radio Symphony — Brahms: Ein deutsches Requiem ∙ hr-Sinfonieorchester ∙ MDR-Rundfunkchor ∙ Solisten ∙ David Zinman"
       }
     ]
   },
@@ -450,6 +490,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Requiem_(Verdi)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Nlq9lJRElBk",
+        "label": "hr-Sinfonieorchester – Frankfurt Radio Symphony — Verdi: Messa da Requiem ∙ hr-Sinfonieorchester ∙ MDR Rundfunkchor ∙ Solisten ∙ Andrés Orozco-Estrada"
       }
     ]
   },
@@ -567,6 +612,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Scheherazade_(Rimsky-Korsakov)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=zY4w4_W30aQ",
+        "label": "SinfonicadeGalicia — Rimsky-Korsakov: Scheherazade op.35 - Leif Segerstam - Sinfónica de Galicia"
       }
     ]
   },
@@ -640,6 +690,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Bol%C3%A9ro",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Dh9bUD-hC0A",
+        "label": "Musiké XXI Music Education — MAURICE RAVEL - Bolero"
       }
     ]
   },
@@ -714,6 +769,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Pictures_at_an_Exhibition",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=XwJMpQiqCm4",
+        "label": "Oslo Philharmonic — Pictures at an Exhibition (complete) / Modest Mussorgsky / Semyon Bychkov / Oslo Philharmonic"
       }
     ]
   },
@@ -752,6 +812,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/The_Marriage_of_Figaro",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=pb1tlh9xn38",
+        "label": "GreatPerformers1 — MOZART - \"Le Nozze di Figaro\" Overture - BARENBOIM / East-West Divan"
       }
     ]
   },
@@ -782,6 +847,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Flute_Concerto_(Nielsen)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=C47qZY65HLs",
+        "label": "Mattia Carugno (tema) — Sébastian Jacot- Nielsen Flute Concerto FS 119"
       }
     ]
   },
@@ -810,14 +880,14 @@ export const expansionPieces3: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Concerto_for_Flute,_Harp_and_Orchestra,_K.299/297c_(Mozart,_Wolfgang_Amadeus)",
-        "label": "IMSLP"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Concerto_for_Flute,_Harp,_and_Orchestra_(Mozart)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=nheif2BuFz0",
+        "label": "Art Of Sound And Vision — Mozart Concerto for Flute  Harp and Orchestra in C major, K 299 - complete - LIVE"
       }
     ]
   },
@@ -850,9 +920,9 @@ export const expansionPieces3: SeedPiece[] = [
         "label": "IMSLP"
       },
       {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Fantasia_and_Fugue_in_G_minor,_BWV_542",
-        "label": "Wikipedia"
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=tgDE3klkmtQ",
+        "label": "Netherlands Bach Society — Bach - Fantasia and fugue in G minor BWV 542 - Van Doeselaar | Netherlands Bach Society"
       }
     ]
   },
@@ -892,9 +962,9 @@ export const expansionPieces3: SeedPiece[] = [
         "label": "IMSLP"
       },
       {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Estampes_(Debussy)",
-        "label": "Wikipedia"
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Gd5kUWDGyUs",
+        "label": "Ashish Xiangyi Kumar — Debussy: Estampes, L.100 (Perianes, Goerner)"
       }
     ]
   },
@@ -937,6 +1007,11 @@ export const expansionPieces3: SeedPiece[] = [
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Polonaise_in_A-flat_major,_Op._53_(Chopin)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=p_iI1J0bALE",
+        "label": "Rousseau — Chopin - Heroic Polonaise (Op. 53 in A Flat Major)"
       }
     ]
   },
@@ -964,14 +1039,14 @@ export const expansionPieces3: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Prelude_in_C-sharp_minor,_Op.3_No.2_(Rachmaninoff,_Sergei)",
-        "label": "IMSLP"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Prelude_in_C-sharp_minor_(Rachmaninoff)",
         "label": "Wikipedia"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=sCtixpIWBto",
+        "label": "Rousseau — Rachmaninoff - Prelude in C Sharp Minor (Op. 3 No. 2)"
       }
     ]
   }

--- a/src/data/seed-expansion-4.ts
+++ b/src/data/seed-expansion-4.ts
@@ -38,16 +38,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/3_Chorals_(Franck,_C%C3%A9sar)",
-        "label": "IMSLP — Franck 3 Chorals"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Trois_chorals",
-        "label": "Wikipedia — Trois Chorals"
-      }
     ]
   },
   {
@@ -88,11 +78,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Organ_Concerto_in_B-flat_major,_Op.4_No.6,_HWV_294_(Handel,_George_Frideric)",
-        "label": "IMSLP — Handel Op. 4 No. 6"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Organ_concertos,_Op._4_(Handel)",
@@ -180,11 +165,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Double_Bass_Concerto_No.2_(Bottesini,_Giovanni)",
-        "label": "IMSLP — Bottesini Concerto No. 2"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Giovanni_Bottesini",
@@ -333,11 +313,6 @@ export const expansionPieces4: SeedPiece[] = [
         "url": "https://imslp.org/wiki/Piano_Quintet_in_A_major,_D.667_(Schubert,_Franz)",
         "label": "IMSLP — Schubert Trout Quintet"
       },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Piano_Quintet_in_A_major_(Schubert)",
-        "label": "Wikipedia — Trout Quintet"
-      }
     ]
   },
   {
@@ -422,11 +397,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/String_Sextet_No.1_in_B-flat_major,_Op.18_(Brahms,_Johannes)",
-        "label": "IMSLP — Brahms String Sextet No. 1"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/String_Sextet_No._1_(Brahms)",
         "label": "Wikipedia — Brahms String Sextet No. 1"
@@ -476,16 +446,6 @@ export const expansionPieces4: SeedPiece[] = [
         "url": "https://imslp.org/wiki/Guitar_Concerto_No.1,_Op.30_(Giuliani,_Mauro)",
         "label": "IMSLP — Giuliani Guitar Concerto No. 1"
       },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=OzRjb0FLLGQ",
-        "label": "Giuliani: Guitar Concerto No. 1 — Pepe Romero"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Guitar_Concerto_No._1_(Giuliani)",
-        "label": "Wikipedia — Giuliani Guitar Concerto No. 1"
-      }
     ]
   },
   {
@@ -525,21 +485,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/12_%C3%89tudes_(Villa-Lobos,_Heitor)",
-        "label": "IMSLP — Villa-Lobos 12 Études"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=6mFpGwFUNFM",
-        "label": "Villa-Lobos: 12 Etudes — Göran Söllscher"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/12_%C3%89tudes_(Villa-Lobos)",
-        "label": "Wikipedia — Villa-Lobos 12 Études"
-      }
     ]
   },
   {
@@ -585,16 +530,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Introduction_and_Allegro_(Ravel,_Maurice)",
-        "label": "IMSLP — Ravel Introduction and Allegro"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=3tcrhHy5hPM",
-        "label": "Ravel: Introduction and Allegro — Marielle Nordmann"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Introduction_and_Allegro_(Ravel)",
         "label": "Wikipedia — Introduction and Allegro"
@@ -631,16 +566,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Rebonds_(Xenakis,_Iannis)",
-        "label": "IMSLP — Xenakis Rebonds"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=JEDzBnFt5cA",
-        "label": "Xenakis: Rebonds b — Sébastien Giot"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Rebonds_(Xenakis)",
@@ -687,16 +612,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/String_Quartet_No.8,_Op.110_(Shostakovich,_Dmitri)",
-        "label": "IMSLP — Shostakovich String Quartet No. 8"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=SjUBHikYbsE",
-        "label": "Shostakovich: String Quartet No. 8 — Emerson String Quartet"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/String_Quartet_No._8_(Shostakovich)",
@@ -745,11 +660,6 @@ export const expansionPieces4: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Also_sprach_Zarathustra,_Op.30_(Strauss,_Richard)",
         "label": "IMSLP — Also sprach Zarathustra"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=dOp9Y9OQLKE",
-        "label": "Strauss: Also sprach Zarathustra — Karajan / Berlin Phil"
       },
       {
         "type": "wikipedia",
@@ -802,11 +712,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Mahler Symphony No. 5"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=_aFdl-A8s7w",
-        "label": "Mahler Symphony No. 5 Adagietto — Bernstein / Vienna Phil"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Symphony_No._5_(Mahler)",
         "label": "Wikipedia — Mahler Symphony No. 5"
@@ -850,16 +755,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Praeludium_in_D_minor,_BuxWV_140_(Buxtehude,_Dieterich)",
-        "label": "IMSLP — Buxtehude BuxWV 140"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=6eFpJkK-lKE",
-        "label": "Buxtehude: Prelude and Fugue in D minor BuxWV 140"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Dieterich_Buxtehude",
@@ -905,16 +800,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Double_Bass_Concerto,_Op.3_(Koussevitzky,_Sergei)",
-        "label": "IMSLP — Koussevitzky Double Bass Concerto"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=WClFhIBfUeE",
-        "label": "Koussevitzky: Double Bass Concerto — Gary Karr"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Double_Bass_Concerto_(Koussevitzky)",
@@ -962,16 +847,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/String_Quartet_No.14_in_D_minor,_D.810_(Schubert,_Franz)",
-        "label": "IMSLP — Schubert Death and the Maiden Quartet"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=LOfSEMXWAXk",
-        "label": "Schubert: Death and the Maiden — Alban Berg Quartet"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/String_Quartet_No._14_(Schubert)",
         "label": "Wikipedia — Death and the Maiden Quartet"
@@ -1013,16 +888,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Symphony_No.6_in_F_major,_Op.68_(Beethoven,_Ludwig_van)",
-        "label": "IMSLP — Beethoven Symphony No. 6"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=iLG-ANQtaKg",
-        "label": "Beethoven: Symphony No. 6 — Karajan / Berlin Philharmonic (1984)"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Symphony_No._6_(Beethoven)",
@@ -1066,16 +931,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Symphony_No.1_in_C_minor,_Op.68_(Brahms,_Johannes)",
-        "label": "IMSLP — Brahms Symphony No. 1"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=_kHNeCTHo3A",
-        "label": "Brahms: Symphony No. 1 — Karajan / Berlin Philharmonic (1987)"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Symphony_No._1_(Brahms)",
         "label": "Wikipedia — Symphony No. 1 (Brahms)"
@@ -1110,21 +965,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Pi%C3%A8ce_h%C3%A9ro%C3%AFque_(Franck,_C%C3%A9sar)",
-        "label": "IMSLP — Franck Pièce héroïque"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=4JBiSINiMjE",
-        "label": "Franck: Pièce héroïque — Marie-Claire Alain"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Pi%C3%A8ce_h%C3%A9ro%C3%AFque",
-        "label": "Wikipedia — Pièce héroïque"
-      }
     ]
   },
   {
@@ -1155,21 +995,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Harp_Concerto_in_C_major_(Boieldieu,_Fran%C3%A7ois-Adrien)",
-        "label": "IMSLP — Boieldieu Harp Concerto"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=qd5pSGBVc1M",
-        "label": "Boieldieu: Harp Concerto — Marielle Nordmann"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Harp_Concerto_(Boieldieu)",
-        "label": "Wikipedia — Boieldieu Harp Concerto"
-      }
     ]
   },
   {
@@ -1205,11 +1030,6 @@ export const expansionPieces4: SeedPiece[] = [
         "url": "https://en.wikipedia.org/wiki/Third_Construction",
         "label": "Wikipedia — Third Construction"
       },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=pNxVZN_OQGA",
-        "label": "Cage: Third Construction — Nexus Percussion"
-      }
     ]
   },
   {
@@ -1248,16 +1068,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Lute_Suite_in_C_minor,_BWV_997_(Bach,_Johann_Sebastian)",
-        "label": "IMSLP — Bach Lute Suite BWV 997"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=qVvpjfEMHH0",
-        "label": "Bach: Lute Suite BWV 997 — Julian Bream (guitar)"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Lute_Suite_in_C_minor,_BWV_997",
         "label": "Wikipedia — Lute Suite BWV 997"
@@ -1292,21 +1102,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Double_Bass_Concerto_No.2_in_E_major_(Dittersdorf,_Karl_Ditters_von)",
-        "label": "IMSLP — Dittersdorf Double Bass Concerto No. 2"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=8L8M1k9biKc",
-        "label": "Dittersdorf: Double Bass Concerto No. 2 — Gary Karr"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Double_Bass_Concertos_(Dittersdorf)",
-        "label": "Wikipedia — Dittersdorf Double Bass Concertos"
-      }
     ]
   },
   {
@@ -1345,16 +1140,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Piano_Trio_No.7_in_B-flat_major,_Op.97_(Beethoven,_Ludwig_van)",
-        "label": "IMSLP — Beethoven Archduke Trio"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=GdFGPF-BQBE",
-        "label": "Beethoven: Archduke Trio — Beaux Arts Trio"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Trio_No._7_(Beethoven)",
         "label": "Wikipedia — Beethoven Archduke Trio"
@@ -1389,16 +1174,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Symphony_No.2_in_D_major,_Op.43_(Sibelius,_Jean)",
-        "label": "IMSLP — Sibelius Symphony No. 2"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=qPR9RbMjpU0",
-        "label": "Sibelius: Symphony No. 2 — Osmo Vänskä / Minnesota Orchestra"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Symphony_No._2_(Sibelius)",
@@ -1442,16 +1217,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Piano_Quintet_in_E-flat_major,_Op.44_(Schumann,_Robert)",
-        "label": "IMSLP — Schumann Piano Quintet"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=KCFSJXcBBpM",
-        "label": "Schumann: Piano Quintet — Martha Argerich and Friends"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Quintet_(Schumann)",
         "label": "Wikipedia — Piano Quintet (Schumann)"
@@ -1494,11 +1259,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Symphonie_fantastique,_Op.14_(Berlioz,_Hector)",
-        "label": "IMSLP — Berlioz: Symphonie fantastique Op. 14"
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=5HgqPpjIH5c",
         "label": "YouTube — Colin Davis, London Symphony Orchestra"
@@ -1508,11 +1268,6 @@ export const expansionPieces4: SeedPiece[] = [
         "url": "https://en.wikipedia.org/wiki/Symphonie_fantastique",
         "label": "Wikipedia — Symphonie fantastique"
       },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/189444440",
-        "label": "Vimeo — Gustavo Dudamel, Orchestre de Paris"
-      }
     ]
   },
   {
@@ -1556,11 +1311,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Saint-Saëns: Symphony No. 3 Op. 78"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=y4DZDeVVxg0",
-        "label": "YouTube — Charles Dutoit, Orchestre de Paris"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Symphony_No._3_(Saint-Sa%C3%ABns)",
         "label": "Wikipedia — Saint-Saëns Symphony No. 3"
@@ -1602,21 +1352,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Prelude_and_Fugue_on_the_name_BACH,_S.260_(Liszt,_Franz)",
-        "label": "IMSLP — Liszt: Prelude and Fugue on BACH S. 260"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=Z3WQOQM-14s",
-        "label": "YouTube — Thierry Escaich, Cathédrale Saint-Étienne"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Prelude_and_Fugue_on_the_name_BACH_(Liszt)",
-        "label": "Wikipedia — Liszt Prelude and Fugue on BACH"
-      }
     ]
   },
   {
@@ -1648,25 +1383,10 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Harp_Sonata,_Op.52_(Ginastera,_Alberto)",
-        "label": "IMSLP — Ginastera: Harp Sonata Op. 52"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=zVLSjU3XRMU",
-        "label": "YouTube — Xavier de Maistre, harp"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Alberto_Ginastera",
         "label": "Wikipedia — Alberto Ginastera"
       },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/228473011",
-        "label": "Vimeo — Gwyneth Wentink, live recital"
-      }
     ]
   },
   {
@@ -1710,11 +1430,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Sor: Fantaisie Op. 7"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=3yRA6oSmC8M",
-        "label": "YouTube — Pepe Romero, guitar"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Fernando_Sor",
         "label": "Wikipedia — Fernando Sor"
@@ -1753,11 +1468,6 @@ export const expansionPieces4: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Gran_Duo_Concertante_(Bottesini,_Giovanni)",
         "label": "IMSLP — Bottesini: Gran Duo Concertante"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=YHcDMSTlPuA",
-        "label": "YouTube — Francois Rabbath & Itzhak Perlman"
       },
       {
         "type": "wikipedia",
@@ -1807,11 +1517,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Fauré: Piano Quartet No. 1 Op. 15"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=K_oGcHJbTsE",
-        "label": "YouTube — Domus Piano Quartet"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Quartet_No._1_(Faur%C3%A9)",
         "label": "Wikipedia — Fauré Piano Quartet No. 1"
@@ -1859,20 +1564,10 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Schumann: Piano Quartet Op. 47"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=gBnl0GtIPeo",
-        "label": "YouTube — Martha Argerich & Gidon Kremer"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Quartet_(Schumann)",
         "label": "Wikipedia — Piano Quartet (Schumann)"
       },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/107490028",
-        "label": "Vimeo — Quatuor Ébène with Nelson Goerner"
-      }
     ]
   },
   {
@@ -1914,11 +1609,6 @@ export const expansionPieces4: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Water_Music_(Handel,_George_Frideric)",
         "label": "IMSLP — Handel: Water Music HWV 348–350"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=Izz6OmFiKWk",
-        "label": "YouTube — Nikolaus Harnoncourt, Concentus Musicus Wien"
       },
       {
         "type": "wikipedia",
@@ -1967,16 +1657,6 @@ export const expansionPieces4: SeedPiece[] = [
         "url": "https://imslp.org/wiki/Flute_Concerto_in_G_minor,_RV_439_(Vivaldi,_Antonio)",
         "label": "IMSLP — Vivaldi: Flute Concerto 'La notte' RV 439"
       },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=PQJWK7JVX1g",
-        "label": "YouTube — Jean-Pierre Rampal, I Solisti Veneti"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Flute_Concerto_in_G_minor,_RV_439_(Vivaldi)",
-        "label": "Wikipedia — Vivaldi Flute Concerto RV 439"
-      }
     ]
   },
   {
@@ -2007,16 +1687,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Enigma_Variations,_Op.36_(Elgar,_Edward)",
-        "label": "IMSLP — Elgar: Enigma Variations Op. 36"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=Zi7wJQXqHnA",
-        "label": "YouTube — BBC Symphony Orchestra, Andrew Davis"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Enigma_Variations",
@@ -2052,21 +1722,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Fantasia_and_Fugue_on_B-A-C-H,_Op.46_(Reger,_Max)",
-        "label": "IMSLP — Reger: Fantasia and Fugue on B-A-C-H Op. 46"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=NVHbPNz9Kk4",
-        "label": "YouTube — Hans Fagius, organ"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Fantasia_and_Fugue_on_B-A-C-H_(Reger)",
-        "label": "Wikipedia — Reger Fantasia and Fugue on B-A-C-H"
-      }
     ]
   },
   {
@@ -2101,11 +1756,6 @@ export const expansionPieces4: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Organ_Symphony_No.3,_Op.28_(Vierne,_Louis)",
         "label": "IMSLP — Vierne: Organ Symphony No. 3 Op. 28"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=OJzCFKdTdYQ",
-        "label": "YouTube — Ben van Oosten, Cavaillé-Coll organ"
       },
       {
         "type": "wikipedia",
@@ -2143,16 +1793,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Chor%C3%B4s_No.1_(Villa-Lobos,_Heitor)",
-        "label": "IMSLP — Villa-Lobos: Choros No. 1"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=fR6G7f8XPZE",
-        "label": "YouTube — Julian Bream, guitar"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Heitor_Villa-Lobos",
         "label": "Wikipedia — Heitor Villa-Lobos"
@@ -2188,11 +1828,6 @@ export const expansionPieces4: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=Qq_9nLLOyFk",
-        "label": "YouTube — Ana Vidovic, complete 20 études"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Leo_Brouwer",
         "label": "Wikipedia — Leo Brouwer"
@@ -2227,11 +1862,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=TqHmO1NSKDE",
-        "label": "YouTube — Mitchell Peters, Los Angeles Philharmonic"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/William_Kraft",
@@ -2280,11 +1910,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Schubert: Octet D. 803"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=gv0SNQS3DKQ",
-        "label": "YouTube — Vienna Octet"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Octet_(Schubert)",
         "label": "Wikipedia — Schubert Octet"
@@ -2323,11 +1948,6 @@ export const expansionPieces4: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/String_Quartet_No.1,_Op.51_No.1_(Brahms,_Johannes)",
         "label": "IMSLP — Brahms: String Quartet No. 1 Op. 51"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=A7i7T2nRF7Y",
-        "label": "YouTube — Emerson String Quartet"
       },
       {
         "type": "wikipedia",
@@ -2370,11 +1990,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Saint-Saëns: Cello Concerto No. 2 Op. 119"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=UqCInWPFoTs",
-        "label": "YouTube — Truls Mørk, cello"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Cello_Concerto_No._2_(Saint-Sa%C3%ABns)",
         "label": "Wikipedia — Saint-Saëns Cello Concerto No. 2"
@@ -2413,11 +2028,6 @@ export const expansionPieces4: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Elegy_(Bottesini,_Giovanni)",
         "label": "IMSLP — Bottesini: Elegy in D major"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=7jTIbhHqP9M",
-        "label": "YouTube — Gary Karr, double bass"
       },
       {
         "type": "wikipedia",
@@ -2461,21 +2071,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Trio_Sonata_No.1_in_E-flat_major,_BWV_525_(Bach,_Johann_Sebastian)",
-        "label": "IMSLP — Bach: Trio Sonata No. 1 BWV 525"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=5rSP2GcBoMo",
-        "label": "YouTube — Marie-Claire Alain, organ"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Trio_Sonatas,_BWV_525%E2%80%93530",
-        "label": "Wikipedia — Trio Sonatas BWV 525–530"
-      }
     ]
   },
   {
@@ -2513,21 +2108,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Organ_Symphony_No.5,_Op.42/1_(Widor,_Charles-Marie)",
-        "label": "IMSLP — Widor: Organ Symphony No. 5 Op. 42/1"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=Pn4b5HaVFo8",
-        "label": "YouTube — Pierre Cochereau, organ (Notre-Dame de Paris)"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Organ_Symphony_No._5_(Widor)",
-        "label": "Wikipedia — Organ Symphony No. 5 (Widor)"
-      }
     ]
   },
   {
@@ -2558,11 +2138,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=9KRNSHGdOZM",
-        "label": "YouTube — Pepe Romero, guitar; Neville Marriner, ASMF"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Concierto_de_Aranjuez",
@@ -2611,11 +2186,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Berlioz: Harold en Italie Op. 16"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=lS8GBTdVYSE",
-        "label": "YouTube — Yuri Bashmet, viola; Seiji Ozawa, Boston Symphony"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Harold_en_Italie",
         "label": "Wikipedia — Harold en Italie"
@@ -2650,21 +2220,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Danses_(Debussy,_Claude)",
-        "label": "IMSLP — Debussy: Danses (Danse sacrée et danse profane)"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=WFfbXvJXiGQ",
-        "label": "YouTube — Marielle Nordmann, harp; Jean-Pierre Rampal"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Danses_(Debussy)",
-        "label": "Wikipedia — Danses (Debussy)"
-      }
     ]
   },
   {
@@ -2706,11 +2261,6 @@ export const expansionPieces4: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Piano_Concerto_No.1,_Op.23_(Tchaikovsky,_Pyotr)",
         "label": "IMSLP — Tchaikovsky: Piano Concerto No. 1 Op. 23"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=TEB4MiHtxA4",
-        "label": "YouTube — Van Cliburn, piano; Kiril Kondrashin (RCA Victor)"
       },
       {
         "type": "wikipedia",
@@ -2760,11 +2310,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Brahms: Piano Trio No. 1 Op. 8"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=LiYNMjl9QoA",
-        "label": "YouTube — Heifetz, Rubinstein, Piatigorsky (RCA Victor)"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Trio_No._1_(Brahms)",
         "label": "Wikipedia — Piano Trio No. 1 (Brahms)"
@@ -2810,11 +2355,6 @@ export const expansionPieces4: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Piano_Quartet_No.2,_Op.45_(Fauré,_Gabriel)",
         "label": "IMSLP — Fauré: Piano Quartet No. 2 Op. 45"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=E6cZ2cBmDls",
-        "label": "YouTube — Quatuor Ébène with Pierre-Laurent Aimard"
       },
       {
         "type": "wikipedia",
@@ -2864,11 +2404,6 @@ export const expansionPieces4: SeedPiece[] = [
         "label": "IMSLP — Hasselmans: La Source Op. 44"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=fCRMjoNFGSQ",
-        "label": "YouTube — Marielle Nordmann, harp"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Alphonse_Hasselmans",
         "label": "Wikipedia — Alphonse Hasselmans"
@@ -2903,11 +2438,6 @@ export const expansionPieces4: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=T3DNMtSaP0s",
-        "label": "YouTube — Paula Robison, flute"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Density_21.5",

--- a/src/data/seed-expansion-5.ts
+++ b/src/data/seed-expansion-5.ts
@@ -39,16 +39,6 @@ export const expansionPieces5: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Pi%C3%A8ces_de_fantaisie,_Op.54_(Vierne,_Louis)",
-        "label": "IMSLP — Vierne: Pièces de fantaisie Op. 54"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=z4RFOEh2iFU",
-        "label": "YouTube — Marie-Claire Alain, Notre-Dame de Paris"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Pi%C3%A8ces_de_fantaisie",
         "label": "Wikipedia — Pièces de fantaisie (Vierne)"
@@ -92,16 +82,6 @@ export const expansionPieces5: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Nocturnal_after_John_Dowland,_Op.70_(Britten,_Benjamin)",
-        "label": "IMSLP — Britten: Nocturnal Op. 70"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=mG5rOtMXaas",
-        "label": "YouTube — Julian Bream, 1966 recording"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Nocturnal_after_John_Dowland",
@@ -153,16 +133,6 @@ export const expansionPieces5: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Danses_sacr%C3%A9e_et_profane_(Debussy,_Claude)",
-        "label": "IMSLP — Debussy: Danses sacrée et profane"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=G4LPq2BbOIg",
-        "label": "YouTube — Fabrice Pierre, harp"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Danses_sacr%C3%A9e_et_profane",
         "label": "Wikipedia — Danses sacrée et profane"
@@ -213,11 +183,6 @@ export const expansionPieces5: SeedPiece[] = [
         "label": "IMSLP — Dragonetti: Double Bass Concerto in A"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=ckIBuCyMhZ8",
-        "label": "YouTube — Chi-chi Nwanoku, double bass"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Domenico_Dragonetti",
         "label": "Wikipedia — Domenico Dragonetti"
@@ -258,11 +223,6 @@ export const expansionPieces5: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Ionisation_(Var%C3%A8se,_Edgard)",
         "label": "IMSLP — Varèse: Ionisation"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=bGBNQBaLPpI",
-        "label": "YouTube — Ensemble InterContemporain, Boulez"
       },
       {
         "type": "wikipedia",
@@ -310,25 +270,10 @@ export const expansionPieces5: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Piano_Quintet_in_G_minor,_Op.57_(Shostakovich,_Dmitri)",
-        "label": "IMSLP — Shostakovich: Piano Quintet Op. 57"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=nCgSKE_qsDc",
-        "label": "YouTube — Sviatoslav Richter & Borodin Quartet"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Quintet_(Shostakovich)",
         "label": "Wikipedia — Shostakovich Piano Quintet"
       },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/297082441",
-        "label": "Vimeo — Takács Quartet & Garrick Ohlsson"
-      }
     ]
   },
   {
@@ -374,20 +319,10 @@ export const expansionPieces5: SeedPiece[] = [
         "label": "IMSLP — Beethoven: String Quartet Op. 131"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=UBnQmMhGNK8",
-        "label": "YouTube — Quartetto Italiano"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/String_Quartet_No._14_(Beethoven)",
         "label": "Wikipedia — Beethoven String Quartet No. 14"
       },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/214694281",
-        "label": "Vimeo — Takács Quartet live performance"
-      }
     ]
   },
   {
@@ -431,11 +366,6 @@ export const expansionPieces5: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Academic_Festival_Overture,_Op.80_(Brahms,_Johannes)",
         "label": "IMSLP — Brahms: Academic Festival Overture Op. 80"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=Y9RpRgMDCTY",
-        "label": "YouTube — Carlos Kleiber, Concertgebouw"
       },
       {
         "type": "wikipedia",
@@ -487,11 +417,6 @@ export const expansionPieces5: SeedPiece[] = [
         "label": "IMSLP — Sibelius: Finlandia Op. 26"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=qMxs-USCBEA",
-        "label": "YouTube — Paavo Berglund, Helsinki Philharmonic"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Finlandia",
         "label": "Wikipedia — Finlandia (Sibelius)"
@@ -541,25 +466,10 @@ export const expansionPieces5: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Appalachian_Spring_(Copland,_Aaron)",
-        "label": "IMSLP — Copland: Appalachian Spring"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=_tYNrAN_S3Q",
-        "label": "YouTube — Leonard Bernstein, New York Philharmonic"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Appalachian_Spring",
         "label": "Wikipedia — Appalachian Spring"
       },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/142734491",
-        "label": "Vimeo — Martha Graham Dance Company, original ballet"
-      }
     ]
   }
 ];

--- a/src/data/seed-expansion-6.ts
+++ b/src/data/seed-expansion-6.ts
@@ -39,16 +39,6 @@ export const expansionPieces6: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Variations_on_a_No%C3%ABl,_Op.20_(Dupr%C3%A9,_Marcel)",
-        "label": "IMSLP — Dupré: Variations on a Noël Op. 20"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=4_dBMtBIKFo",
-        "label": "YouTube — Pierre Cochereau, Notre-Dame de Paris"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Marcel_Dupr%C3%A9",
         "label": "Wikipedia — Marcel Dupré"
@@ -93,19 +83,14 @@ export const expansionPieces6: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Images,_Op.29_(Tournier,_Marcel)",
-        "label": "IMSLP — Tournier: Images Op. 29"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=tENQEyHbmEE",
-        "label": "YouTube — Isabelle Moretti, harp"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Marcel_Tournier",
         "label": "Wikipedia — Marcel Tournier"
+      },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=w_0kLfvY1L0",
+        "label": "Emmanuel Ceysson — Marcel Tournier - Images Suite no.1 Op.29 with string quartet - I. Clair de lune sur l'étang du parc"
       }
     ]
   },
@@ -142,25 +127,10 @@ export const expansionPieces6: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Drumming_(Reich,_Steve)",
-        "label": "IMSLP — Reich: Drumming"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=FGXbPBZbFE4",
-        "label": "YouTube — Steve Reich and Musicians"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Drumming_(Reich)",
         "label": "Wikipedia — Drumming (Reich)"
       },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/57688089",
-        "label": "Vimeo — Percussion ensemble, live performance"
-      }
     ]
   },
   {
@@ -200,26 +170,6 @@ export const expansionPieces6: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/La_Catedral_(Barrios_Mangor%C3%A9,_Agust%C3%ADn)",
-        "label": "IMSLP — Barrios: La Catedral"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=4_GZ5Z5g5_c",
-        "label": "YouTube — John Williams, guitar"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/La_Catedral_(Barrios)",
-        "label": "Wikipedia — La Catedral (Barrios)"
-      },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/106297952",
-        "label": "Vimeo — Ana Vidovic, live performance"
-      }
     ]
   },
   {
@@ -260,16 +210,6 @@ export const expansionPieces6: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Double_Bass_Concerto_No.1_in_E_major_(Dittersdorf,_Carl_Ditters_von)",
-        "label": "IMSLP — Dittersdorf: Double Bass Concerto No. 1"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=lhivBBGSvXI",
-        "label": "YouTube — Gary Karr, double bass"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Carl_Ditters_von_Dittersdorf",
@@ -321,20 +261,10 @@ export const expansionPieces6: SeedPiece[] = [
         "label": "IMSLP — Dvořák: Piano Quintet Op. 81"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=BFkAhcHVGEo",
-        "label": "YouTube — Emanuel Ax & Cleveland Quartet"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Quintet_No._2_(Dvo%C5%99%C3%A1k)",
         "label": "Wikipedia — Dvořák Piano Quintet No. 2"
       },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/329184002",
-        "label": "Vimeo — Imogen Cooper & Belcea Quartet"
-      }
     ]
   },
   {
@@ -378,11 +308,6 @@ export const expansionPieces6: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Symphony_No.4,_Op.60_(Beethoven,_Ludwig_van)",
         "label": "IMSLP — Beethoven: Symphony No. 4 Op. 60"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=ZZUOM8PJM5Q",
-        "label": "YouTube — Carlos Kleiber, Bavarian State Orchestra"
       },
       {
         "type": "wikipedia",
@@ -488,16 +413,6 @@ export const expansionPieces6: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/String_Quintet_in_C_major,_D.956_(Schubert,_Franz)",
-        "label": "IMSLP — Schubert: String Quintet D. 956"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=z8LQ7y_HyMM",
-        "label": "YouTube — Alban Berg Quartet & Heinrich Schiff"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/String_Quintet_(Schubert)",
         "label": "Wikipedia — Schubert String Quintet"
@@ -550,11 +465,6 @@ export const expansionPieces6: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Prelude_and_Fugue_in_E_minor,_BWV_548_(Bach,_Johann_Sebastian)",
         "label": "IMSLP — Bach: Prelude and Fugue BWV 548"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=O6gBjxDkFqI",
-        "label": "YouTube — Marie-Claire Alain, organ"
       },
       {
         "type": "wikipedia",

--- a/src/data/seed-expansion-7.ts
+++ b/src/data/seed-expansion-7.ts
@@ -39,16 +39,6 @@ export const expansionPieces7: SeedPiece[] = [
     ],
     "external_links": [
       {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Grand_Sonata,_Op.22_(Sor,_Fernando)",
-        "label": "IMSLP — Sor: Grand Sonata Op. 22"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=GqS3CW_KXNI",
-        "label": "YouTube — Julian Bream, guitar"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Fernando_Sor",
         "label": "Wikipedia — Fernando Sor"
@@ -99,11 +89,6 @@ export const expansionPieces7: SeedPiece[] = [
         "label": "IMSLP — Bottesini: Double Bass Concerto No. 1"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=rXKQM7aLBfU",
-        "label": "YouTube — Franco Petracchi, double bass"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Giovanni_Bottesini",
         "label": "Wikipedia — Giovanni Bottesini"
@@ -147,21 +132,6 @@ export const expansionPieces7: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/L%27Apparition_de_l%27%C3%89glise_%C3%A9ternelle_(Messiaen,_Olivier)",
-        "label": "IMSLP — Messiaen: L'Apparition de l'Église éternelle"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=eC3T6jF8Kp8",
-        "label": "YouTube — Olivier Latry, Notre-Dame de Paris"
-      },
-      {
-        "type": "wikipedia",
-        "url": "https://en.wikipedia.org/wiki/L%27Apparition_de_l%27%C3%89glise_%C3%A9ternelle",
-        "label": "Wikipedia — L'Apparition de l'Église éternelle"
-      }
     ]
   },
   {
@@ -194,16 +164,6 @@ export const expansionPieces7: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Rhapsody,_Op.10_(Grandjany,_Marcel)",
-        "label": "IMSLP — Grandjany: Rhapsody Op. 10"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=Qx5HQl7vMHQ",
-        "label": "YouTube — Yolanda Kondonassis, harp"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Marcel_Grandjany",
@@ -241,16 +201,6 @@ export const expansionPieces7: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Psappha_(Xenakis,_Iannis)",
-        "label": "IMSLP — Xenakis: Psappha"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=x2LgBKS1Wco",
-        "label": "YouTube — Sylvio Gualda, percussion"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Psappha_(Xenakis)",
@@ -295,21 +245,6 @@ export const expansionPieces7: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Variations_on_a_Theme_by_Haydn,_Op.56a_(Brahms,_Johannes)",
-        "label": "IMSLP — Brahms: Variations on a Theme by Haydn Op. 56a"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=VpVS4bvLSnM",
-        "label": "YouTube — Carlos Kleiber, Vienna Philharmonic"
-      },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/143517422",
-        "label": "Vimeo — Berlin Philharmonic, live performance"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Variations_on_a_Theme_by_Haydn",
@@ -356,21 +291,6 @@ export const expansionPieces7: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Piano_Trio_No.1_in_B-flat_major,_D.898_(Schubert,_Franz)",
-        "label": "IMSLP — Schubert: Piano Trio D. 898"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=XYy3pS8_fTU",
-        "label": "YouTube — Beaux Arts Trio"
-      },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/254818430",
-        "label": "Vimeo — Florestan Trio, live performance"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Trio_No._1_(Schubert)",
@@ -419,11 +339,6 @@ export const expansionPieces7: SeedPiece[] = [
         "type": "imslp",
         "url": "https://imslp.org/wiki/Symphony_No.101_in_D_major,_Hob.I:101_(Haydn,_Joseph)",
         "label": "IMSLP — Haydn: Symphony No. 101 'The Clock'"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=1Q9NglLBB6A",
-        "label": "YouTube — Leonard Bernstein, Vienna Philharmonic"
       },
       {
         "type": "vimeo",
@@ -480,16 +395,6 @@ export const expansionPieces7: SeedPiece[] = [
         "label": "IMSLP — Dvořák: String Quartet Op. 96 'American'"
       },
       {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=Hpz3dap2ZBc",
-        "label": "YouTube — Emerson String Quartet"
-      },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/301452178",
-        "label": "Vimeo — Belcea Quartet, live performance"
-      },
-      {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/String_Quartet_No._12_(Dvo%C5%99%C3%A1k)",
         "label": "Wikipedia — Dvořák String Quartet No. 12"
@@ -535,21 +440,6 @@ export const expansionPieces7: SeedPiece[] = [
       }
     ],
     "external_links": [
-      {
-        "type": "imslp",
-        "url": "https://imslp.org/wiki/Piano_Trio_No.2,_Op.67_(Shostakovich,_Dmitri)",
-        "label": "IMSLP — Shostakovich: Piano Trio No. 2 Op. 67"
-      },
-      {
-        "type": "youtube",
-        "url": "https://www.youtube.com/watch?v=SH3nSHr4_KE",
-        "label": "YouTube — Beaux Arts Trio"
-      },
-      {
-        "type": "vimeo",
-        "url": "https://vimeo.com/380174523",
-        "label": "Vimeo — Trio Wanderer, live performance"
-      },
       {
         "type": "wikipedia",
         "url": "https://en.wikipedia.org/wiki/Piano_Trio_No._2_(Shostakovich)",

--- a/src/data/seed-expansion-8.ts
+++ b/src/data/seed-expansion-8.ts
@@ -42,40 +42,15 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'IMSLP — Castelnuovo-Tedesco: Guitar Concerto No. 1 Op. 99',
       },
       {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Guitar_Concerto_No._1_(Castelnuovo-Tedesco)',
-        label: 'Wikipedia — Guitar Concerto No. 1 (Castelnuovo-Tedesco)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=aAHDoHslYHQ',
-        label: 'Andrés Segovia — 1954 recording (historic premiere performer)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=YT_k0DPoANA',
-        label: 'Sharon Isbin — Grammy Award recording, NYPO',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2kzPBBMsblQmhGikM7PBFZ',
-        label: 'Sharon Isbin / NYPO — Grammy Award recording',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3FkRcYKT3GRg8nOO6V7nwR',
-        label: 'Pepe Romero / Academy of St Martin in the Fields — Philips',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/CastelnuovoTedescoGuitarConcerto1Segovia',
-        label: 'Andrés Segovia — 1954 historic recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/guitar-concertos/castelnuovo-tedesco-concerto-1',
         label: 'Conservatory competition performance — guitar and piano',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=dJt12W7_gdY",
+        "label": "Rodders — Mario Castelnuovo-Tedesco : Concerto No. 1 in D major for guitar and orchestra Op. 99 (1939)"
+      }
     ],
   },
   {
@@ -114,40 +89,15 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/5_Preludes_(Villa-Lobos,_Heitor)',
-        label: 'IMSLP — Villa-Lobos: 5 Preludes',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Preludes_(Villa-Lobos)',
-        label: 'Wikipedia — Preludes (Villa-Lobos)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=Nh5GBSKnYQ8',
-        label: 'John Williams — complete Five Preludes',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=oRIbNFgVzhs',
-        label: 'Julian Bream — Prelude No. 1',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1XZ5AJvPJVQbNTCIGcsMUb',
-        label: 'John Williams — Sony Classical recording',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/VillaLobos5PrelJohnWilliamsGuitar',
-        label: 'John Williams — historic studio recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/guitar-masters/villa-lobos-preludes-complete',
         label: 'Student recital — Royal College of Music',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=9q7UlMiMQ-s",
+        "label": "SiccasGuitars — Five Preludes by Heitor Villa-Lobos | Siccas Guitars"
+      }
     ],
   },
   {
@@ -186,40 +136,20 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Sonatina_(Moreno_Torroba,_Federico)',
-        label: 'IMSLP — Torroba: Sonatina for Guitar',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Federico_Moreno_Torroba',
         label: 'Wikipedia — Federico Moreno Torroba',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=yZnPiHCXebs',
-        label: 'Andrés Segovia — historic recording (dedicatee)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=CdCb9Cqc7co',
-        label: 'Pepe Romero — complete Sonatina',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4FX5nfvLMBlvVhR3kW7Grx',
-        label: 'Andrés Segovia — Deutsche Grammophon Archiv',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/TorrobaSonatinaSegovia',
-        label: 'Andrés Segovia — 1952 recording',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/classicalguitar/torroba-sonatina-recital',
         label: 'RCM guitar diploma recital performance',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=fi3E9fLP4bk",
+        "label": "SiccasGuitars — Ana Vidovic plays Sonatina by Federico Moreno Torroba"
+      }
     ],
   },
   {
@@ -261,31 +191,6 @@ export const expansionPieces8: SeedPiece[] = [
         type: 'imslp',
         url: 'https://imslp.org/wiki/Homenaje_(Falla,_Manuel_de)',
         label: 'IMSLP — de Falla: Homenaje pour le tombeau de Debussy',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Homenaje_(de_Falla)',
-        label: 'Wikipedia — Homenaje (de Falla)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=NkgeMkizxJY',
-        label: 'Andrés Segovia — historic recording',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=3YTRY1DXAig',
-        label: 'Julian Bream — EMI recording',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/0cPOq77KJsVg5DxGJ6hQf6',
-        label: 'Julian Bream — EMI Classics collection',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/FallaHomenajeSegovia',
-        label: 'Andrés Segovia — 1950s recording',
       },
       {
         type: 'soundcloud',
@@ -340,35 +245,15 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Johann Baptist Vanhal',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=6fIihSuvR9E',
-        label: 'Klaus Stoll — Berlin Philharmonic principal bass',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=X2GBxnGaLUw',
-        label: 'Chi-chi Nwanoku — BBC Proms performance',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5rFhQ2WyGAlMD6sQmH7z3G',
-        label: 'Chi-chi Nwanoku / Academy of Ancient Music — L\'Oiseau-Lyre',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/VanhalDoubleBassConerto',
-        label: 'Gary Karr — historic recording with orchestra',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/doublebasstudio/vanhal-concerto-d-major',
         label: 'ISB Competition semifinal recording',
       },
       {
-        type: 'vimeo',
-        url: 'https://vimeo.com/312847562',
-        label: 'Young soloist — European String Teachers Association competition',
-      },
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Dt-bNf6h0tI",
+        "label": "London Symphony Orchestra — Vanhal Double Bass Concerto in D Major // Rinat Ibragimov, double bass"
+      }
     ],
   },
   {
@@ -407,40 +292,20 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Tarantella_(Dragonetti,_Domenico)',
-        label: 'IMSLP — Dragonetti: Tarantella for Double Bass',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Domenico_Dragonetti',
         label: 'Wikipedia — Domenico Dragonetti',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=kNQ5pTnKhbg',
-        label: 'Chi-chi Nwanoku — concert performance',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=4TsS3UmPqYo',
-        label: 'ISB Young Artists Competition finalist',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1jDL2REJe5QUfB7d3RZaRh',
-        label: 'Chi-chi Nwanoku — Hyperion Records',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/DragonettiPiecesForDoubleBass',
-        label: 'Ludwig Streicher — historic Viennese recording',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/bassrecitals/dragonetti-tarantella-recital',
         label: 'Conservatoire de Paris student recital',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=hhUyEO3WwMk",
+        "label": "Mikyung Sung — \"Dragonetti\" Nanny Double Bass Concerto - I (Mikyung Sung double bass, Inja Choi piano)"
+      }
     ],
   },
   {
@@ -479,45 +344,15 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Organ_Sonata_on_the_94th_Psalm_(Reubke,_Julius)',
-        label: 'IMSLP — Reubke: Sonata on the 94th Psalm',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Organ_Sonata_on_the_94th_Psalm',
-        label: 'Wikipedia — Organ Sonata on the 94th Psalm',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=zWCgMbBCH8I',
-        label: 'Olivier Latry — Notre-Dame de Paris (grand-orgue)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=VJFxlVT7fy8',
-        label: 'Ben van Oosten — Merseburg Cathedral',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6iRgJMlwQCsY2FBmvsMnhb',
-        label: 'Olivier Latry — Deutsche Grammophon',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/ReubkePsalmSonata94',
-        label: 'Karl Richter — historic 1960s recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/organrecitals/reubke-94th-psalm-cathedral',
         label: 'Prizewinner — Chartres International Organ Competition',
       },
       {
-        type: 'vimeo',
-        url: 'https://vimeo.com/278834901',
-        label: 'Ben Bloor — St Paul\'s Cathedral, London',
-      },
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=U9gCvM7PaYA",
+        "label": "organwizard — Gillian Weir- Sonata on the 94th Psalm, by Julius Reubke"
+      }
     ],
   },
   {
@@ -556,36 +391,6 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Suite,_Op.5_(Durufl%C3%A9,_Maurice)',
-        label: 'IMSLP — Duruflé: Suite Op. 5',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Suite_(Durufl%C3%A9)',
-        label: 'Wikipedia — Suite (Duruflé)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=0yw3NqVyMGo',
-        label: 'Marie-Claire Alain — complete Suite Op. 5',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=9FpqRyXS_0Y',
-        label: 'Olivier Latry — Toccata (St-Étienne-du-Mont, Paris)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4dQfmAF4EV1eMHsW7JHYHU',
-        label: 'Marie-Claire Alain — Erato Records',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/DurufleOrganWorks',
-        label: 'Maurice Duruflé — self-conducted 1950s recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/organworks/durufle-suite-op5-toccata',
         label: 'Laureate — St Albans International Organ Competition',
@@ -595,6 +400,11 @@ export const expansionPieces8: SeedPiece[] = [
         url: 'https://vimeo.com/344122901',
         label: 'Anna Lapwood — Pembroke College Cambridge',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=94ybEIYYA1w",
+        "label": "David Bendix Nielsen — Maurice Duruflé: Suite for Organ, Op. 5"
+      }
     ],
   },
   {
@@ -633,36 +443,6 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Litanies,_Op.79_(Alain,_Jehan)',
-        label: 'IMSLP — Alain: Litanies Op. 79',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Litanies_(Alain)',
-        label: 'Wikipedia — Litanies (Alain)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=_CXWaovgP9Y',
-        label: 'Marie-Claire Alain — St-Nicolas-de-Coutances',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=zk0OjrISHos',
-        label: 'Olivier Latry — Notre-Dame de Paris',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4LLjzBRUTfzWzBZUGVA2ot',
-        label: 'Marie-Claire Alain — Erato complete organ works',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/AlainOrganWorksMarieClaire',
-        label: 'Marie-Claire Alain — 1960s recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/organcompetition/alain-litanies-prizewinner',
         label: 'Finalist — Calgary International Organ Competition',
@@ -672,6 +452,11 @@ export const expansionPieces8: SeedPiece[] = [
         url: 'https://vimeo.com/389274012',
         label: 'Anna Lapwood — King\'s College Cambridge',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Mvs7w4OqJro",
+        "label": "Sir Philip Ledger - Topic — Litanies, Op.79"
+      }
     ],
   },
   {
@@ -710,40 +495,15 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/6_Sonatas,_Op.65_(Mendelssohn,_Felix)',
-        label: 'IMSLP — Mendelssohn: 6 Organ Sonatas Op. 65',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/6_Organ_Sonatas_(Mendelssohn)',
-        label: 'Wikipedia — 6 Organ Sonatas (Mendelssohn)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=7r0LBdQ-moo',
-        label: 'Peter Hurford — St Albans Abbey',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=EBFfLMmPxps',
-        label: 'Simon Preston — Westminster Abbey',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/51tVEEDo2bLzY7cGFpRDVf',
-        label: 'Peter Hurford — Decca complete organ sonatas',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/MendelssohnOrganSonatas',
-        label: 'E. Power Biggs — historic recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/organrecital/mendelssohn-sonata-3-recital',
         label: 'FRCO examination recital — Royal College of Organists',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=hhMvETANi5o",
+        "label": "Akademia Filmu i Telewizji — Felix  Mendelssohn - Bartholdy, Sonata No. 3 in A Major op. 65"
+      }
     ],
   },
   {
@@ -787,40 +547,15 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'IMSLP — Debussy: Sonata for Flute, Viola and Harp',
       },
       {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Sonata_for_Flute,_Viola_and_Harp_(Debussy)',
-        label: 'Wikipedia — Sonata for Flute, Viola and Harp (Debussy)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=aXhGFMJ1mDA',
-        label: 'Emmanuel Pahud / Tabea Zimmermann / Marie-Pierre Langlamet',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=3oUSqPiAJfY',
-        label: 'William Bennett / Cecil Aronowitz / Osian Ellis — historic recording',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4Dt8VKTBZ0A4lV01SiyGEh',
-        label: 'Pahud / Zimmermann / Langlamet — EMI Classics',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3sK1fT9zYXjdL9c5mPuQ4H',
-        label: 'Nash Ensemble — Hyperion Records',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/DebussySonataFluteViolaHarpMelos',
-        label: 'Melos Ensemble — 1960s recording',
-      },
-      {
         type: 'vimeo',
         url: 'https://vimeo.com/241673012',
         label: 'Trio competition semifinal — Geneva International Music Competition',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=mI-wlmMNU6c",
+        "label": "olla-vogala — Claude Debussy - Sonata for Flute, Viola and Harp"
+      }
     ],
   },
   {
@@ -859,40 +594,20 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Impromptu,_Op.86_(Faur%C3%A9,_Gabriel)',
-        label: 'IMSLP — Fauré: Impromptu for Harp Op. 86',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Gabriel_Faur%C3%A9#Harp',
         label: 'Wikipedia — Fauré harp works',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=YOnHNGStEzI',
-        label: 'Yolanda Kondonassis — concert recording',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=EcWqcqy4LXo',
-        label: 'Sivan Magen — World Harp Congress',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6XR8HtfUCfSmLXr5nS4yvG',
-        label: 'Yolanda Kondonassis — Azica Records',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/FaureHarpImpromptu',
-        label: 'Nicanor Zabaleta — historic DGG recording',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/harprecitals/faure-impromptu-op86',
         label: 'Conservatoire National Supérieur student recital',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Imiky1nEx-A",
+        "label": "Harpist Hyejin Kim | 하피스트 김혜진 — Gabriel Fauré: Impromptu pour harpe, op. 86"
+      }
     ],
   },
   {
@@ -931,40 +646,20 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Fantasy,_Op.35_(Spohr,_Louis)',
-        label: 'IMSLP — Spohr: Fantasy for Harp Op. 35',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Louis_Spohr',
         label: 'Wikipedia — Louis Spohr',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=G6FVelLHRHg',
-        label: 'Catrin Finch — BBC Young Musician Award winner',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=LKbBHrXymBQ',
-        label: 'Isabelle Moretti — complete Fantasy',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3EJpRVtv1CvtXZ2iNBt0WX',
-        label: 'Catrin Finch — Deutsche Grammophon',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/SpohrHarpFantasyZabaleta',
-        label: 'Nicanor Zabaleta — DGG historic recording',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/harpcompetition/spohr-fantasy-35-semifinal',
         label: 'World Harp Congress competition semifinal',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=VNQOIM6evD0",
+        "label": "Bartje Bartmans — Louis Spohr - Fantasy, Op. 35 for Harp (1807)"
+      }
     ],
   },
   {
@@ -1013,35 +708,15 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Hindemith chamber music',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=2V9sEMlL15A',
-        label: 'Sivan Magen — International Harp Contest in Israel winner',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=KGsJLCFN8Ik',
-        label: 'Xavier de Maistre — complete Sonata',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1nKXZSbNvw8w1LMXvpJlqY',
-        label: 'Xavier de Maistre — Sony Classical',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/HindemithHarpSonataRecording',
-        label: 'Susann McDonald — historic Lyrichord recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/harpmasterworks/hindemith-sonata-harp',
         label: 'Finalist — Israel International Harp Contest',
       },
       {
-        type: 'vimeo',
-        url: 'https://vimeo.com/421783045',
-        label: 'Florentine Mulsant — Lille Conservatoire recital',
-      },
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=T_YrDOH9ECg",
+        "label": "George N. Gianopoulos, composer — Paul Hindemith - Sonata for Harp (1939) [Score-Video]"
+      }
     ],
   },
   {
@@ -1080,34 +755,9 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Concerto_for_Marimba,_Vibraphone_and_Orchestra,_Op.278_(Milhaud,_Darius)',
-        label: 'IMSLP — Milhaud: Concerto for Marimba, Vibraphone and Orchestra Op. 278',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Darius_Milhaud#Concertos',
         label: 'Wikipedia — Milhaud concertos',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=hAV8I7jYFzM',
-        label: 'Keiko Abe / Nagoya Philharmonic — marimba soloist',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=wG9p4WZ_ixc',
-        label: 'Emmanuel Séjourné — complete Concerto',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3d5wRqb7KR3h6KL1Aeh7lN',
-        label: 'Emmanuel Séjourné / Orchestre Philharmonique de Strasbourg',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/MilhaudMarimbaConerto',
-        label: 'Clair Omar Musser — early recording',
       },
       {
         type: 'soundcloud',
@@ -1119,6 +769,11 @@ export const expansionPieces8: SeedPiece[] = [
         url: 'https://vimeo.com/312047856',
         label: 'Lucas Niggli — Lucerne Festival performance',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=mviKkoT9Cr4",
+        "label": "Rodders — Darius Milhaud : Concerto for marimba, vibraphone and orchestra Op. 278 (1947)"
+      }
     ],
   },
   {
@@ -1157,34 +812,9 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Concertino_for_Marimba_and_Orchestra,_Op.21_(Creston,_Paul)',
-        label: 'IMSLP — Creston: Concertino for Marimba Op. 21',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Paul_Creston',
         label: 'Wikipedia — Paul Creston',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=Vd8p41X5GWk',
-        label: 'Keiko Abe — complete Concertino',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=H9MxaQBVlFc',
-        label: 'PASIC Competition masterclass performance',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2dFnRn1tRGY1J4lYmqYkLz',
-        label: 'Evelyn Glennie / BBC Symphony Orchestra — RCA Red Seal',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/CrestonMarimbaConcertino',
-        label: 'Ruth Stuber Jeanne — premiere recording',
       },
       {
         type: 'soundcloud',
@@ -1234,34 +864,9 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Concerto_pour_percussion_et_orchestre_de_chambre_(Jolivet,_Andr%C3%A9)',
-        label: 'IMSLP — Jolivet: Concerto pour percussion et orchestre de chambre',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Andr%C3%A9_Jolivet',
         label: 'Wikipedia — André Jolivet',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=hgLdJy8rQrs',
-        label: 'Jean Batigne — premiere performance archive',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=4ybSmrZG8BE',
-        label: 'Evelyn Glennie — BBC Radio 3 broadcast',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6xKVoW2X4UxM8zOw5Z2Gky',
-        label: 'Evelyn Glennie — RCA Red Seal recording',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/JolivetPercussionConcerto',
-        label: 'Jean Batigne / Orchestre de Chambre de Paris — 1960s recording',
       },
       {
         type: 'soundcloud',
@@ -1269,10 +874,10 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'CNSM Paris student competition recording',
       },
       {
-        type: 'vimeo',
-        url: 'https://vimeo.com/203847011',
-        label: 'Cédric Spina — Orchestre National de France',
-      },
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Hk3bjXUPLLI",
+        "label": "San Francisco Conservatory of Music — André Jolivet, Concerto pour percussion"
+      }
     ],
   },
   {
@@ -1311,45 +916,15 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Piano_Trio_in_A_minor_(Ravel,_Maurice)',
-        label: 'IMSLP — Ravel: Piano Trio in A minor',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Piano_Trio_(Ravel)',
         label: 'Wikipedia — Piano Trio (Ravel)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=DPAPlKuRN2k',
-        label: 'Renaud Capuçon / Gautier Capuçon / Martha Argerich',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=hxlrWGQSILQ',
-        label: 'Beaux Arts Trio — complete Trio',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4GiXX3oFSKO0mHqPw4DnfO',
-        label: 'Argerich / R. Capuçon / G. Capuçon — Deutsche Grammophon',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1dK8pf8rOilpYmXYNS9F3z',
-        label: 'Beaux Arts Trio — Philips recording',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/RavelPianoTrioBeauxArts',
-        label: 'Beaux Arts Trio — historic 1960s recording',
-      },
-      {
-        type: 'vimeo',
-        url: 'https://vimeo.com/274521033',
-        label: 'Trio Wanderer — Verbier Festival masterclass',
-      },
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=CKAwByyYoCw",
+        "label": "AVROTROS Klassiek — Ravel: Piano Trio in A minor - Janine Jansen - International Chamber Music Festival - Live HD"
+      }
     ],
   },
   {
@@ -1396,31 +971,6 @@ export const expansionPieces8: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Horn_Trio_(Brahms)',
         label: 'Wikipedia — Horn Trio (Brahms)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=M6MPlTjLFqY',
-        label: 'Barry Tuckwell / Itzhak Perlman / Vladimir Ashkenazy — Decca',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=x3kRMnP_hKQ',
-        label: 'Eric Ruske / Joshua Bell / Jean-Yves Thibaudet',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6jJBRuHdPiUAlkT4VyMO7c',
-        label: 'Tuckwell / Perlman / Ashkenazy — Decca',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5TGqyQI3YLGqN3pBHVlaTY',
-        label: 'Radovan Vlatkovic / Thomas Zehetmair / Till Fellner',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/BrahmsHornTrio',
-        label: 'Dennis Brain / Menuhin / Kentner — 1956 recording',
       },
       {
         type: 'vimeo',
@@ -1475,35 +1025,15 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Beethoven String Quartet No. 1',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=y8r0jYxZzBE',
-        label: 'Alban Berg Quartet — complete quartet',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=V3Vl1cW4zVQ',
-        label: 'Emerson String Quartet — DG recording',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2WbRN4gLFvEMEFqBi3m4Xz',
-        label: 'Alban Berg Quartet — EMI Classics',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6jLfEXrIGjJ2k3E8xVjG9T',
-        label: 'Takács Quartet — Decca',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/BeethovenStringQuartetOp18Budapest',
-        label: 'Budapest String Quartet — 1952 Columbia recording',
-      },
-      {
         type: 'vimeo',
         url: 'https://vimeo.com/289745012',
         label: 'Calidore String Quartet — Verbier Festival masterclass',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=GfKZxWqexuo",
+        "label": "Schwammerl — BEETHOVEN String Quartet No. 1 in F major (Op. 18, No. 1) Score"
+      }
     ],
   },
   {
@@ -1552,35 +1082,15 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Schumann Piano Trio No. 1',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=VX0yiOuHLto',
-        label: 'Beaux Arts Trio — complete Trio',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=oHE_fzK74lQ',
-        label: 'Florestan Trio — Hyperion recording',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5I5Q0UVxgEQYlFh9x3eWLm',
-        label: 'Florestan Trio — Hyperion Records',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/0v3AkajG7BIr9PVeQyuUfT',
-        label: 'Trio Wanderer — harmonia mundi',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/SchumannPianoTrioBeauxArts',
-        label: 'Beaux Arts Trio — Philips 1960s recording',
-      },
-      {
         type: 'vimeo',
         url: 'https://vimeo.com/315821047',
         label: 'Gould Piano Trio — Leeds chamber music festival',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Ej1TYiN6W9c",
+        "label": "Thomas Hoppe — ATOS Trio: R.Schumann - Trio no.1 in d-minor, op.63"
+      }
     ],
   },
   {
@@ -1629,35 +1139,10 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Fauré Piano Quintet No. 1',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=YT9MKfUqNXA',
-        label: 'Domus / Susan Tomes — complete quintet',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=O8Uh5nJdqac',
-        label: 'Imogen Cooper / Chilingirian Quartet — BBC broadcast',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5nFLVmE2e0F2tF5nJvQN7g',
-        label: 'Domus — Hyperion Records',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2QFT0PNHkOLHjuG5D8hGzJ',
-        label: 'Pascal Rogé / Quatuor Ysaÿe — Decca',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/FaurePianoQuintetNo1',
-        label: 'Jean Doyen / Quatuor Loewenguth — 1950s recording',
-      },
-      {
-        type: 'vimeo',
-        url: 'https://vimeo.com/362910845',
-        label: 'Imogen Cooper — Leeds International Piano Competition masterclass',
-      },
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=3uGqAVkQt70",
+        "label": "Classical Gems — Gabriel Fauré - Piano Quintet No.1 in D Minor, Op.89"
+      }
     ],
   },
   {
@@ -1706,35 +1191,10 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Symphony No. 2 (Brahms)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=qd1LaHCR4eI',
-        label: 'Carlos Kleiber / Vienna Philharmonic — 1983 (legendary recording)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=C9dJMnHtNkQ',
-        label: 'Leonard Bernstein / Vienna Philharmonic — 1982',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1iCd28TfHfIHVRHZcRGJr7',
-        label: 'Carlos Kleiber / Vienna Philharmonic — Deutsche Grammophon (Gramophone Award)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/06FO43lS7bCKM7W5HXGRfD',
-        label: 'Claudio Abbado / Berlin Philharmonic — Deutsche Grammophon',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/BrahmsSymphony2Furtwangler',
-        label: 'Wilhelm Furtwängler / Berlin Philharmonic — 1951 recording',
-      },
-      {
-        type: 'vimeo',
-        url: 'https://vimeo.com/298124751',
-        label: 'Mirga Gražinytė-Tyla / CBSO — live Proms',
-      },
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=FAuUUIvfkp0",
+        "label": "wocomoMUSIC — Brahms - Symphony No. 2 in D major, Op. 73 | The Cleveland Orchestra, Franz Welser-Möst"
+      }
     ],
   },
   {
@@ -1783,35 +1243,15 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Symphony No. 4 (Tchaikovsky)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=_qCBFzFTMJk',
-        label: 'Mravinsky / Leningrad Philharmonic — 1960 (definitive recording)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=VBjoGHNFxVU',
-        label: 'Mariss Jansons / Oslo Philharmonic — 1997',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2jCRmhLjilB3LI8tFy4Z1y',
-        label: 'Mravinsky / Leningrad Philharmonic — DGG Galleria (historic)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5bI1xTcHHbhBFkd7YEj2Li',
-        label: 'Mariss Jansons / Oslo Philharmonic — EMI Classics',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/TchaikovskySymphony4Mravinsky',
-        label: 'Mravinsky / Leningrad Philharmonic — 1956 recording',
-      },
-      {
         type: 'vimeo',
         url: 'https://vimeo.com/341092867',
         label: 'Gustavo Dudamel / Simón Bolívar Symphony — Salzburg',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=t1VRuZGAFOY",
+        "label": "ioannis mavridis — P. TCHAIKOVSKY - Symphony No.4, f moll, Op.36 [New York Philharmonic, Leonard Bernstein]"
+      }
     ],
   },
   {
@@ -1861,33 +1301,8 @@ export const expansionPieces8: SeedPiece[] = [
       },
       {
         type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=kGQJSHSHdLo',
-        label: 'Bruno Walter / Columbia Symphony — 1961 (historic premiere recording)',
-      },
-      {
-        type: 'youtube',
         url: 'https://www.youtube.com/watch?v=vOvXhyldUko',
         label: 'Claudio Abbado / Berlin Philharmonic — 1997',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5fphUJfYnXb0sBEhpEeIFp',
-        label: 'Claudio Abbado / Berlin Philharmonic — DGG (Gramophone Award)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3T2SRRUEYqKBuSmhoxnA0m',
-        label: 'Bruno Walter / Columbia Symphony — Sony Essential Classics',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/MahlerSymphony4BrunoWalter',
-        label: 'Bruno Walter / New York Philharmonic — 1945 recording',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/MahlerSymphonyNo4Mengelberg',
-        label: 'Willem Mengelberg / Concertgebouw — 1939 (historic)',
       },
       {
         type: 'vimeo',

--- a/src/data/seed-expansion-9.ts
+++ b/src/data/seed-expansion-9.ts
@@ -47,35 +47,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: "Wikipedia — Prélude à l'après-midi d'un faune",
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=NL4haNfIGJ0',
-        label: 'Pierre Boulez — Cleveland Orchestra (Deutsche Grammophon)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=SleOT0dOoVc',
-        label: 'Herbert von Karajan — Berlin Philharmonic (1964 studio recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4mQyBnJlnULkIBdELhQGaU',
-        label: 'Pierre Boulez / Cleveland Orchestra — Deutsche Grammophon',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/7KVlkX8B0nDsn2YMdgQg4M',
-        label: 'Simon Rattle / Berlin Philharmonic — EMI Classics',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/DebussyPrelApresMidiFaunToscaniniNBC1938',
-        label: 'Arturo Toscanini / NBC Symphony Orchestra — 1938 historic broadcast',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/debussy-orchestral/prelude-apres-midi-faune',
         label: 'Paris Conservatoire Orchestra — archival conservatory broadcast',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=Y9iDOt2WbjY",
+        "label": "hr-Sinfonieorchester – Frankfurt Radio Symphony — Debussy: Prélude à l’après-midi d’un faune ∙ hr-Sinfonieorchester ∙ Andrés Orozco-Estrada"
+      }
     ],
   },
   {
@@ -124,35 +104,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — The Firebird (Stravinsky)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=LEo4IQhCOyE',
-        label: 'Igor Stravinsky — Columbia Symphony Orchestra (composer conducting, 1961)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=GKMU1Bx1OjE',
-        label: 'Gustavo Dudamel — Simon Bolivar Symphony Orchestra (Proms 2007)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5GzwvxG0kNWL2hQxbHMkdU',
-        label: 'Stravinsky / Columbia Symphony Orchestra — conductor-composer Sony recording',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2WEB9VwmRMBN4f0jRzlnAI',
-        label: 'Michael Tilson Thomas / San Francisco Symphony — SFS Media',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/StravinskyFirebirdSuite1919Stokowski',
-        label: 'Leopold Stokowski / Philadelphia Orchestra — 1927 historic recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/stravinsky-ballets/firebird-suite-1919',
         label: 'National Youth Orchestra — proms debut broadcast',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=pHxstiIybz4",
+        "label": "Toronto Symphony Orchestra — Stravinsky: Suite from The Firebird (1919 revision) / Peter Oundjian · Toronto Symphony Orchestra"
+      }
     ],
   },
   {
@@ -201,35 +161,10 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Symphony No. 3 (Brahms)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=DhDvQFMqv5w',
-        label: 'Carlos Kleiber — Vienna Philharmonic (legendary 1981 Musikverein concert)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=oVt5AJ3GWUY',
-        label: 'Herbert von Karajan — Berlin Philharmonic (1988 digital recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1wZx8VBDvJNk9B3AKkopvR',
-        label: 'Carlos Kleiber / Vienna Philharmonic — Deutsche Grammophon',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3cOFB6hFMxIJGsNM8FdVVS',
-        label: 'Leonard Bernstein / Vienna Philharmonic — Deutsche Grammophon',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/BrahmsSymphony3ToscaniniNBCSO1948',
-        label: 'Arturo Toscanini / NBC Symphony Orchestra — 1948 broadcast',
-      },
-      {
-        type: 'vimeo',
-        url: 'https://vimeo.com/123456789',
-        label: 'Andris Nelsons — Boston Symphony Orchestra (2016 Tanglewood broadcast)',
-      },
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=mmXB2YQnq84",
+        "label": "wocomoMUSIC — Brahms - Symphony No. 3 in F major, Op. 90 | The Cleveland Orchestra, Franz Welser-Möst"
+      }
     ],
   },
   {
@@ -268,11 +203,6 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Symphony_No.5,_Op.47_(Shostakovich,_Dmitri)',
-        label: 'IMSLP — Shostakovich: Symphony No. 5 Op. 47',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Symphony_No._5_(Shostakovich)',
         label: 'Wikipedia — Symphony No. 5 (Shostakovich)',
@@ -281,26 +211,6 @@ export const expansionPieces9: SeedPiece[] = [
         type: 'youtube',
         url: 'https://www.youtube.com/watch?v=rRgXUFnfKIY',
         label: 'Yevgeny Mravinsky — Leningrad Philharmonic (1973 DG live recording)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=o2nh7jrXPbM',
-        label: 'Mariss Jansons — Oslo Philharmonic (2003 EMI recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/0rNBSRULERpbxEfbFYRd7Y',
-        label: 'Yevgeny Mravinsky / Leningrad Philharmonic — Deutsche Grammophon',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4oBbcCJjIHTXdMy8FqBbm3',
-        label: 'Mariss Jansons / Oslo Philharmonic — EMI Classics',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/Shostakovich-Symphony5-Mravinsky1938',
-        label: 'Yevgeny Mravinsky — 1938 premiere-era broadcast recording',
       },
       {
         type: 'vimeo',
@@ -355,35 +265,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Don Quixote (Strauss)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=HhEO8SMFZYM',
-        label: 'Jacqueline du Pré / Adrian Boult — BBC Symphony Orchestra (1966 Proms)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=Hpa2qBjcSfA',
-        label: 'Yo-Yo Ma / Seiji Ozawa — Boston Symphony Orchestra (Sony Classical)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3TEjBvPuBL8VnX9kEeVaDA',
-        label: 'Yo-Yo Ma / Seiji Ozawa / Boston Symphony Orchestra — Sony Classical',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5MFdFiHy8Kd6JlE4vN8Xry',
-        label: 'Emanuel Feuermann / Eugene Ormandy — Philadelphia Orchestra (RCA)',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/StraussDonQuixoteFeuermann1940',
-        label: 'Emanuel Feuermann / Philadelphia Orchestra — 1940 historic recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/strauss-tone-poems/don-quixote-op35',
         label: 'Munich Philharmonic — conservatory broadcast excerpt',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=5PvCGu2Ue0U",
+        "label": "Roc Vela — Don Quixote, Op. 35 - Richard Strauss (Score)"
+      }
     ],
   },
   {
@@ -432,35 +322,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — La Valse (Ravel)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=6pADMVvhkSY',
-        label: 'Pierre Boulez — Berlin Philharmonic (2004 live recording)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=d-F_VBZQKDA',
-        label: 'Charles Dutoit — Orchestre Symphonique de Montréal (Decca)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1xLH2uLSg6GGZV8xsrUlKt',
-        label: 'Charles Dutoit / Orchestre Symphonique de Montréal — Decca',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6lXsNDGJX2DPGQpUbVNEhX',
-        label: 'Pierre Boulez / Berlin Philharmonic — Deutsche Grammophon',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/RavelLaValseKoussevitzky1930',
-        label: 'Serge Koussevitzky / Boston Symphony Orchestra — 1930 historic recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/ravel-orchestral/la-valse-live-broadcast',
         label: 'Conservatoire de Paris Orchestra — student broadcast performance',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=CeomfSaTHzc",
+        "label": "Berlin Philharmonic Orchestra - Topic — Ravel: La valse, M. 72 - Choreographic poem, for Orchestra: La valse, M. 72"
+      }
     ],
   },
   {
@@ -499,45 +369,15 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/String_Quartet_No.62_in_C_major,_Op.76_No.3_(Haydn,_Joseph)',
-        label: 'IMSLP — Haydn: String Quartet Op. 76 No. 3 "Emperor"',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/String_Quartet_No._62_(Haydn)',
-        label: 'Wikipedia — String Quartet No. 62 "Emperor" (Haydn)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=2Kl2BPNX7dE',
-        label: 'Alban Berg Quartet — EMI studio recording (1990)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=JwFh0NvHSVQ',
-        label: 'Emerson String Quartet — Deutsche Grammophon recording',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2vLtF4BKrm7Q1Z9oJDwDrP',
-        label: 'Alban Berg Quartet — EMI Classics complete Op. 76',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4VPX7NBqCfvAJWqfuXbKTx',
-        label: 'Emerson String Quartet — Deutsche Grammophon complete Haydn Op. 76',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/HaydnEmperorQuartetBuschQuartet1937',
-        label: 'Busch Quartet — 1937 historic recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/haydn-chamber/emperor-quartet-op76-no3',
         label: 'Conservatory quartet competition performance',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=qoWdtGUe5fc",
+        "label": "Anthony Mondon — Haydn - String Quartet, Op. 76, No. 3"
+      }
     ],
   },
   {
@@ -586,35 +426,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — String Quartet No. 19 "Dissonance" (Mozart)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=tDHFXz6Gb7E',
-        label: 'Alban Berg Quartet — EMI live recording (Vienna, 1985)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=yCwY6EqUWMU',
-        label: 'Amadeus Quartet — BBC broadcast recording (classic interpretation)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5KtkmqpVF7U9LD7rJjYeVt',
-        label: 'Alban Berg Quartet — EMI complete Haydn Quartets box set',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1VNzc3PFKMGiRRKQoRg1dP',
-        label: 'Hagen Quartet — Deutsche Grammophon recording',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/MozartDissonanceQuartetBuschQuartet1935',
-        label: 'Busch Quartet — 1935 historic EMI recording',
-      },
-      {
         type: 'vimeo',
         url: 'https://vimeo.com/345678901',
         label: 'Jerusalem Quartet — BBC Proms 2015 live broadcast',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=f3oK4XVMARs",
+        "label": "DW Classical Music — Mozart: String Quartet No. 19, Dissonance | Gewandhaus Quartet"
+      }
     ],
   },
   {
@@ -663,35 +483,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Piano Trio No. 1 (Mendelssohn)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=oDBDYNmRWzU',
-        label: 'Beaux Arts Trio — Philips studio recording (authoritative interpretation)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=OLfEdBJcfh8',
-        label: 'Trio Wanderer — Harmonia Mundi recording (2006)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4dBuQ9jZb2dSK8LcIZyaRu',
-        label: 'Beaux Arts Trio — Philips Classics',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/7cHTJGg3VCJg2uVjuY9KR5',
-        label: 'Trio Wanderer — Harmonia Mundi',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/MendelssohnPianoTrioOp49CortotThibaudCasals1926',
-        label: 'Cortot-Thibaud-Casals Trio — 1926 historic HMV recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/chamber-music-archive/mendelssohn-trio-op49',
         label: 'Leeds International Chamber Music Competition — 2019 finalist',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=-PAFzEnJ6NU",
+        "label": "Thomas Hoppe — ATOS Trio: Mendelssohn - Trio no.1 in d-minor, op.49 - live at Wigmore Hall"
+      }
     ],
   },
   {
@@ -730,45 +530,20 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/String_Quartet_No.1,_JW_VII/8_(Jan%C3%A1%C4%8Dek,_Leo%C5%A1)',
-        label: 'IMSLP — Janáček: String Quartet No. 1 "Kreutzer Sonata"',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/String_Quartet_No._1_(Jan%C3%A1%C4%8Dek)',
         label: 'Wikipedia — String Quartet No. 1 (Janáček)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=IjhU5dlItiA',
-        label: 'Janáček Quartet — Supraphon studio recording (authoritative Czech interpretation)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=PzTzdNmm9yU',
-        label: 'Emerson String Quartet — Deutsche Grammophon (2005 recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3V4r1TDlzVB9gq7MbB5ILk',
-        label: 'Janáček Quartet — Supraphon complete string quartets',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6hzVt3peBe84P3SrVn0MLR',
-        label: 'Pavel Haas Quartet — Supraphon (2015 Gramophone Award recording)',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/JanacekKreutzerSonataQuartetBBC1962',
-        label: 'Janáček Quartet — BBC broadcast recording (1962)',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/janacek-chamber/string-quartet-1-kreutzer',
         label: 'International Janáček Festival — competition performance 2022',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=0TNeUJYiAoo",
+        "label": "olla-vogala — Leoš Janáček - String Quartet No. 1 \"Kreutzer Sonata\""
+      }
     ],
   },
   {
@@ -817,35 +592,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Violin Sonata No. 3 (Enescu)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=5gMnDq1hOvo',
-        label: 'George Enescu / Dinu Lipatti — 1943 historic Geneva recording (composer as violinist)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=oBvFhP2sQoM',
-        label: 'Christian Tetzlaff / Lars Vogt — BBC Proms (2015 live broadcast)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2F6G8HKvVgKbWd9MpJ7fqL',
-        label: 'Remus Azoiței / Eduard Stan — Romanian recording',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5U4rZ3pVQfW8YbK2lM9xBn',
-        label: 'Gidon Kremer / Nikolai Lugansky — ECM New Series',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/EnescuViolinSonata3ComposerLipatti1943',
-        label: 'George Enescu / Dinu Lipatti — 1943 Geneva broadcast (historic)',
-      },
-      {
         type: 'vimeo',
         url: 'https://vimeo.com/456789012',
         label: 'George Enescu International Competition — 2018 finalist recital',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=PxEhnONVGNE",
+        "label": "olla-vogala — George Enescu - Violin Sonata No. 3, Op. 25"
+      }
     ],
   },
   {
@@ -884,45 +639,20 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Violin_Sonata_No.1,_Op.80_(Prokofiev,_Sergei)',
-        label: 'IMSLP — Prokofiev: Violin Sonata No. 1 Op. 80',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Violin_Sonata_No._1_(Prokofiev)',
         label: 'Wikipedia — Violin Sonata No. 1 (Prokofiev)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=I_Z-KfJBMvo',
-        label: 'David Oistrakh / Sviatoslav Richter — 1968 live recording (premiere violinist)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=mRpf1_Ps4hg',
-        label: 'Hilary Hahn / Natalie Zhu — Deutsche Grammophon (2018 recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/0MnCT2RV1YI6YfE3tQVbBo',
-        label: 'David Oistrakh / Sviatoslav Richter — Philips historic reissue',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/7LxS8cZi0tBfKqnPZYpbNR',
-        label: 'Hilary Hahn / Natalie Zhu — Deutsche Grammophon',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/ProkofievViolinSonata1OistrakhOborin1946Premiere',
-        label: 'David Oistrakh / Lev Oborin — 1946 premiere-era Moscow recording',
       },
       {
         type: 'vimeo',
         url: 'https://vimeo.com/567890123',
         label: 'Maxim Vengerov — Menuhin Competition masterclass (2018 Genève)',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=RFnKuiKPjfc",
+        "label": "Camerata Pacifica — Prokofiev: Violin Sonata Nº.1 in F Minor, Op. 80 — Paul Huang, Gilles Vonsattel, Camerata Pacifica"
+      }
     ],
   },
   {
@@ -971,35 +701,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Violin Sonata No. 2 (Ravel)',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=nEflY5KQHRY',
-        label: 'Itzhak Perlman / Martha Argerich — live recording (legendary collaboration)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=GOvP6qQ6XCg',
-        label: 'Renaud Capuçon / Martha Argerich — Salzburg Festival 2019',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3LvUdxMMzajZMQmZMHvqUx',
-        label: 'Itzhak Perlman / Vladimir Ashkenazy — Decca',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5NKrPq8Lnzb9Vp4Y2KmtXj',
-        label: 'Renaud Capuçon / Bertrand Chamayou — Erato',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/RavelViolinSonata2EnescuRavel1929',
-        label: 'George Enescu / Maurice Ravel — 1929 composer-violinist recording (historic)',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/ravel-chamber/violin-sonata-no2-blues',
         label: 'Conservatoire National Supérieur — student recital competition',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=FkIxuxqBBJE",
+        "label": "Augustin Hadelich — Augustin Hadelich - Ravel Sonata with Orion Weiss (Live November 2021)"
+      }
     ],
   },
   {
@@ -1043,40 +753,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'IMSLP — Bach: Prelude and Fugue in C major BWV 547',
       },
       {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Prelude_and_Fugue_in_C_major,_BWV_547',
-        label: 'Wikipedia — Prelude and Fugue in C major BWV 547',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=iMUc9_CR2tQ',
-        label: 'Marie-Claire Alain — Bach complete organ works (Erato, 1994)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=b9K14NtPMWY',
-        label: 'Hans-Ola Ericsson — Luleå Cathedral, Sweden (2009 recital)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4Pn8KZhJeFq5lNLVZyjMJ9',
-        label: 'Marie-Claire Alain — Bach Complete Organ Works (Erato)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1FrKjHBrH94vP3kHWU2xLh',
-        label: 'Peter Hurford — Bach Organ Works Decca recording',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/BachBWV547PreludeFugueOrganHelmutWalcha',
-        label: 'Helmut Walcha — Archiv historic recording (1950s)',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/bach-organ-works/bwv547-prelude-fugue-cmajor',
         label: 'Royal College of Organists — student competition performance',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=P97d0Y8Hx_g",
+        "label": "Netherlands Bach Society — Bach - Prelude and fugue in C major BWV 547 - Van Doeselaar | Netherlands Bach Society"
+      }
     ],
   },
   {
@@ -1120,40 +805,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'IMSLP — Handel: Organ Concerto Op. 4 No. 1 HWV 289',
       },
       {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Organ_Concertos,_Op._4_(Handel)',
-        label: 'Wikipedia — Handel Op. 4 Organ Concertos',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=vVFzF2JpZXs',
-        label: 'Simon Preston / Trevor Pinnock — Academy of Ancient Music (Archiv)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=BVkXSfZiVXs',
-        label: 'Daniel Chorzempa / Concerto Amsterdam (Philips historic recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5p1Jyk2o9bMkQ4JV7mxHAQ',
-        label: 'Simon Preston / Academy of Ancient Music — Archiv Produktion',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1QBnCvRoJ4vHPxKHLWpFts',
-        label: 'Richard Egarr / Academy of Ancient Music — Harmonia Mundi',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/HandelOrganConcertoOp4No1E.PowerBiggsMusicHall1954',
-        label: 'E. Power Biggs / London Philharmonic — 1954 CBS historic recording',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/handel-organ/concerto-op4-no1-gminor',
         label: 'Royal Academy of Music — period instrument ensemble recital',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=RgoflxWzUNU",
+        "label": "TheOmniWasher — Handel - Organ Concerto No.1 Opus 4 in G minor"
+      }
     ],
   },
   {
@@ -1192,45 +852,15 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Grande_Pi%C3%A8ce_symphonique,_Op.17_(Franck,_C%C3%A9sar)',
-        label: 'IMSLP — Franck: Grande Pièce Symphonique Op. 17',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Grande_Pi%C3%A8ce_symphonique',
-        label: 'Wikipedia — Grande Pièce Symphonique (Franck)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=a9pSRSc8MqE',
-        label: 'Marie-Claire Alain — Orgue de Saint-Clotilde Paris (Erato)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=HNS0g_Z9xaU',
-        label: 'Louis Thiry — recorded at Cavaillé-Coll organ Sainte-Clotilde 1974',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2tMqh6GjJ8JTp9hnE7xKcV',
-        label: 'Olivier Latry — Franck Organ Works (Deutsche Grammophon)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4UkXJBH7VqyG9nOZ5wK3MW',
-        label: 'Marie-Claire Alain — Franck complete organ works (Erato)',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/FranckGrandePieceSymphoniqueDupreOrgan1946',
-        label: 'Marcel Dupré — Sainte-Clotilde historic broadcast recording (1946)',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/franck-organ/grande-piece-symphonique-op17',
         label: 'Conservatoire National Supérieur de Musique — organ diploma recital',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=dkxY3lk3qLQ",
+        "label": "Le Sheet Music Boi — César Franck - Grande Pièce Symphonique, Op.17"
+      }
     ],
   },
   {
@@ -1268,41 +898,6 @@ export const expansionPieces9: SeedPiece[] = [
       },
     ],
     external_links: [
-      {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Suite_espa%C3%B1ola,_Op.47_(Alb%C3%A9niz,_Isaac)',
-        label: 'IMSLP — Albéniz: Suite española Op. 47 (Asturias/Leyenda)',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Asturias_(Alb%C3%A9niz)',
-        label: 'Wikipedia — Asturias (Albéniz)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=8INsqtNgNJM',
-        label: 'Andrés Segovia — 1955 classic recording (Decca)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=hUdyZjFNFxA',
-        label: 'John Williams — Sony Classical recording (authoritative modern interpretation)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5qXj2qGPXUSa4wKpDdLHkz',
-        label: 'Andrés Segovia — The Segovia Collection (Deutsche Grammophon)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3MmX8Yz7nRJDcLpWg4AvRF',
-        label: 'John Williams — Spanish Guitar Music (Sony Classical)',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/AlbenizAsturiasLeyendaSegovia1949Recording',
-        label: 'Andrés Segovia — 1949 78rpm historic recording',
-      },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/guitar-competition/albeniz-asturias-leyenda',
@@ -1346,45 +941,15 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Lute_Suite_in_G_minor,_BWV_995_(Bach,_Johann_Sebastian)',
-        label: 'IMSLP — Bach: Lute Suite in G minor BWV 995',
-      },
-      {
-        type: 'wikipedia',
-        url: 'https://en.wikipedia.org/wiki/Lute_suites_(Bach)',
-        label: 'Wikipedia — Bach Lute Suites',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=J-TnAKdnOVk',
-        label: 'John Williams — Sony Classical (guitar transcription)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=8Mv5CqkBCzc',
-        label: 'Julian Bream — EMI recording (classic British guitar interpretation)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/0mvq1wFNRaqH6CAtq7VzrP',
-        label: 'John Williams — The Baroque Album (Sony Classical)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/7a2Xjb8WbU3y4fmPN9oqkT',
-        label: 'Julian Bream — Lute Suites (EMI Classics)',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/BachBWV995LuteSuiteGminorSegovia1945',
-        label: 'Andrés Segovia — 1945 Decca recording (first modern guitar recording)',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/bach-guitar/lute-suite-bwv995-g-minor',
         label: 'RNCM guitar student — Concerto for Guitar Competition entry',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=7A4vR1NFS_I",
+        "label": "Edoardo Lambertenghi — J. S. Bach - Suite in G minor, BWV 995 - Evangelina Mascardi, baroque lute"
+      }
     ],
   },
   {
@@ -1423,45 +988,20 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Lute_suites_(Weiss,_Silvius_Leopold)',
-        label: 'IMSLP — Weiss: Lute Suites',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Silvius_Leopold_Weiss',
         label: 'Wikipedia — Silvius Leopold Weiss',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=sMpFe7CX_mE',
-        label: 'Hopkinson Smith — lute performance (Astrée Auvidis recording)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=EGKntPkn7q0',
-        label: 'Konrad Junghänel — lute (Deutsche Harmonia Mundi)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1Yb9ThKWb7Z4Gn2GWknHLV',
-        label: 'Hopkinson Smith — Weiss Lute Suites (Astrée Auvidis)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3QHmXJo3rKb6ygHDZv0FpK',
-        label: 'Xavier Diaz-Latorre — guitar transcriptions (Harmonia Mundi)',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/WeissLuteSuitesDminorSmithLute',
-        label: 'Hopkinson Smith — archival lute broadcast BBC Radio 3 (1990)',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/weiss-baroque-lute/suite-d-minor-guitar',
         label: 'Schola Cantorum Basiliensis — student lute recital',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=iCt1lF4kZ-o",
+        "label": "Baroque Room — Sylvius Leopold Weiss (1687–1750) - Sonatas for Lute [Robert Barto] [Vol. 1]"
+      }
     ],
   },
   {
@@ -1510,35 +1050,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Antonio Capuzzi',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=a09oBuKsGoA',
-        label: 'Rinat Ibragimov — BBC Philharmonic (BBC recording)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=3vfAWb2DJkw',
-        label: 'Klaus Stoll — Berlin Philharmonic principal bass (studio recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6VtZpFmxKqPB4WeDrFqtHN',
-        label: 'Rinat Ibragimov / BBC Philharmonic — Chandos',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1Mf3nUpQYvRiLZ6wZKpXWp',
-        label: 'Thomas Martin / English Chamber Orchestra — Nimbus Records',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/CapuzziDoubleBassConciertoBBC1961',
-        label: 'BBC Light Music archive — 1961 broadcast recording of Double Bass Concerto',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/doublebass-competition/capuzzi-concerto-f-major',
         label: 'ISB Young Bassist Competition — 2021 junior category finalist',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=WZ9GO_fY8vQ",
+        "label": "String Virtuoso — Capuzzi — Double Bass Concerto (F major), Played by Lorraine Campet, Double Bass. Part 1 of 3."
+      }
     ],
   },
   {
@@ -1577,45 +1097,20 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Concertino_in_A_major_(Nanny,_Edouard)',
-        label: 'IMSLP — Nanny: Concertino in A major for Double Bass',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/%C3%89douard_Nanny',
         label: 'Wikipedia — Édouard Nanny',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=2mfX3kQ_vsc',
-        label: 'Jeff Bradetich — University of North Texas recording',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=wBJHr6ybFow',
-        label: 'Rodion Petrov — Geneva International Competition semifinal (2019)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4dQKH0rSVLYPBTpHJKHxzR',
-        label: 'Gary Karr — Concertos for Double Bass (Delos)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2kFYLTPBwHm3mRq7vN7Jqe',
-        label: 'Timothy Cobb / Orchestra — double bass concertante works recording',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/NannyConcertinoAMajorDBParis1955',
-        label: 'Paris Conservatoire archive — concours performance 1955',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/nanny-double-bass/concertino-a-major',
         label: 'Conservatoire de Paris — prize-winning student recital',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=a_KuAVMB_hM",
+        "label": "sfacademyorchestra — Édouard Nanny (Dragonetti)- Concerto for Double Bass in A Major. Charles Chandler, Andrei Gorbatenko"
+      }
     ],
   },
   {
@@ -1654,45 +1149,20 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Bass_Sonata_(Hindemith,_Paul)',
-        label: 'IMSLP — Hindemith: Sonata for Double Bass and Piano',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Paul_Hindemith#Sonatas',
         label: 'Wikipedia — Hindemith Sonatas (Paul Hindemith)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=D2xQtIr8mus',
-        label: 'Klaus Stoll / Gerhart Hetzel — Berlin Philharmonic principals',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=G9KJhE5Fq7o',
-        label: 'Rinat Ibragimov / Péter Nagy — ISB Convention recital',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5mKL2PXrKBnZoJDGvHqYBX',
-        label: 'Joel Quarrington / Robert Kortgaard — CBC Records',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3rJ7BNt4oP6qFWR2fK5yDh',
-        label: 'Gary Karr / Harmon Lewis — Hindemith Sonatas double bass (Delos)',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/HindemithDoubleBasssonata1952KarrBroadcast',
-        label: 'Gary Karr / Harmon Lewis — 1968 broadcast (ISB historic recording)',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/hindemith-chamber/double-bass-sonata-1949',
         label: 'Hochschule für Musik Frankfurt — graduate recital competition entry',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=tA04KtjWTIE",
+        "label": "ContrebasseClassique — Paul Hindemith – Sonata for Double Bass and Piano"
+      }
     ],
   },
   {
@@ -1731,45 +1201,20 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Harp_Concerto_in_G_minor,_Op.81_(Parish_Alvars,_Elias)',
-        label: 'IMSLP — Parish Alvars: Harp Concerto in G minor Op. 81',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Elias_Parish_Alvars',
         label: 'Wikipedia — Elias Parish Alvars',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=3vF8Wt5U5Ks',
-        label: 'Susanna Mälkki / Fabrice Pierre — BBC Proms harp concerto broadcast',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=TuB7q2Ye0_w',
-        label: 'Xavier de Maistre — Vienna Philharmonic Soloists (Decca recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/4Xk6GpQNsMUz7bZ2vK0ZrB',
-        label: 'Xavier de Maistre / Vienna Chamber Orchestra — Sony Classical',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/1bJfNLV4GPQsW0K2pPvRYQ',
-        label: 'Marisa Robles / Academy of St Martin in the Fields — Chandos',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/ParishAlvarsHarpConcertoGminorBBC1978',
-        label: 'Marisa Robles — BBC Symphony Orchestra broadcast (1978)',
       },
       {
         type: 'soundcloud',
         url: 'https://soundcloud.com/harp-competition/parish-alvars-concerto-gminor',
         label: 'World Harp Congress Competition — finalist performance',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=EVUZoqvNqK8",
+        "label": "KuhlauDilfeng2 — Elias Parish Alvars - Harp Concerto in G-minor, Op.81 (1842)"
+      }
     ],
   },
   {
@@ -1818,35 +1263,15 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Henriette Renié',
       },
       {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=7qVqH3LFsXA',
-        label: "Isabelle Moretti — solo harp recital (Paris Philharmonie)",
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=KNh4dB7PgN8',
-        label: 'Emily Levin — Dallas Symphony principal harp (recital recording)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/2xKJvNGy7wF3R0BmT4fYpC',
-        label: 'Isabelle Moretti — French Harp Music (Harmonia Mundi)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/6pB3wWVRX9YnJzqTZ8mN5D',
-        label: 'Xavier de Maistre — Souvenirs: Harp Favorites (Sony Classical)',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/RenieContemplatioHarpLily1956Paris',
-        label: 'Lily Laskine — 1956 Paris Radio broadcast (historic French harp recording)',
-      },
-      {
         type: 'soundcloud',
         url: 'https://soundcloud.com/harp-conservatory/renie-contemplation-1901',
         label: 'American Harp Society — student competition finalist (2021)',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=CNSS-Ah5yWk",
+        "label": "Mélanie Laurent, Harpiste — Contemplation - Henriette Renié"
+      }
     ],
   },
   {
@@ -1885,45 +1310,20 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'imslp',
-        url: 'https://imslp.org/wiki/Veni,_Veni,_Emmanuel_(MacMillan,_James)',
-        label: 'IMSLP — MacMillan: Veni, Veni, Emmanuel (1992)',
-      },
-      {
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Veni,_Veni,_Emmanuel_(MacMillan)',
         label: 'Wikipedia — Veni, Veni, Emmanuel (MacMillan)',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=K0HEqPscr_o',
-        label: 'Evelyn Glennie / CBSO — 1992 BBC Proms world premiere broadcast',
-      },
-      {
-        type: 'youtube',
-        url: 'https://www.youtube.com/watch?v=t3EUMFGXXYI',
-        label: 'Colin Currie / RSNO — BBC Scotland live broadcast (2010)',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/5nQ7KfFpTyMZjnWpb1VoHC',
-        label: 'Evelyn Glennie / CBSO / Simon Rattle — BMG Classics',
-      },
-      {
-        type: 'spotify',
-        url: 'https://open.spotify.com/album/3jB4ckX9E2WwLrXMfZvKgp',
-        label: 'Colin Currie / Scottish Chamber Orchestra — Linn Records',
-      },
-      {
-        type: 'internet_archive',
-        url: 'https://archive.org/details/MacMillanVeniVeniEmmanuelGlennie1992PromsLive',
-        label: 'Evelyn Glennie — 1992 BBC Proms world premiere (BBC archive broadcast)',
       },
       {
         type: 'vimeo',
         url: 'https://vimeo.com/678901234',
         label: 'Nicholas Collon / Aurora Orchestra — Royal Festival Hall 2019 live stream',
       },
+      {
+        "type": "youtube",
+        "url": "https://www.youtube.com/watch?v=lDIaSm7Rrz4",
+        "label": "Cmaj7 — James MacMillan - Percussion Concerto \"Veni, Veni, Emmanuel\" (1992)"
+      }
     ],
   },
 ];

--- a/src/data/seed-expansion.ts
+++ b/src/data/seed-expansion.ts
@@ -41,7 +41,6 @@ export const expansionPieces: SeedPiece[] = [
       { id: 'e-bach-pass-henle', publisher: 'Henle Verlag', editor: 'Jean-Claude Zehnder', year: 2010, description: 'Urtext edition with practical performance suggestions.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Passacaglia_and_Fugue_in_C_minor,_BWV_582_(Bach,_Johann_Sebastian)', label: 'IMSLP — editions available' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Passacaglia_and_Fugue_in_C_minor,_BWV_582', label: 'Wikipedia — Passacaglia BWV 582' }
     ],
   },
@@ -62,7 +61,6 @@ export const expansionPieces: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Organ_Symphony_No.5,_Op.42_No.1_(Widor,_Charles-Marie)', label: 'IMSLP — editions available' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._5_(Widor)', label: 'Wikipedia — Widor Symphony No. 5' }
     ],
   },
   {
@@ -143,7 +141,6 @@ export const expansionPieces: SeedPiece[] = [
       { id: 'e-ravel-q-durand', publisher: 'Durand', editor: 'Maurice Ravel', year: 1904, description: 'Original publication. The standard performing edition for decades.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet_(Ravel,_Maurice)', label: 'IMSLP — editions available' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_(Ravel)', label: 'Wikipedia — Ravel String Quartet' }
     ],
   },
@@ -163,7 +160,6 @@ export const expansionPieces: SeedPiece[] = [
       { id: 'e-debussy-q-durand', publisher: 'Durand', editor: 'Claude Debussy', year: 1894, description: 'Original edition.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/String_Quartet,_Op.10_(Debussy,_Claude)', label: 'IMSLP — editions available' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_(Debussy)', label: 'Wikipedia — Debussy String Quartet' }
     ],
   },
@@ -226,7 +222,6 @@ export const expansionPieces: SeedPiece[] = [
       { id: 'e-schub-trio2-baren', publisher: 'Bärenreiter', editor: 'Martin Chusid', year: 2003, description: 'New Schubert Edition critical text.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Trio_No.2,_D.929_(Schubert,_Franz)', label: 'IMSLP — editions available' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Trio_No._2_(Schubert)', label: 'Wikipedia — Schubert Piano Trio No. 2' }
     ],
   },

--- a/src/data/seed-piano-violin-new.ts
+++ b/src/data/seed-piano-violin-new.ts
@@ -42,7 +42,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Sonata_No.23,_Op.57_(Beethoven,_Ludwig_van)', label: 'IMSLP — Appassionata Sonata' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Sonata_No._23_(Beethoven)', label: 'Wikipedia — Appassionata Sonata' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Sonata_No._23_(Beethoven)', label: 'Wikipedia — Appassionata Sonata' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=0Ak_7tTxZrk", "label": "Ahmed Barod — Beethoven Sonata N° 23 'Appassionata'   Daniel Barenboim" }
     ],
   },
   {
@@ -125,7 +126,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Scherzo_No.2,_Op.31_(Chopin,_Fr%C3%A9d%C3%A9ric)', label: 'IMSLP — Scherzo No. 2' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Scherzo_No._2_(Chopin)', label: 'Wikipedia — Chopin Scherzo No. 2' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Scherzo_No._2_(Chopin)', label: 'Wikipedia — Chopin Scherzo No. 2' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=OCUSalQf-jY", "label": "Deutsche Grammophon - DG — Seong-Jin Cho – Chopin: Scherzo No. 2 in B Flat Minor, Op. 31" }
     ],
   },
   {
@@ -208,7 +210,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Italian_Concerto,_BWV_971_(Bach,_Johann_Sebastian)', label: 'IMSLP — Italian Concerto' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Italian_Concerto', label: 'Wikipedia — Italian Concerto' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Italian_Concerto', label: 'Wikipedia — Italian Concerto' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=ghTitIMtTCM", "label": "o_o — András Schiff - Bach. Italian Concerto in F BWV971" }
     ],
   },
   {
@@ -312,7 +315,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Jeux_d%27eau_(Ravel,_Maurice)', label: 'IMSLP — Jeux d\'eau' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Jeux_d%27eau_(Ravel)', label: 'Wikipedia — Jeux d\'eau' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Jeux_d%27eau_(Ravel)', label: 'Wikipedia — Jeux d\'eau' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=Z1QrFd7lNcU", "label": "Deutsche Grammophon - DG — Seong-Jin Cho - Ravel: Jeux D'Eau, M.30" }
     ],
   },
   {
@@ -353,7 +357,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Carnaval,_Op.9_(Schumann,_Robert)', label: 'IMSLP — Carnaval' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Carnaval_(Schumann)', label: 'Wikipedia — Carnaval' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Carnaval_(Schumann)', label: 'Wikipedia — Carnaval' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=LNo2aiKV-a0", "label": "Arthur Rubinstein — Schumann - Carnaval, op. 9 - Boris Giltburg" }
     ],
   },
   {
@@ -413,7 +418,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Concerto_No.21_in_C_major,_K.467_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP — Mozart Piano Concerto No. 21' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Concerto_No._21_(Mozart)', label: 'Wikipedia — Mozart Piano Concerto No. 21' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Concerto_No._21_(Mozart)', label: 'Wikipedia — Mozart Piano Concerto No. 21' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=CVKpvD3X6EM", "label": "TheFbiFilesRepeat — Mozart - Piano concerto No 21, Elvira Madigan - Best-of Classical Music" }
     ],
   },
   {
@@ -433,7 +439,6 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/4_Impromptus,_D.899_(Schubert,_Franz)', label: 'IMSLP — Impromptus D. 899' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/4_Impromptus,_Op._90_(Schubert)', label: 'Wikipedia — Schubert Impromptus Op. 90' }
     ],
   },
   {
@@ -454,7 +459,6 @@ export const pianoViolinNew: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Sonata_in_B-flat_major,_D.960_(Schubert,_Franz)', label: 'IMSLP — Schubert Sonata D. 960' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=MAZ8PA5_gVA', label: 'Schubert: Piano Sonata in B-flat Major, D.960' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Sonata_in_B-flat_major,_D._960_(Schubert)', label: 'Wikipedia — Schubert Sonata D. 960' }
     ],
   },
   {
@@ -474,7 +478,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Sonata_No.7,_Op.83_(Prokofiev,_Sergei)', label: 'IMSLP — Prokofiev Sonata No. 7' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Sonata_No._7_(Prokofiev)', label: 'Wikipedia — Prokofiev Sonata No. 7' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Sonata_No._7_(Prokofiev)', label: 'Wikipedia — Prokofiev Sonata No. 7' },
+      { type: 'youtube', url: 'https://www.youtube.com/watch?v=h21KSLqj7HA', label: 'Prok Prok — Prokofiev Piano Sonata No. 7 in B-flat Major, Op. 83, "Stalingrad" (Pollini)' }
     ],
   },
 
@@ -496,7 +501,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Sonata_No.1_in_G_minor,_BWV_1001_(Bach,_Johann_Sebastian)', label: 'IMSLP — Violin Sonata BWV 1001' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonatas_and_Partitas_for_Solo_Violin_(Bach)', label: 'Wikipedia — Bach Solo Violin Works' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonatas_and_Partitas_for_Solo_Violin_(Bach)', label: 'Wikipedia — Bach Solo Violin Works' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=MRKy3kX8XUM", "label": "Netherlands Bach Society — Bach - Violin Sonata no. 1 in G minor BWV 1001 - Sato | Netherlands Bach Society" }
     ],
   },
   {
@@ -516,7 +522,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Concerto_in_A_minor,_BWV_1041_(Bach,_Johann_Sebastian)', label: 'IMSLP — Bach Violin Concerto BWV 1041' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_in_A_minor_(Bach)', label: 'Wikipedia — Bach Violin Concerto in A minor' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_in_A_minor_(Bach)', label: 'Wikipedia — Bach Violin Concerto in A minor' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=Q3-5144TaYg", "label": "Bachology — Hilary Hahn plays J.S.Bach Violin Concerto No.1 in a minor BWV1041-Deutsche Kammerphil. Bremen" }
     ],
   },
   {
@@ -536,7 +543,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/24_Caprices_for_Solo_Violin,_Op.1_(Paganini,_Niccol%C3%B2)', label: 'IMSLP — 24 Caprices' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Caprice_No._24_(Paganini)', label: 'Wikipedia — Paganini Caprice No. 24' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Caprice_No._24_(Paganini)', label: 'Wikipedia — Paganini Caprice No. 24' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=UcL0IsklM3M", "label": "Virtual Sheet Music — Hilary Hahn - Paganini - Caprice 24 - Sheet Music Play Along" }
     ],
   },
   {
@@ -556,7 +564,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/24_Caprices_for_Solo_Violin,_Op.1_(Paganini,_Niccol%C3%B2)', label: 'IMSLP — 24 Caprices' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/24_Caprices_for_Solo_Violin_(Paganini)', label: 'Wikipedia — Paganini 24 Caprices' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/24_Caprices_for_Solo_Violin_(Paganini)', label: 'Wikipedia — Paganini 24 Caprices' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=ZqzHlcYjRRM", "label": "Warner Classics — Paganini: Caprice No.1 for Violin (Augustin Hadelich)" }
     ],
   },
   {
@@ -575,7 +584,8 @@ export const pianoViolinNew: SeedPiece[] = [
       { id: 'e-paganini-c5-peters', publisher: 'Peters', editor: 'Carl Flesch', year: 1930, description: 'Flesch edition with detailed bowing and fingering suggestions.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/24_Caprices_for_Solo_Violin,_Op.1_(Paganini,_Niccol%C3%B2)', label: 'IMSLP — 24 Caprices' }
+      { type: 'imslp', url: 'https://imslp.org/wiki/24_Caprices_for_Solo_Violin,_Op.1_(Paganini,_Niccol%C3%B2)', label: 'IMSLP — 24 Caprices' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=0jXXWBt5URw", "label": "Sumina Studer — N. Paganini Caprice no. 5 | Sumina Studer" }
     ],
   },
   {
@@ -594,7 +604,8 @@ export const pianoViolinNew: SeedPiece[] = [
       { id: 'e-paganini-c9-imi', publisher: 'International Music Company', editor: 'Ruggiero Ricci', year: 1990, description: 'Ricci\'s performance edition with practical solutions for the double-stop passages.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/24_Caprices_for_Solo_Violin,_Op.1_(Paganini,_Niccol%C3%B2)', label: 'IMSLP — 24 Caprices' }
+      { type: 'imslp', url: 'https://imslp.org/wiki/24_Caprices_for_Solo_Violin,_Op.1_(Paganini,_Niccol%C3%B2)', label: 'IMSLP — 24 Caprices' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=Lbzlby9vsPQ", "label": "TheExarion — Niccolò Paganini - Caprice for Solo Violin, Op. 1 No. 9 (Sheet Music)" }
     ],
   },
   {
@@ -613,7 +624,8 @@ export const pianoViolinNew: SeedPiece[] = [
       { id: 'e-paganini-c13-peters', publisher: 'Peters', editor: 'Carl Flesch', year: 1930, description: 'Flesch edition with fingerings and bowings for all 24 Caprices.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/24_Caprices_for_Solo_Violin,_Op.1_(Paganini,_Niccol%C3%B2)', label: 'IMSLP — 24 Caprices' }
+      { type: 'imslp', url: 'https://imslp.org/wiki/24_Caprices_for_Solo_Violin,_Op.1_(Paganini,_Niccol%C3%B2)', label: 'IMSLP — 24 Caprices' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=Ffvww1dqxkU", "label": "Ellingmint — Paganini Caprice no.13 [HQ]" }
     ],
   },
   {
@@ -632,8 +644,8 @@ export const pianoViolinNew: SeedPiece[] = [
       { id: 'e-brahms-vc-imi', publisher: 'International Music Company', editor: 'Joseph Joachim', year: 1905, description: 'Joachim\'s own edition with his cadenza and bowings.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Concerto_in_D_major,_Op.77_(Brahms,_Johannes)', label: 'IMSLP — Brahms Violin Concerto' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_(Brahms)', label: 'Wikipedia — Brahms Violin Concerto' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_(Brahms)', label: 'Wikipedia — Brahms Violin Concerto' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=UFl9xuYP5T8", "label": "hr-Sinfonieorchester – Frankfurt Radio Symphony — Brahms: Violinkonzert ∙ hr-Sinfonieorchester ∙ Hilary Hahn ∙ Paavo Järvi" }
     ],
   },
   {
@@ -653,7 +665,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Concerto_in_D_major,_Op.61_(Beethoven,_Ludwig_van)', label: 'IMSLP — Beethoven Violin Concerto' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_(Beethoven)', label: 'Wikipedia — Beethoven Violin Concerto' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_(Beethoven)', label: 'Wikipedia — Beethoven Violin Concerto' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=cokCgWPRZPg", "label": "Warner Classics — Itzhak Perlman – Beethoven: Violin Concerto (with Daniel Barenboim, Berliner Philharmoniker)" }
     ],
   },
   {
@@ -673,7 +686,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Sonata_No.9,_Op.47_(Beethoven,_Ludwig_van)', label: 'IMSLP — Kreutzer Sonata' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Sonata_No._9_(Beethoven)', label: 'Wikipedia — Kreutzer Sonata' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Sonata_No._9_(Beethoven)', label: 'Wikipedia — Kreutzer Sonata' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=COGcCBJAC6I", "label": "kamngaty — Beethoven.Violin.Sonata.No.9.Op.47.kreutzer.[Anne-Sophie Mutter.-.Lambert.Orkis]" }
     ],
   },
   {
@@ -692,7 +706,6 @@ export const pianoViolinNew: SeedPiece[] = [
       { id: 'e-sibelius-vc-boosey', publisher: 'Boosey & Hawkes', editor: 'Original publication', year: 1905, description: 'The standard Boosey & Hawkes edition.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Concerto_in_D_minor,_Op.47_(Sibelius,_Jean)', label: 'IMSLP — Sibelius Violin Concerto' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=gpS_u5RvMpM', label: 'Sarah Chang plays Sibelius Violin Concerto in D minor' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_(Sibelius)', label: 'Wikipedia — Sibelius Violin Concerto' }
     ],
@@ -714,7 +727,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Zigeunerweisen,_Op.20_(Sarasate,_Pablo_de)', label: 'IMSLP — Zigeunerweisen' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Zigeunerweisen_(Sarasate)', label: 'Wikipedia — Zigeunerweisen' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Zigeunerweisen_(Sarasate)', label: 'Wikipedia — Zigeunerweisen' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=ufIlOXXMqs0", "label": "PHOENIX — Itzhak Perlman - Pablo de Sarasate, Zigeunerweisen Op.20" }
     ],
   },
   {
@@ -734,7 +748,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Concerto_No.1,_Op.26_(Bruch,_Max)', label: 'IMSLP — Bruch Violin Concerto No. 1' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_No._1_(Bruch)', label: 'Wikipedia — Bruch Violin Concerto No. 1' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_No._1_(Bruch)', label: 'Wikipedia — Bruch Violin Concerto No. 1' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=KDJ6Wbzgy3E", "label": "hr-Sinfonieorchester – Frankfurt Radio Symphony — Bruch: 1. Violinkonzert ∙ hr-Sinfonieorchester ∙ Hilary Hahn ∙ Andrés Orozco-Estrada" }
     ],
   },
   {
@@ -775,7 +790,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Concerto_No.3_in_G_major,_K.216_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP — Mozart Violin Concerto No. 3' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_No._3_(Mozart)', label: 'Wikipedia — Mozart Violin Concerto No. 3' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_No._3_(Mozart)', label: 'Wikipedia — Mozart Violin Concerto No. 3' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=IhQAtkXOK6o", "label": "Violin Express — Mozart: Violin Concerto No. 3 - Hilary Hahn /Gustavo Dudamel /Stuttgart Radio Symphony Orchestra" }
     ],
   },
   {
@@ -794,8 +810,8 @@ export const pianoViolinNew: SeedPiece[] = [
       { id: 'e-ss-irc-imi', publisher: 'International Music Company', editor: 'Zino Francescatti', year: 1958, description: 'Francescatti\'s performance edition.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Introduction_et_Rondo_capriccioso,_Op.28_(Saint-Sa%C3%ABns,_Camille)', label: 'IMSLP — Introduction and Rondo Capriccioso' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Introduction_and_Rondo_Capriccioso', label: 'Wikipedia — Introduction and Rondo Capriccioso' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Introduction_and_Rondo_Capriccioso', label: 'Wikipedia — Introduction and Rondo Capriccioso' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=8UTq1eZrDkI", "label": "Malta Philharmonic Orchestra — Introduction and Rondo Capriccioso Op.28, Saint-Saëns - Ray Chen & Malta Philharmonic Orchestra" }
     ],
   },
   {
@@ -815,7 +831,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Praeludium_and_Allegro_(Kreisler,_Fritz)', label: 'IMSLP — Praeludium and Allegro' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Fritz_Kreisler', label: 'Wikipedia — Fritz Kreisler' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Fritz_Kreisler', label: 'Wikipedia — Fritz Kreisler' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=nyCjUPoAFX4", "label": "Heifetz International Music Institute — Kreisler: Praeludium & Allegro | SoHyun Ko, violin; Miki Aoki, piano" }
     ],
   },
 
@@ -839,7 +856,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Sonata_No.32,_Op.111_(Beethoven,_Ludwig_van)', label: 'IMSLP — Beethoven Sonata Op. 111' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Sonata_No._32_(Beethoven)', label: 'Wikipedia — Beethoven Sonata No. 32' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Sonata_No._32_(Beethoven)', label: 'Wikipedia — Beethoven Sonata No. 32' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=8AQ9hZTpgwM", "label": "Klassische Musik — Beethoven - Piano Sonata No.32 in C minor, Op.111 | Evgeny Kissin" }
     ],
   },
 
@@ -860,8 +878,8 @@ export const pianoViolinNew: SeedPiece[] = [
       { id: 'e-wieniawski-pb1-pwm', publisher: 'PWM Edition', editor: 'Irena Dubiska', year: 1965, description: 'Polish critical edition based on first publication.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Polonaise_brillante_No.1,_Op.4_(Wieniawski,_Henryk)', label: 'IMSLP — Polonaise brillante No. 1' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Henryk_Wieniawski', label: 'Wikipedia — Wieniawski' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Henryk_Wieniawski', label: 'Wikipedia — Wieniawski' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=0UPrGttumdw", "label": "Bomsori 김봄소리 — Wieniawski Polonaise in D major, Op.4 - Bomsori Kim 김봄소리" }
     ],
   },
   {
@@ -902,7 +920,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphonie_espagnole,_Op.21_(Lalo,_%C3%89douard)', label: 'IMSLP — Symphonie espagnole' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphonie_espagnole', label: 'Wikipedia — Symphonie espagnole' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphonie_espagnole', label: 'Wikipedia — Symphonie espagnole' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=NJMxCmHjsn4", "label": "Itzhak Perlman - Topic — Lalo: Symphonie espagnole, Op. 21: I. Allegro non troppo" }
     ],
   },
   {
@@ -922,7 +941,8 @@ export const pianoViolinNew: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Tha%C3%AFs_(Massenet,_Jules)', label: 'IMSLP — Thaïs' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Tha%C3%AFs_(opera)', label: 'Wikipedia — Thaïs' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Tha%C3%AFs_(opera)', label: 'Wikipedia — Thaïs' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=7QtGOWemQhY", "label": "Rusanda Panfili — Jules Massenet - Meditation from Thais for Violin and Piano" }
     ],
   },
 
@@ -943,8 +963,8 @@ export const pianoViolinNew: SeedPiece[] = [
       { id: 'e-telemann-ff1-henle', publisher: 'Henle Verlag', editor: 'Marion Beyer', year: 2016, description: 'Urtext with detailed source commentary.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/12_Fantasias_for_Solo_Flute,_TWV_40:2-13_(Telemann,_Georg_Philipp)', label: 'IMSLP — 12 Fantasias for Solo Flute' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/12_Fantasias_for_Solo_Flute_(Telemann)', label: 'Wikipedia — Telemann Flute Fantasias' }
+      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/12_Fantasias_for_Solo_Flute_(Telemann)', label: 'Wikipedia — Telemann Flute Fantasias' },
+      { "type": "youtube", "url": "https://www.youtube.com/watch?v=Yni2mEgVFqM", "label": "Flutist Yubeen Kim Official — Georg Philipp Telemann, Fantasia No.1 in A major TWV 40:2 플루트 김유빈" }
     ],
   }
     ];

--- a/src/data/seed.ts
+++ b/src/data/seed.ts
@@ -60,8 +60,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=PCicM6i59_I', label: 'Bach Cello Suite No.1 - Prelude' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=DwHpDOWhkGk', label: 'Bach - Cello Suite No. 1 in G Major BWV1007 - Mov. 1-3/6' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Suites_(Bach)', label: 'Wikipedia — Cello Suites' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/61dYvvfIRtIDFuqZypPAta', label: 'Yo-Yo Ma — Prelude' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/1FkFiOLin8DIUgIdALwO9n', label: 'Mstislav Rostropovich — Prelude' },
       { type: 'internet_archive', url: 'https://archive.org/details/01No.1InGBwv10071.PreludeModerato', label: 'Pablo Casals — Prelude (historic recording)' },
       { type: 'internet_archive', url: 'https://archive.org/details/bach-j.s.-suites-for-cello-cello-bwv-1007-1012-pierre-fournier', label: 'Pierre Fournier — Complete Cello Suites' },
       { type: 'vimeo', url: 'https://vimeo.com/557158390', label: 'Jean-Guihen Queyras — Prelude (video)' },
@@ -91,12 +89,8 @@ export const seedPieces: SeedPiece[] = [
       { id: 'e-dvorak-cc-barenreiter', publisher: 'Bärenreiter', editor: 'Jonathan Del Mar', year: 2016, description: 'New critical edition with detailed source commentary and performance suggestions.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Concerto_in_B_minor,_Op.104_(Dvo%C5%99%C3%A1k,_Anton%C3%ADn)', label: 'IMSLP — Dvořák Cello Concerto' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=FVKb3DwPFA8', label: 'Gautier Capuçon | Dvořák: Cello Concerto' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_(Dvo%C5%99%C3%A1k)', label: 'Wikipedia — Dvořák Cello Concerto' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0IQ2wNbgTMGCVh2R0RYtY4', label: 'Kian Soltani / Barenboim / Staatskapelle Berlin' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0nE5LAhlotmOrADLNeU5n9', label: 'Rostropovich / Karajan / Berliner Philharmoniker' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0DQsuhP1UeQqT1ru5u7rF2', label: 'Jacqueline du Pré — Dvorak Cello Concerto' },
       { type: 'internet_archive', url: 'https://archive.org/details/DvorakCelloConcertoInBMinorOp.104', label: 'Rostropovich / Karajan — 1968 recording' },
       { type: 'internet_archive', url: 'https://archive.org/details/DvorakCelloConcerto-Piatigorsky', label: 'Piatigorsky / Ormandy / Philadelphia — 1946' },
     ],
@@ -127,8 +121,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Sonata_No.14,_Op.27_No.2_(Beethoven,_Ludwig_van)', label: 'IMSLP — Moonlight Sonata' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=4Tr0otuiQuU', label: 'Beethoven - Moonlight Sonata' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Sonata_No._14_(Beethoven)', label: 'Wikipedia — Moonlight Sonata' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/4HYkUtgKploAEhKbUqHa8w', label: 'Daniel Barenboim — III. Presto agitato' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/3DNRdudZ2SstnDCVKFdXxG', label: 'Paul Lewis — I. Adagio sostenuto' },
       { type: 'internet_archive', url: 'https://archive.org/details/beethoven-moonlight-sonata-horowitz-1947', label: 'Vladimir Horowitz — 1947 RCA (historic)' },
       { type: 'internet_archive', url: 'https://archive.org/details/BeethovenPianoSonataNo.14moonlightrubinstein', label: 'Arthur Rubinstein — 1962' },
       { type: 'vimeo', url: 'https://vimeo.com/36754749', label: 'Khatia Buniatishvili — Masterclass performance' },
@@ -159,8 +151,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Ballade_No.1,_Op.23_(Chopin,_Fr%C3%A9d%C3%A9ric)', label: 'IMSLP — Ballade No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Ballade_No._1_(Chopin)', label: 'Wikipedia — Chopin Ballade No. 1' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=BSFNl4roGlI', label: 'Chopin - Ballade No.1 in G minor, Op.23 (Krystian Zimerman)' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7pLC3L3hscXCEA5iCKY4EN', label: 'Seong-Jin Cho — 2015 Chopin Competition winner' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/5Ks5ENUFNQDfaqxjZnCkVJ', label: 'Krystian Zimerman' },
       { type: 'internet_archive', url: 'https://archive.org/details/ChopinBalladeNo.1InGMinorOp.23richterPrague1960', label: 'Sviatoslav Richter — Live Prague 1960 (landmark)' },
     ],
   },
@@ -182,8 +172,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Etudes,_Op.10_(Chopin,_Fr%C3%A9d%C3%A9ric)', label: 'IMSLP — Études Op. 10' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=g0hoN6_HDVU', label: 'Chopin: Etudes Op.10 and Op.25' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/3T97YpxIHTRBfoqY5FX4AR', label: 'Maurizio Pollini — Etude No. 1' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0LwEwG9XjaVfmZ4VpOyQat', label: 'Seong-Jin Cho — Chopin Competition' },
       { type: 'internet_archive', url: 'https://archive.org/details/20220922-chopin-etudes-opp.-10-25-maurizio-pollini', label: 'Maurizio Pollini — Complete Etudes' },
       { type: 'internet_archive', url: 'https://archive.org/details/CHOPINEtudes-Cortot-NEWTRANSFER', label: 'Alfred Cortot — 1933 (remastered)' },
     ],
@@ -207,8 +195,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Suite_bergamasque_(Debussy,_Claude)', label: 'IMSLP — Suite bergamasque' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=CvFH_6DNRCY', label: 'CLAUDE DEBUSSY:  CLAIR DE LUNE' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Suite_bergamasque', label: 'Wikipedia — Suite bergamasque' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/1cmigB9I6IRpFqjIbzvSQB', label: 'Alice Sara Ott — Suite bergamasque' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0JqCZH9a6xWjiw68rNwxG2', label: 'Hayato Sumino — Clair de Lune' },
       { type: 'internet_archive', url: 'https://archive.org/details/pascal-roge-debussy-clair-de-lune', label: 'Pascal Rogé — Clair de lune' },
       { type: 'vimeo', url: 'https://vimeo.com/193024034', label: 'Sarah Chapeskie — Conservatory Canada Convocation 2016' },
     ],
@@ -235,10 +221,7 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Partita_No.2_in_D_minor,_BWV_1004_(Bach,_Johann_Sebastian)', label: 'IMSLP — Partita No. 2' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonatas_and_Partitas_for_Solo_Violin_(Bach)', label: 'Wikipedia — Bach Solo Violin Works' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=pnK6R5ej6Hg', label: 'Bach - Violin Partita no. 2 in D minor BWV 1004 - Sato | Netherlands Bach Society' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7IVkyo8IVhPsRuZwdfpoLo', label: 'Hilary Hahn — Ciaccona (1997)' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0c8ylcOCPdmcQuBlULkzlx', label: 'Ray Chen — Chaconne' },
       { type: 'internet_archive', url: 'https://archive.org/details/BachPartitaForSoloViolinNo.2InDMinorBwv1004', label: 'Jascha Heifetz — Complete Partita No. 2 (1952)' },
-      { type: 'vimeo', url: 'https://vimeo.com/113908045', label: 'Lisa Fujita — Chaconne, New England Conservatory 2014' },
     ],
     movements: [
       { name: 'I. Allemanda' },
@@ -267,8 +250,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Concerto_in_E_minor,_Op.64_(Mendelssohn,_Felix)', label: 'IMSLP — Mendelssohn Violin Concerto' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_(Mendelssohn)', label: 'Wikipedia — Mendelssohn Violin Concerto' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=I03Hs6dwj7E', label: 'Ray Chen Mendelssohn Violin Concerto in E minor, Op. 64' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7y9ygf5AHcHwoSlnhFvF6F', label: 'Hilary Hahn / Oslo Philharmonic' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/6poscVRRM6DOvOO92pcY1e', label: 'Ray Chen / Swedish Radio Symphony' },
       { type: 'internet_archive', url: 'https://archive.org/details/HilaryHahnMendelssohnViolinConcertoInEMinorOp64', label: 'Hilary Hahn — Mendelssohn Violin Concerto' },
       { type: 'internet_archive', url: 'https://archive.org/details/mend-vc-nm-bw', label: 'Nathan Milstein / Bruno Walter — Carnegie Hall 1945' },
     ],
@@ -298,8 +279,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=YuBeBjqKSGQ', label: 'The Magic Flute – Queen of the Night aria' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Der_H%C3%B6lle_Rache_kocht_in_meinem_Herzen', label: 'Wikipedia — Queen of the Night Aria' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/6DJLaCcgjdwCcxBGXJa4wH', label: 'Diana Damrau / Le Cercle De L\'Harmonie' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/2rBGaOX4RpJ223CClciFTc', label: 'Natalie Dessay / Orchestra of the Age of Enlightenment' },
       { type: 'internet_archive', url: 'https://archive.org/details/78_queen-of-the-night-aria_lily-pons-mozart-bruno-walter_gbia0284391a', label: 'Lily Pons / Bruno Walter — 78rpm (historic)' },
     ],
   },
@@ -322,9 +301,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Erlk%C3%B6nig,_D.328_(Schubert,_Franz)', label: 'IMSLP — Erlkönig' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=JS91p-vmSf0', label: 'Fischer-Dieskau / Moore — definitive recording' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Erlk%C3%B6nig_(Schubert)', label: 'Wikipedia — Erlkönig' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0hES7IYAQSwBAPXJeLKcGN', label: 'Dietrich Fischer-Dieskau / Gerald Moore (1965)' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7amy9gggHIGsU7pd8vHZEL', label: 'Ian Bostridge / Julius Drake' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/4oomOHx8NgPq2flBcGxtxD', label: 'Bryn Terfel / Malcolm Martineau' },
       { type: 'internet_archive', url: 'https://archive.org/details/erlkonig-dfd-gm-66-68', label: 'Fischer-Dieskau / Moore — DG 1966-68' },
     ],
   },
@@ -346,7 +322,6 @@ export const seedPieces: SeedPiece[] = [
       { id: 'e-bach-wtc1-bischoff', publisher: 'Kalmus (reprint)', editor: 'Hans Bischoff', year: 1883, description: 'Historic critical edition. Still valued for Bischoff\'s scholarly notes, though superseded by modern Urtexts.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/The_Well-Tempered_Clavier,_Book_1,_BWV_846-869_(Bach,_Johann_Sebastian)', label: 'IMSLP — Well-Tempered Clavier I' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/The_Well-Tempered_Clavier', label: 'Wikipedia — Well-Tempered Clavier' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=gVah1cr3pU0', label: 'Lang Lang – Bach: The Well-Tempered Clavier: Book 1, 1.Prelude C Major, BWV 846' },
     ],
@@ -373,7 +348,6 @@ export const seedPieces: SeedPiece[] = [
       { id: 'e-mozart-fc1-henle', publisher: 'Henle Verlag', editor: 'Henrik Wiese', year: 2013, description: 'Urtext with cadenzas. Includes both historically appropriate and modern cadenza options.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Flute_Concerto_No.1_in_G_major,_K.313/285c_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP — Mozart Flute Concerto No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Flute_Concerto_No._1_(Mozart)', label: 'Wikipedia — Mozart Flute Concerto No. 1' }
     ],
   },
@@ -396,10 +370,6 @@ export const seedPieces: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_(Elgar)', label: 'Wikipedia — Elgar Cello Concerto' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/3PwJLGFcKrecmaRbJQYMSg', label: 'Sheku Kanneh-Mason / LSO / Rattle — BBC Young Musician winner (2020)' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/4cIcY14P7NSdOvpW1wJMev', label: 'Jacqueline du Pré / LSO / Barbirolli — Landmark recording' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0O62RntbSupfaZeryUMml5', label: 'Alisa Weilerstein / Staatskapelle Berlin / Barenboim' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/77rF1FKgWjluNtGCTs8YUz', label: 'Sol Gabetta — Live: Elgar & Martinů' },
       { type: 'internet_archive', url: 'https://archive.org/details/j.duprej.barbirolliliveatprague03011967elgarcelloconcerto', label: 'Jacqueline du Pré / Barbirolli — Live Prague 1967' },
       { type: 'vimeo', url: 'https://vimeo.com/212893480', label: 'Truls Mørk / Concertgebouw — Live Amsterdam 2017' },
     ],
@@ -428,11 +398,7 @@ export const seedPieces: SeedPiece[] = [
       { id: 'e-tchaik-vc-imi', publisher: 'International Music Company', editor: 'David Oistrakh', year: 1965, description: 'Oistrakh\'s performance edition with his own fingerings and bowings. Invaluable practical insights from the greatest interpreter of this concerto.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Concerto_in_D_major,_Op.35_(Tchaikovsky,_Pyotr)', label: 'IMSLP — Tchaikovsky Violin Concerto' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_(Tchaikovsky)', label: 'Wikipedia — Tchaikovsky Violin Concerto' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5Iijzf1oBpKJwatVUb2P7o', label: 'Hilary Hahn / Royal Liverpool PO — Grammy Award winner' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1yI084e5Lz0yNVQNBT4sNa', label: 'Nicola Benedetti / Czech Philharmonic / Hrůša' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0V6V6fwKxTHDrsLLmgW432', label: 'Itzhak Perlman / Philadelphia Orchestra / Ormandy' },
       { type: 'internet_archive', url: 'https://archive.org/details/TCHAIKOVSKYViolinConcerto-Heifetz-NEWTRANSFER', label: 'Jascha Heifetz — Landmark recording (remastered)' },
       { type: 'internet_archive', url: 'https://archive.org/details/TCHAIKOVSKYViolinConcerto-Milstein-NewTransfer', label: 'Nathan Milstein — Historic recording (remastered)' },
     ],
@@ -463,8 +429,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Piano_Concerto_No.2,_Op.18_(Rachmaninoff,_Sergei)', label: 'IMSLP — Rachmaninoff Piano Concerto No. 2' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=rEGOihjqO9w', label: 'Rachmaninoff: Piano Concerto No. 2 — Anna Fedorova' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Concerto_No._2_(Rachmaninoff)', label: 'Wikipedia — Rachmaninoff Piano Concerto No. 2' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/0v3T6fPnrptRXOrd854hIl', label: 'Yuja Wang / LA Philharmonic / Dudamel (2023)' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7fcDQg8prLdJwim6Ey7neB', label: 'Khatia Buniatishvili / Czech Philharmonic / Järvi' },
       { type: 'internet_archive', url: 'https://archive.org/details/RACHMANINOFFPianoConcertoNo.2-Richter', label: 'Sviatoslav Richter — Landmark recording' },
       { type: 'internet_archive', url: 'https://archive.org/details/RACHMANINOFFPianoConcertoNo.2InCMinor-NEWTRANSFER', label: 'Rachmaninoff / Philadelphia Orchestra / Stokowski — 1929 historic' },
     ],
@@ -495,12 +459,7 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.2_in_D_minor,_BWV_1008_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 2' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Suites_(Bach)', label: 'Wikipedia — Bach Cello Suites' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/3oXgDnhVSSNEwWCdobzliC', label: 'Anastasia Kobekina — Prelude (2025)' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/2vO5wNNXjXU28OWp5gyHEO', label: 'Yo-Yo Ma — Prelude' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/79IIPSm0SPeUf4axiNTopk', label: 'Mstislav Rostropovich — Prelude' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2CAPFGnqtqzx5LjuWILaC9', label: 'Alisa Weilerstein — Complete Cello Suites (2020)' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_suites-for-unaccompanied-violoncello-no-1_pablo-casals-johann-sebastian-bach', label: 'Pablo Casals — Suites No. 1 & 2 (historic LP)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/bachcellosuites_rostropovich', label: 'Mstislav Rostropovich — Complete Bach Cello Suites' },
     ],
     movements: [
       { name: 'I. Prelude' },
@@ -530,9 +489,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.3_in_C_major,_BWV_1009_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 3' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=mGQLXRTl3Z0', label: 'Mischa Maisky plays Bach Cello Suite No.1 in G' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Suites_(Bach)', label: 'Wikipedia — Bach Cello Suites' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/6CBJw0LW0MRwNcmqQ3KBNd', label: 'Steven Isserlis — Prelude' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/4HBGaiBz5jIN3qwf6xACmH', label: 'Yo-Yo Ma — Prelude' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/2CAPFGnqtqzx5LjuWILaC9', label: 'Alisa Weilerstein — Complete Cello Suites (2020)' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_suites-for-cello-unaccompanied-no-3-in-c-m_johann-sebastian-bach-pablo-casals', label: 'Pablo Casals — Suites No. 3 & 4 (historic LP)' },
       { type: 'internet_archive', url: 'https://archive.org/details/bach-j.s.-suites-for-cello-cello-bwv-1007-1012-pierre-fournier', label: 'Pierre Fournier — Complete Cello Suites' },
     ],
@@ -564,9 +520,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.4_in_E-flat_major,_BWV_1010_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 4' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Suites_(Bach)', label: 'Wikipedia — Bach Cello Suites' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0dDcSr2vBxvILNB8oTpI01', label: 'Yo-Yo Ma — Prelude' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/1AxgfOUwe0LCmQiwxElEzb', label: 'Anastasia Kobekina — Bach Cello Suites (2025)' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0krN1xBgSqDHCNV3dPADZn', label: 'Emmanuelle Bertrand — Prelude' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_suites-for-cello-unaccompanied-no-3-in-c-m_johann-sebastian-bach-pablo-casals', label: 'Pablo Casals — Suites No. 3 & 4 (historic LP)' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_intgrale-des-six-suites-pour-violoncelle-s_johann-sebastian-bach-janos-starker', label: 'János Starker — Complete Suites (historic)' },
     ],
@@ -597,9 +550,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.5_in_C_minor,_BWV_1011_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 5' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Suites_(Bach)', label: 'Wikipedia — Bach Cello Suites' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7ekIYM7PEFS47LwMes5Y5g', label: 'Yo-Yo Ma — Prelude' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/265LZkpBksnPVvE80mkwOz', label: 'Bruno Philippe — Prelude (2022)' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0SvpN8VUVlR0LmZhiz7zue', label: 'Jean-Guihen Queyras — Prelude (2024)' },
       { type: 'internet_archive', url: 'https://archive.org/details/suite-no.-5-in-c-minor-for-cello', label: 'Frans Helmerson — Suite No. 5 (1974)' },
       { type: 'internet_archive', url: 'https://archive.org/details/bach-j.s.-the-six-suites-for-violoncelo-solo-bwv-1007-1012-nikolaus-harnoncourt-dvg', label: 'Nikolaus Harnoncourt — Complete Suites (baroque cello)' },
     ],
@@ -631,9 +581,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.6_in_D_major,_BWV_1012_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 6' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Suites_(Bach)', label: 'Wikipedia — Bach Cello Suites' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7j8Zvc4SWkmjohXxuraria', label: 'Yo-Yo Ma — Prelude' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/3h5asYrn0bnWSlhfPdzrCh', label: 'Pieter Wispelwey — Sarabande' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/395a36jZL57W6VKFHSMxWX', label: 'Steven Isserlis — Sarabande' },
       { type: 'vimeo', url: 'https://vimeo.com/channels/earlymusic/29470725', label: 'William Skeen — Gavotte (baroque cello)' },
       { type: 'internet_archive', url: 'https://archive.org/details/01-alc-02-bach-cello-suites-2-5-6', label: 'Dimitry Markevitch — Cello Suites 2, 5 & 6' },
     ],
@@ -665,9 +612,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Concerto_No.1_in_C_major,_Hob.VIIb:1_(Haydn,_Joseph)', label: 'IMSLP — Haydn Cello Concerto No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_No._1_(Haydn)', label: 'Wikipedia — Haydn Cello Concerto No. 1' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5lIyZy3BA2mzcQjgobHQva', label: 'Gautier Capuçon / Mahler Chamber Orchestra / Harding' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/5Dcrc4FKYFZ1K2X29d0UpM', label: 'Mstislav Rostropovich / ASMF — Cadenza by Britten' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/07Oij3AVn2iUvRZOq9I8bb', label: 'Yo-Yo Ma / English Chamber Orchestra' },
       { type: 'internet_archive', url: 'https://archive.org/details/HaydnCelloConcertoNo.1InCMajorHob.Viib1', label: 'Mstislav Rostropovich / ASMF (1988)' },
     ],
     movements: [
@@ -694,9 +638,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Concerto_No.2_in_D_major,_Hob.VIIb:2_(Haydn,_Joseph)', label: 'IMSLP — Haydn Cello Concerto No. 2' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_No._2_(Haydn)', label: 'Wikipedia — Haydn Cello Concerto No. 2' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5lIyZy3BA2mzcQjgobHQva', label: 'Gautier Capuçon / Mahler Chamber Orchestra / Harding' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/4YjekQXLEgXAUtIT9u5I3r', label: 'Jacqueline du Pré / LSO / Barbirolli' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7tiAXCvYvxbuqA1pwU0QDn', label: 'Steven Isserlis / COE / Norrington' },
       { type: 'internet_archive', url: 'https://archive.org/details/haydn-cello-concertos-nos.-1-2', label: 'Lynn Harrell / ASMF / Marriner' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_haydn-cello-concerto-in-c-boccherini-cell_jacqueline-du-pr-daniel-barenboim-joseph-h', label: 'Jacqueline du Pré / Barenboim — Haydn & Boccherini (LP)' },
     ],
@@ -725,8 +666,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Concerto_in_A_minor,_Op.129_(Schumann,_Robert)', label: 'IMSLP — Schumann Cello Concerto' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_(Schumann)', label: 'Wikipedia — Schumann Cello Concerto' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/7o54pvt3DHOw6CUgXbMznF', label: 'Gautier Capuçon / Haitink / Chamber Orchestra of Europe — Live (2019)' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/1D18l8wZj2PZ4nzXTYo8ln', label: 'Jacqueline du Pré / Barenboim / New Philharmonia' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_cello-concerto-five-pieces-in-folk-style_robert-schumann-pablo-casals-prades-festiv', label: 'Pablo Casals — Prades Festival (historic)' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_cello-concerto-schelomo-rhapsody-for-ce_leonard-rose-robert-schumann-leonard-berns', label: 'Leonard Rose / Bernstein / New York Philharmonic' },
     ],
@@ -755,8 +694,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Concerto_No.1,_Op.33_(Saint-Sa%C3%ABns,_Camille)', label: 'IMSLP — Saint-Saëns Cello Concerto No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_No._1_(Saint-Sa%C3%ABns)', label: 'Wikipedia — Saint-Saëns Cello Concerto No. 1' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7fypWvEPty7DCveyRNamTN', label: 'Gautier Capuçon / Bringuier / Orchestre Philharmonique de Radio France' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/1sIHqy6vKF4GVsOGrR8H8a', label: 'Han-Na Chang / Rostropovich / LSO' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_two-great-cello-concertos_camille-saintsans-douard-lalo-andr-navarra', label: 'André Navarra / Münch / Orchestre des Concerts Lamoureux' },
       { type: 'internet_archive', url: 'https://archive.org/details/nobel-prize-concert-2021', label: 'Sol Gabetta — 2021 Nobel Prize Concert' },
     ],
@@ -779,10 +716,8 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Sonata_No.1,_Op.38_(Brahms,_Johannes)', label: 'IMSLP — Brahms Cello Sonata No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Sonata_No._1_(Brahms)', label: 'Wikipedia — Brahms Cello Sonata No. 1' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/51om33yZB4mzqP287DSSn2', label: 'Yo-Yo Ma / Emanuel Ax' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0ZtgCxmIDZG1aAs1SEt1FQ', label: 'Jacqueline du Pré / Barenboim' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/3gXrLgst05Onm15YgFv7d7', label: 'Jean-Guihen Queyras / Alexandre Tharaud' },
       { type: 'internet_archive', url: 'https://archive.org/details/20220922-brahms-cello-sonatas-opp.-38-99-mstislav-rostropovich', label: 'Mstislav Rostropovich / Rudolf Serkin' },
+      { type: 'youtube', url: 'https://www.youtube.com/watch?v=J7ecdXzSADE', label: 'stahlsaite — Johannes Brahms: Cello Sonata e minor op. 38' }
     ],
     movements: [
       { name: 'I. Allegro non troppo' },
@@ -807,9 +742,6 @@ export const seedPieces: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_No._1_(Shostakovich)', label: 'Wikipedia — Shostakovich Cello Concerto No. 1' },
-      { type: 'spotify', url: 'https://open.spotify.com/album/5YbrLDgDvaC5i5JqY6fBou', label: 'Sol Gabetta / Lorin Maazel' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0EFVPhrcAJxu4r65BjkveH', label: 'Gautier Capuçon / Gergiev / Mariinsky Orchestra' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/4dLVUG0RvDi1DmwWr48UcP', label: 'Yo-Yo Ma / Nelsons / Boston Symphony' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_concerto-for-cello-in-e-flat-op-107-symph_dmitri-shostakovich-mstislav-rostropovich_0', label: 'Mstislav Rostropovich / Ormandy — 1959 premiere recording' },
     ],
     movements: [
@@ -856,8 +788,6 @@ export const seedPieces: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Sonata,_Op.8_(Kod%C3%A1ly,_Zolt%C3%A1n)', label: 'IMSLP — Kodály Solo Cello Sonata' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonata_for_Solo_Cello_(Kod%C3%A1ly)', label: 'Wikipedia — Kodály Solo Cello Sonata' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/0FQhbYzkI5XiGkjmdBNsII', label: 'Gautier Capuçon' },
-      { type: 'spotify', url: 'https://open.spotify.com/track/7plpqyCO2HlNi4fhIrKctj', label: 'Alisa Weilerstein' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_kodaly-sonata-for-solo-cello-starker-duo_zoltn-kodly-janos-starker-arnold-eidus', label: 'János Starker — Landmark recording' },
     ],
     movements: [
@@ -1125,7 +1055,6 @@ export const seedPieces: SeedPiece[] = [
       { id: 'e-schubert-am-henle', publisher: 'Henle Verlag', editor: 'Walther Dürr', year: 2003, description: 'Urtext from the Neue Schubert-Ausgabe. Faithful to the composer\'s original markings.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/Ellens_Gesang_III,_D.839_(Schubert,_Franz)', label: 'IMSLP — Schubert Ave Maria' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=2bosouX_d8Y', label: 'Schubert - Ave Maria' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Ellens_dritter_Gesang', label: 'Wikipedia — Ave Maria (Schubert)' }
     ],
@@ -1210,7 +1139,6 @@ export const seedPieces: SeedPiece[] = [
     ],
     external_links: [
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=KJ_HHRJf0xg', label: 'Carmen - Habanera' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Habanera_(Carmen)', label: 'Wikipedia — Habanera (Carmen)' }
     ],
   },
   {
@@ -1328,7 +1256,6 @@ export const seedPieces: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Flute_Sonata_in_B_minor,_BWV_1030_(Bach,_Johann_Sebastian)', label: 'IMSLP — Bach Flute Sonata BWV 1030' },
-      { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonata_in_B_minor_for_flute_and_harpsichord', label: 'Wikipedia — Bach Flute Sonata BWV 1030' },
       { type: 'spotify', url: 'https://open.spotify.com/track/5braP1h19lbvUvUZODlP3S', label: 'Emmanuel Pahud / Trevor Pinnock' },
       { type: 'spotify', url: 'https://open.spotify.com/track/7dQGhoFB2FLtOMw7PX6Yzm', label: 'Jean-Pierre Rampal / Robert Veyron-Lacroix' },
       { type: 'internet_archive', url: 'https://archive.org/details/20220123-bach-j.s.-o-flute-sonatas-vol.-1-janet-see-davitt-moroney', label: 'Janet See / Davitt Moroney — Baroque flute (1991)' },
@@ -1465,7 +1392,6 @@ export const seedPieces: SeedPiece[] = [
       { id: 'e-piatti-c1-stainer', publisher: 'Stainer & Bell', editor: 'Original publication', year: 1874, description: 'The original publication. Historical reference.' }
     ],
     external_links: [
-      { type: 'imslp', url: 'https://imslp.org/wiki/12_Caprices,_Op.25_(Piatti,_Alfredo)', label: 'IMSLP — Piatti 12 Caprices' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Alfredo_Piatti', label: 'Wikipedia — Alfredo Piatti' }
     ],
   },


### PR DESCRIPTION
## Summary

The Recordings tab on piece pages was full of broken links — 62% of seed `external_links` (2,665 / 4,265) pointed to non-existent YouTube videos, Spotify albums, IMSLP pages, etc. Most were fabricated IDs from earlier LLM-generated seed expansions that were never validated.

**Two commits:**

- **feat(scripts)** — `validate-seed-urls.ts --fix` now handles multi-line entries (was silently skipping most pruning targets). New `repopulate-recordings.ts` fills missing YouTube links via the YouTube Data API v3: preserves curated entries, queries `composer + title + catalog#`, auto-stops on quota exceeded.
- **fix(seed)** — Stripped 2,639 dead URLs across all `seed*.ts` files. Repopulated 86 pieces with fresh YouTube links from the API. All 1,626 surviving URLs now pass validation.

## State after this PR

- 881 pieces total
- 204 have YouTube links (118 curated + 86 newly fetched)
- 677 still empty (exhausted today's 10k-unit YouTube API quota)

## Follow-up

Continue repopulating at 100 pieces/day with remaining daily quota, or request a quota bump at https://console.cloud.google.com/apis/api/youtube.googleapis.com/quotas (approved to 1M within ~1-2 days is typical) to finish in one run.

Longer-term: consider a scheduled (weekly) revalidator + auto-PR to catch ongoing URL rot.

## Test plan
- [x] Validator pass on all seed files: \`bun run scripts/validate-seed-urls.ts\` — 1626/1626 OK
- [x] \`bun run test\` — 134 pass, 5 pre-existing failures (unrelated, same on \`main\`)
- [ ] Spot-check piece pages in browser — confirm Recordings tab renders only working links

🤖 Generated with [Claude Code](https://claude.com/claude-code)