### PR TITLE
fix: restore soundcloud validation + prune 85 dead URLs dropped by PR #11 merge

### DIFF
--- a/scripts/validate-seed-urls.ts
+++ b/scripts/validate-seed-urls.ts
@@ -70,6 +70,13 @@ async function check(link: Link): Promise<Result> {
       return { ok: true };
     }
 
+    // SoundCloud: oembed returns 404 for missing tracks. Generic HTML fetch always 200s (SPA).
+    if (link.type === 'soundcloud') {
+      const r = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(link.url)}`, { signal: ctrl });
+      if (!r.ok) return { ok: false, reason: `soundcloud oembed ${r.status}` };
+      return { ok: true };
+    }
+
     // Default: GET with redirect follow. HEAD is unreliable on archive.org/IMSLP.
     const r = await fetch(link.url, { signal: ctrl, redirect: 'follow', headers: { 'user-agent': 'irregular-pearl-link-validator/1.0' } });
     if (!r.ok) return { ok: false, reason: `http ${r.status}` };

--- a/src/data/seed-expansion-10.ts
+++ b/src/data/seed-expansion-10.ts
@@ -147,7 +147,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Clarinet_Quintet_in_A_major,_K.581_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP — Clarinet Quintet, K. 581' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Clarinet_Quintet_(Mozart)', label: 'Wikipedia — Clarinet Quintet (Mozart)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/wienerphilharmoniker/mozart-clarinet-quintet-k581', label: 'Vienna Philharmonic Chamber Concert — live recording' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -185,7 +184,6 @@ export const expansionPieces10: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Dieterich_Buxtehude', label: 'Wikipedia — Dieterich Buxtehude' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/rco-amsterdam/buxtehude-praeludium-buxwv-140-organ-concertgebouw', label: 'Concertgebouw organ recital — live recording' },
     ],
   },
   {
@@ -261,7 +259,6 @@ export const expansionPieces10: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Camille_Saint-Sa%C3%ABns', label: 'Wikipedia — Camille Saint-Saëns' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/rco-amsterdam/saint-saens-fantaisie-op101-organ-live', label: 'Concertgebouw organ — live recital recording' },
     ],
   },
   {
@@ -294,7 +291,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Aria_in_Classic_Style_(Grandjany,_Marcel)', label: 'IMSLP — Aria in Classic Style' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Marcel_Grandjany', label: 'Wikipedia — Marcel Grandjany' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/american-harp-society/grandjany-aria-in-classic-style-live', label: 'American Harp Society — live competition recording' },
       { type: 'vimeo', url: 'https://vimeo.com/305012847', label: 'International Harp Contest in Israel — semi-final round' },
     ],
   },
@@ -327,7 +323,6 @@ export const expansionPieces10: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/A_Ceremony_of_Carols', label: 'Wikipedia — A Ceremony of Carols' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/bbc-radio-3/britten-ceremony-of-carols-op28', label: 'BBC Singers — BBC Radio 3 broadcast' },
     ],
   },
   {
@@ -359,7 +354,6 @@ export const expansionPieces10: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Marcel_Tournier', label: 'Wikipedia — Marcel Tournier' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/paris-conservatoire-harp/tournier-au-matin-competition-2019', label: 'Paris Conservatoire Harp Competition — 2019 finalist recording' },
       { type: 'vimeo', url: 'https://vimeo.com/294857602', label: 'World Harp Congress — live round recording' },
     ],
   },
@@ -430,7 +424,6 @@ export const expansionPieces10: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Giovanni_Bottesini', label: 'Wikipedia — Giovanni Bottesini' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/bbc-radio-3/bottesini-elegy-db-recital', label: 'Leon Bosch — BBC Radio 3 recital' },
     ],
   },
   {
@@ -463,7 +456,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Gran_Duo_Concertante_(Bottesini,_Giovanni)', label: 'IMSLP — Gran Duo Concertante' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Giovanni_Bottesini', label: 'Wikipedia — Giovanni Bottesini' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/ard-competition/bottesini-gran-duo-ard-double-bass', label: 'ARD Munich Competition — double bass final (live)' },
     ],
   },
   // === ORCHESTRAL ===
@@ -616,7 +608,6 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'soundcloud', url: 'https://soundcloud.com/wigmore-hall/haydn-string-quartet-op76-fifths-live', label: 'Belcea Quartet — Wigmore Hall live recording' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -694,7 +685,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Suite_gothique,_Op.25_(Bo%C3%ABllmann,_L%C3%A9on)', label: 'IMSLP — Suite gothique, Op. 25' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Suite_gothique', label: 'Wikipedia — Suite gothique' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/rco-amsterdam/boellmann-suite-gothique-live-recital', label: 'Ben van Oosten — Netherlands Organ concert recording' },
     ],
     movements: [
       { name: 'I. Introduction-Choral' },
@@ -733,7 +723,6 @@ export const expansionPieces10: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Esquisses_byzantines_(Mulet,_Henri)', label: 'IMSLP — Esquisses byzantines (incl. Tu es Petra)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Henri_Mulet', label: 'Wikipedia — Henri Mulet' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/paris-conservatoire-organ/mulet-tu-es-petra-live-recital', label: 'International Organ Competition — recital recording' },
     ],
   },
 
@@ -767,7 +756,6 @@ export const expansionPieces10: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Gabriel_Piern%C3%A9', label: 'Wikipedia — Gabriel Pierné' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/american-harp-society/pierne-impromptu-caprice-competition', label: 'American Harp Society National Competition — semi-final round' },
       { type: 'vimeo', url: 'https://vimeo.com/189654023', label: 'International Harp Contest in Israel — round recording' },
     ],
   },
@@ -801,7 +789,6 @@ export const expansionPieces10: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'soundcloud', url: 'https://soundcloud.com/ircam-paris/stockhausen-zyklus-solo-perc-live', label: 'IRCAM — live performance recording (Paris)' },
     ],
   },
 
@@ -910,7 +897,6 @@ export const expansionPieces10: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Reinhold_Gliere', label: 'Wikipedia — Reinhold Glière' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/ard-competition/gliere-intermezzo-tarantella-ard-double-bass', label: 'ARD International Music Competition — double bass round (live)' },
       { type: 'vimeo', url: 'https://vimeo.com/224789115', label: 'BBC Young Musician — double bass category final' },
     ],
   },

--- a/src/data/seed-expansion-11.ts
+++ b/src/data/seed-expansion-11.ts
@@ -175,7 +175,6 @@ export const expansionPieces11: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.4,_Op.90_(Mendelssohn,_Felix)', label: 'IMSLP — Symphony No. 4, Op. 90' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._4_(Mendelssohn)', label: 'Wikipedia — Mendelssohn Symphony No. 4' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/orchestral-classics/mendelssohn-symphony-4-italian', label: 'Orchestral Classics — Italian Symphony highlights' },
     ],
     movements: [
       { name: 'I. Allegro vivace' },

--- a/src/data/seed-expansion-12.ts
+++ b/src/data/seed-expansion-12.ts
@@ -458,7 +458,6 @@ export const expansionPieces12: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Clarinet_Sonatas_(Brahms)', label: 'Wikipedia — Clarinet Sonatas (Brahms)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/classical-music/brahms-clarinet-sonata-op120-1', label: 'Brahms Clarinet Sonata No. 1 — excerpt' },
     ],
     movements: [
       { name: 'I. Allegro appassionato' },
@@ -508,7 +507,6 @@ export const expansionPieces12: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Organ_Sonata_No._1_(Elgar)', label: 'Wikipedia — Organ Sonata No. 1 (Elgar)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/elgar-society/elgar-organ-sonata-op28-trotter', label: 'Thomas Trotter — Live recital recording' },
     ],
     movements: [
       { name: 'I. Allegro maestoso' },
@@ -547,7 +545,6 @@ export const expansionPieces12: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Flor_Peeters', label: 'Wikipedia — Flor Peeters' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/organ-music/peeters-toccata-fugue-hymn-ave-maris-stella', label: 'Student recital — Royal Flemish Conservatory' },
     ],
     movements: [
       { name: 'I. Toccata' },
@@ -633,7 +630,6 @@ export const expansionPieces12: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Gabriel_Piern%C3%A9#Works', label: 'Wikipedia — Gabriel Pierné works' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/classical-harp/pierne-concertstuck-nordmann', label: 'Marielle Nordmann — Concertstück excerpt' },
     ],
   },
 
@@ -708,7 +704,6 @@ export const expansionPieces12: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Jean-Michel_Damase', label: 'Wikipedia — Jean-Michel Damase' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/conservatoire-paris/damase-sonatine-en-trio-conservatoire', label: 'Conservatoire National Supérieur de Paris — student recital' },
     ],
     movements: [
       { name: 'I. Allegretto' },
@@ -787,7 +782,6 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'soundcloud', url: 'https://soundcloud.com/marimba-competition/zivkovic-funny-marimba-competition', label: 'International Marimba Competition finalist — competition recording' },
     ],
     movements: [
       { name: 'I. Crazy' },
@@ -835,7 +829,6 @@ export const expansionPieces12: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'soundcloud', url: 'https://soundcloud.com/classical-guitar/villa-lobos-prelude-1-yang', label: 'Xuefei Yang — Prelude No. 1 excerpt' },
     ],
   },
 
@@ -869,7 +862,6 @@ export const expansionPieces12: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Manuel_Ponce#Guitar_music', label: 'Wikipedia — Manuel Ponce guitar works' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/classical-guitar/ponce-sonata-guitarra-miolin', label: 'Anders Miolin — Ponce Sonata excerpt' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -908,7 +900,6 @@ export const expansionPieces12: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Mario_Castelnuovo-Tedesco#Guitar_sonata', label: 'Wikipedia — Mario Castelnuovo-Tedesco guitar works' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/classical-guitar/castelnuovo-tedesco-sonata-barrueco', label: 'Manuel Barrueco — Sonata Op. 77 excerpt' },
     ],
     movements: [
       { name: 'I. Allegro con spirito' },

--- a/src/data/seed-expansion-13.ts
+++ b/src/data/seed-expansion-13.ts
@@ -73,7 +73,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._1_(Prokofiev)', label: 'Wikipedia -- Symphony No. 1 (Prokofiev)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/mariinsky/prokofiev-symphony-1-classical', label: 'Mariinsky Orchestra -- live broadcast recording' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -153,7 +152,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._1_(Schumann)', label: 'Wikipedia -- Symphony No. 1 (Schumann)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/hr-sinfonieorchester/schumann-symphony-1-spring', label: 'HR-Sinfonieorchester Frankfurt -- broadcast recording' },
     ],
     movements: [
       { name: 'I. Andante un poco maestoso -- Allegro molto vivace' },
@@ -234,7 +232,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quartet_No._2_(Jan%C3%A1%C4%8Dek)', label: 'Wikipedia -- String Quartet No. 2 (Janacek)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/belcea-quartet/janacek-string-quartet-2', label: 'Belcea Quartet -- live recital recording' },
     ],
     movements: [
       { name: 'I. Andante -- Con moto' },
@@ -353,7 +350,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quintet_No.4_in_G_minor,_K.516_(Mozart,_Wolfgang_Amadeus)', label: 'IMSLP -- String Quintet K. 516' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quintet_No._4_(Mozart)', label: 'Wikipedia -- String Quintet No. 4 (Mozart)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/conservatoireparis/mozart-quintet-g-minor-k516', label: 'Paris Conservatoire -- live recital recording' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -431,7 +427,6 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'soundcloud', url: 'https://soundcloud.com/parker-quartet/dvorak-american-quartet-op96', label: 'Parker Quartet -- Boston Conservatory live recital' },
     ],
     movements: [
       { name: 'I. Allegro ma non troppo' },
@@ -474,7 +469,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/11_Chorale_Preludes,_Op.122_(Brahms,_Johannes)', label: 'IMSLP -- Eleven Chorale Preludes, Op. 122' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Eleven_Chorale_Preludes_(Brahms)', label: 'Wikipedia -- Eleven Chorale Preludes (Brahms)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/rcco-organ/brahms-chorale-preludes-op122', label: 'Royal Canadian College of Organists -- recital recording' },
     ],
   },
 
@@ -507,7 +501,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Dietrich_Buxtehude', label: 'Wikipedia -- Dietrich Buxtehude' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/organ-heritage/buxtehude-praeludium-buxwv140', label: 'Lubeck Marienkirche -- historic organ reconstruction recording' },
     ],
   },
 
@@ -541,7 +534,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphonie-Passion,_Op.23_(Dupr%C3%A9,_Marcel)', label: 'IMSLP -- Symphonie-Passion, Op. 23' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Marcel_Dupr%C3%A9', label: 'Wikipedia -- Marcel Dupre' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/orgue-saint-ouen/dupre-symphonie-passion-op23', label: 'Live performance -- Cavaille-Coll organ, Saint-Ouen, Rouen' },
     ],
     movements: [
       { name: 'I. Le Monde dans l\'attente du Sauveur' },
@@ -616,7 +608,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Harp_Concerto_(Ginastera)', label: 'Wikipedia -- Harp Concerto (Ginastera)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/juilliard/ginastera-harp-concerto-juilliard', label: 'Juilliard School -- student concerto competition performance' },
     ],
     movements: [
       { name: 'I. Allegro giusto' },
@@ -653,7 +644,6 @@ export const expansionPieces13: SeedPiece[] = [
       },
     ],
     external_links: [
-      { type: 'soundcloud', url: 'https://soundcloud.com/rncm-harp/britten-suite-for-harp-op83', label: 'RNCM Harp -- student competition recording' },
     ],
     movements: [
       { name: 'I. Overture: Maestoso -- Allegretto -- Maestoso' },
@@ -694,7 +684,6 @@ export const expansionPieces13: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Concertino_for_Harp_and_Orchestra_(Tailleferre,_Germaine)', label: 'IMSLP -- Harp Concertino (Tailleferre)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Germaine_Tailleferre', label: 'Wikipedia -- Germaine Tailleferre' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/cnsm-paris/tailleferre-concertino-harp', label: 'CNSM Paris -- student concerto recital' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -735,7 +724,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Iannis_Xenakis', label: 'Wikipedia -- Iannis Xenakis' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/ard-competition/xenakis-rebonds-ard-percussion', label: 'ARD Competition finalist -- Munich 2017' },
     ],
   },
 
@@ -768,7 +756,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/John_Psathas', label: 'Wikipedia -- John Psathas' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/john-psathas-composer/view-from-olympus-demo', label: 'John Psathas official -- composer recording' },
     ],
   },
 
@@ -801,7 +788,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Kaija_Saariaho', label: 'Wikipedia -- Kaija Saariaho' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/ircam-paris/saariaho-six-japanese-gardens', label: 'IRCAM Paris -- original electronics archive' },
       { type: 'vimeo', url: 'https://vimeo.com/314206792', label: 'International Percussion Competition -- Salzburg 2018 finalist' },
     ],
     movements: [
@@ -846,7 +832,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Manuel_Ponce', label: 'Wikipedia -- Manuel Ponce' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/rcm-guitar/ponce-sonata-romantica', label: 'Royal College of Music -- guitar recital' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -885,7 +870,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Roland_Dyens', label: 'Wikipedia -- Roland Dyens' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/rcm-guitar/dyens-tango-en-skai-student', label: 'Royal College of Music -- guitar student recital' },
     ],
   },
 
@@ -918,7 +902,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Luis_de_Mil%C3%A1n', label: 'Wikipedia -- Luis de Milan' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/rncm-guitar/milan-pavane-renaissance', label: 'RNCM Guitar -- Renaissance music recital' },
     ],
   },
 
@@ -954,7 +937,6 @@ export const expansionPieces13: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Johann_Matthias_Sperger', label: 'Wikipedia -- Johann Matthias Sperger' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/isb-doublebass/sperger-concerto-d-major-student', label: 'International Society of Bassists -- student concerto recording' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },

--- a/src/data/seed-expansion-15.ts
+++ b/src/data/seed-expansion-15.ts
@@ -52,7 +52,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quintet_No.2,_Op.111_(Brahms,_Johannes)', label: 'IMSLP — String Quintet No. 2 Op. 111 (Brahms)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/String_Quintet_No._2_(Brahms)', label: 'Wikipedia — String Quintet No. 2 (Brahms)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/talich-quartet/brahms-string-quintet-op111', label: 'Talich Quartet — studio recording' },
     ],
   },
 
@@ -74,7 +73,6 @@ export const expansionPieces15: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Piano_Quartet_No._1_(Mozart)', label: 'Wikipedia — Piano Quartet No. 1 (Mozart)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/mozarteum-salzburg/mozart-piano-quartet-k478', label: 'Mozarteum Salzburg ensemble — concert recording' },
     ],
     movements: [
       { name: 'I. Allegro' },
@@ -101,7 +99,6 @@ export const expansionPieces15: SeedPiece[] = [
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/String_Quintet_in_C_major,_Op.29_(Beethoven,_Ludwig_van)', label: 'IMSLP — String Quintet Op. 29 (Beethoven)' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/quartetto-italiano/beethoven-string-quintet-op29', label: 'Quintetto Borciani — competition recording' },
     ],
     movements: [
       { name: 'I. Allegro moderato' },
@@ -243,7 +240,6 @@ export const expansionPieces15: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Gabriel_Fauré', label: 'Wikipedia — Gabriel Fauré' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/ecm-records/faure-impromptu-harp', label: 'Tara Minassian — conservatoire prize recording' },
     ],
   },
 
@@ -563,7 +559,6 @@ export const expansionPieces15: SeedPiece[] = [
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Symphony_No.4_in_E-flat_major_(Bruckner,_Anton)', label: 'IMSLP — Symphony No. 4 "Romantic" (Bruckner)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Symphony_No._4_(Bruckner)', label: 'Wikipedia — Bruckner Symphony No. 4 "Romantic"' },
-      { type: 'soundcloud', url: 'https://soundcloud.com/berliner-philharmoniker/bruckner-symphony-4', label: 'Simon Rattle / Berlin Philharmonic — Digital Concert Hall' },
     ],
     movements: [
       { name: 'I. Bewegt, nicht zu schnell (Sonata Allegro)' },

--- a/src/data/seed-expansion-8.ts
+++ b/src/data/seed-expansion-8.ts
@@ -42,11 +42,6 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'IMSLP — Castelnuovo-Tedesco: Guitar Concerto No. 1 Op. 99',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/guitar-concertos/castelnuovo-tedesco-concerto-1',
-        label: 'Conservatory competition performance — guitar and piano',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=dJt12W7_gdY",
         "label": "Rodders — Mario Castelnuovo-Tedesco : Concerto No. 1 in D major for guitar and orchestra Op. 99 (1939)"
@@ -88,11 +83,6 @@ export const expansionPieces8: SeedPiece[] = [
       },
     ],
     external_links: [
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/guitar-masters/villa-lobos-preludes-complete',
-        label: 'Student recital — Royal College of Music',
-      },
       {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=9q7UlMiMQ-s",
@@ -141,11 +131,6 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Federico Moreno Torroba',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/classicalguitar/torroba-sonatina-recital',
-        label: 'RCM guitar diploma recital performance',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=fi3E9fLP4bk",
         "label": "SiccasGuitars — Ana Vidovic plays Sonatina by Federico Moreno Torroba"
@@ -191,11 +176,6 @@ export const expansionPieces8: SeedPiece[] = [
         type: 'imslp',
         url: 'https://imslp.org/wiki/Homenaje_(Falla,_Manuel_de)',
         label: 'IMSLP — de Falla: Homenaje pour le tombeau de Debussy',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/guitarrecitals/de-falla-homenaje',
-        label: 'Conservatory diploma recital recording',
       },
     ],
   },
@@ -245,11 +225,6 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Johann Baptist Vanhal',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/doublebasstudio/vanhal-concerto-d-major',
-        label: 'ISB Competition semifinal recording',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=Dt-bNf6h0tI",
         "label": "London Symphony Orchestra — Vanhal Double Bass Concerto in D Major // Rinat Ibragimov, double bass"
@@ -297,11 +272,6 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Domenico Dragonetti',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/bassrecitals/dragonetti-tarantella-recital',
-        label: 'Conservatoire de Paris student recital',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=hhUyEO3WwMk",
         "label": "Mikyung Sung — \"Dragonetti\" Nanny Double Bass Concerto - I (Mikyung Sung double bass, Inja Choi piano)"
@@ -344,11 +314,6 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/organrecitals/reubke-94th-psalm-cathedral',
-        label: 'Prizewinner — Chartres International Organ Competition',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=U9gCvM7PaYA",
         "label": "organwizard — Gillian Weir- Sonata on the 94th Psalm, by Julius Reubke"
@@ -390,11 +355,6 @@ export const expansionPieces8: SeedPiece[] = [
       },
     ],
     external_links: [
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/organworks/durufle-suite-op5-toccata',
-        label: 'Laureate — St Albans International Organ Competition',
-      },
       {
         type: 'vimeo',
         url: 'https://vimeo.com/344122901',
@@ -443,11 +403,6 @@ export const expansionPieces8: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/organcompetition/alain-litanies-prizewinner',
-        label: 'Finalist — Calgary International Organ Competition',
-      },
-      {
         type: 'vimeo',
         url: 'https://vimeo.com/389274012',
         label: 'Anna Lapwood — King\'s College Cambridge',
@@ -494,11 +449,6 @@ export const expansionPieces8: SeedPiece[] = [
       },
     ],
     external_links: [
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/organrecital/mendelssohn-sonata-3-recital',
-        label: 'FRCO examination recital — Royal College of Organists',
-      },
       {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=hhMvETANi5o",
@@ -599,11 +549,6 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Fauré harp works',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/harprecitals/faure-impromptu-op86',
-        label: 'Conservatoire National Supérieur student recital',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=Imiky1nEx-A",
         "label": "Harpist Hyejin Kim | 하피스트 김혜진 — Gabriel Fauré: Impromptu pour harpe, op. 86"
@@ -649,11 +594,6 @@ export const expansionPieces8: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Louis_Spohr',
         label: 'Wikipedia — Louis Spohr',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/harpcompetition/spohr-fantasy-35-semifinal',
-        label: 'World Harp Congress competition semifinal',
       },
       {
         "type": "youtube",
@@ -708,11 +648,6 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Hindemith chamber music',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/harpmasterworks/hindemith-sonata-harp',
-        label: 'Finalist — Israel International Harp Contest',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=T_YrDOH9ECg",
         "label": "George N. Gianopoulos, composer — Paul Hindemith - Sonata for Harp (1939) [Score-Video]"
@@ -758,11 +693,6 @@ export const expansionPieces8: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Darius_Milhaud#Concertos',
         label: 'Wikipedia — Milhaud concertos',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/percussionworks/milhaud-marimba-concerto-comp',
-        label: 'World Marimba Competition finalist — Stuttgart',
       },
       {
         type: 'vimeo',
@@ -817,11 +747,6 @@ export const expansionPieces8: SeedPiece[] = [
         label: 'Wikipedia — Paul Creston',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/marimbacompetitions/creston-concertino-semifinal',
-        label: 'PASIC Young Artist Competition finalist',
-      },
-      {
         type: 'vimeo',
         url: 'https://vimeo.com/389451203',
         label: 'Timothy Deighton — NMC Recordings premiere session',
@@ -867,11 +792,6 @@ export const expansionPieces8: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Andr%C3%A9_Jolivet',
         label: 'Wikipedia — André Jolivet',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/percussionsolos/jolivet-concerto-perc-chamber',
-        label: 'CNSM Paris student competition recording',
       },
       {
         "type": "youtube",

--- a/src/data/seed-expansion-9.ts
+++ b/src/data/seed-expansion-9.ts
@@ -47,11 +47,6 @@ export const expansionPieces9: SeedPiece[] = [
         label: "Wikipedia — Prélude à l'après-midi d'un faune",
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/debussy-orchestral/prelude-apres-midi-faune',
-        label: 'Paris Conservatoire Orchestra — archival conservatory broadcast',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=Y9iDOt2WbjY",
         "label": "hr-Sinfonieorchester – Frankfurt Radio Symphony — Debussy: Prélude à l’après-midi d’un faune ∙ hr-Sinfonieorchester ∙ Andrés Orozco-Estrada"
@@ -102,11 +97,6 @@ export const expansionPieces9: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/The_Firebird',
         label: 'Wikipedia — The Firebird (Stravinsky)',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/stravinsky-ballets/firebird-suite-1919',
-        label: 'National Youth Orchestra — proms debut broadcast',
       },
       {
         "type": "youtube",
@@ -265,11 +255,6 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Don Quixote (Strauss)',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/strauss-tone-poems/don-quixote-op35',
-        label: 'Munich Philharmonic — conservatory broadcast excerpt',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=5PvCGu2Ue0U",
         "label": "Roc Vela — Don Quixote, Op. 35 - Richard Strauss (Score)"
@@ -322,11 +307,6 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — La Valse (Ravel)',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/ravel-orchestral/la-valse-live-broadcast',
-        label: 'Conservatoire de Paris Orchestra — student broadcast performance',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=CeomfSaTHzc",
         "label": "Berlin Philharmonic Orchestra - Topic — Ravel: La valse, M. 72 - Choreographic poem, for Orchestra: La valse, M. 72"
@@ -368,11 +348,6 @@ export const expansionPieces9: SeedPiece[] = [
       },
     ],
     external_links: [
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/haydn-chamber/emperor-quartet-op76-no3',
-        label: 'Conservatory quartet competition performance',
-      },
       {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=qoWdtGUe5fc",
@@ -483,11 +458,6 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Piano Trio No. 1 (Mendelssohn)',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/chamber-music-archive/mendelssohn-trio-op49',
-        label: 'Leeds International Chamber Music Competition — 2019 finalist',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=-PAFzEnJ6NU",
         "label": "Thomas Hoppe — ATOS Trio: Mendelssohn - Trio no.1 in d-minor, op.49 - live at Wigmore Hall"
@@ -533,11 +503,6 @@ export const expansionPieces9: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/String_Quartet_No._1_(Jan%C3%A1%C4%8Dek)',
         label: 'Wikipedia — String Quartet No. 1 (Janáček)',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/janacek-chamber/string-quartet-1-kreutzer',
-        label: 'International Janáček Festival — competition performance 2022',
       },
       {
         "type": "youtube",
@@ -701,11 +666,6 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Violin Sonata No. 2 (Ravel)',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/ravel-chamber/violin-sonata-no2-blues',
-        label: 'Conservatoire National Supérieur — student recital competition',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=FkIxuxqBBJE",
         "label": "Augustin Hadelich — Augustin Hadelich - Ravel Sonata with Orion Weiss (Live November 2021)"
@@ -751,11 +711,6 @@ export const expansionPieces9: SeedPiece[] = [
         type: 'imslp',
         url: 'https://imslp.org/wiki/Prelude_and_Fugue_in_C_major,_BWV_547_(Bach,_Johann_Sebastian)',
         label: 'IMSLP — Bach: Prelude and Fugue in C major BWV 547',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/bach-organ-works/bwv547-prelude-fugue-cmajor',
-        label: 'Royal College of Organists — student competition performance',
       },
       {
         "type": "youtube",
@@ -805,11 +760,6 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'IMSLP — Handel: Organ Concerto Op. 4 No. 1 HWV 289',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/handel-organ/concerto-op4-no1-gminor',
-        label: 'Royal Academy of Music — period instrument ensemble recital',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=RgoflxWzUNU",
         "label": "TheOmniWasher — Handel - Organ Concerto No.1 Opus 4 in G minor"
@@ -852,11 +802,6 @@ export const expansionPieces9: SeedPiece[] = [
     ],
     external_links: [
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/franck-organ/grande-piece-symphonique-op17',
-        label: 'Conservatoire National Supérieur de Musique — organ diploma recital',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=dkxY3lk3qLQ",
         "label": "Le Sheet Music Boi — César Franck - Grande Pièce Symphonique, Op.17"
@@ -898,11 +843,6 @@ export const expansionPieces9: SeedPiece[] = [
       },
     ],
     external_links: [
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/guitar-competition/albeniz-asturias-leyenda',
-        label: 'GFA International Guitar Competition — 2022 semifinal performance',
-      },
     ],
   },
   {
@@ -940,11 +880,6 @@ export const expansionPieces9: SeedPiece[] = [
       },
     ],
     external_links: [
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/bach-guitar/lute-suite-bwv995-g-minor',
-        label: 'RNCM guitar student — Concerto for Guitar Competition entry',
-      },
       {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=7A4vR1NFS_I",
@@ -991,11 +926,6 @@ export const expansionPieces9: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Silvius_Leopold_Weiss',
         label: 'Wikipedia — Silvius Leopold Weiss',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/weiss-baroque-lute/suite-d-minor-guitar',
-        label: 'Schola Cantorum Basiliensis — student lute recital',
       },
       {
         "type": "youtube",
@@ -1050,11 +980,6 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Antonio Capuzzi',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/doublebass-competition/capuzzi-concerto-f-major',
-        label: 'ISB Young Bassist Competition — 2021 junior category finalist',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=WZ9GO_fY8vQ",
         "label": "String Virtuoso — Capuzzi — Double Bass Concerto (F major), Played by Lorraine Campet, Double Bass. Part 1 of 3."
@@ -1100,11 +1025,6 @@ export const expansionPieces9: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/%C3%89douard_Nanny',
         label: 'Wikipedia — Édouard Nanny',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/nanny-double-bass/concertino-a-major',
-        label: 'Conservatoire de Paris — prize-winning student recital',
       },
       {
         "type": "youtube",
@@ -1154,11 +1074,6 @@ export const expansionPieces9: SeedPiece[] = [
         label: 'Wikipedia — Hindemith Sonatas (Paul Hindemith)',
       },
       {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/hindemith-chamber/double-bass-sonata-1949',
-        label: 'Hochschule für Musik Frankfurt — graduate recital competition entry',
-      },
-      {
         "type": "youtube",
         "url": "https://www.youtube.com/watch?v=tA04KtjWTIE",
         "label": "ContrebasseClassique — Paul Hindemith – Sonata for Double Bass and Piano"
@@ -1204,11 +1119,6 @@ export const expansionPieces9: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Elias_Parish_Alvars',
         label: 'Wikipedia — Elias Parish Alvars',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/harp-competition/parish-alvars-concerto-gminor',
-        label: 'World Harp Congress Competition — finalist performance',
       },
       {
         "type": "youtube",
@@ -1261,11 +1171,6 @@ export const expansionPieces9: SeedPiece[] = [
         type: 'wikipedia',
         url: 'https://en.wikipedia.org/wiki/Henriette_Reni%C3%A9',
         label: 'Wikipedia — Henriette Renié',
-      },
-      {
-        type: 'soundcloud',
-        url: 'https://soundcloud.com/harp-conservatory/renie-contemplation-1901',
-        label: 'American Harp Society — student competition finalist (2021)',
       },
       {
         "type": "youtube",

--- a/src/data/seed.ts
+++ b/src/data/seed.ts
@@ -399,7 +399,6 @@ export const seedPieces: SeedPiece[] = [
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Violin_Concerto_(Tchaikovsky)', label: 'Wikipedia — Tchaikovsky Violin Concerto' },
-      { type: 'internet_archive', url: 'https://archive.org/details/TCHAIKOVSKYViolinConcerto-Heifetz-NEWTRANSFER', label: 'Jascha Heifetz — Landmark recording (remastered)' },
       { type: 'internet_archive', url: 'https://archive.org/details/TCHAIKOVSKYViolinConcerto-Milstein-NewTransfer', label: 'Nathan Milstein — Historic recording (remastered)' },
     ],
     movements: [
@@ -551,7 +550,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.5_in_C_minor,_BWV_1011_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 5' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Suites_(Bach)', label: 'Wikipedia — Bach Cello Suites' },
       { type: 'internet_archive', url: 'https://archive.org/details/suite-no.-5-in-c-minor-for-cello', label: 'Frans Helmerson — Suite No. 5 (1974)' },
-      { type: 'internet_archive', url: 'https://archive.org/details/bach-j.s.-the-six-suites-for-violoncelo-solo-bwv-1007-1012-nikolaus-harnoncourt-dvg', label: 'Nikolaus Harnoncourt — Complete Suites (baroque cello)' },
     ],
     movements: [
       { name: 'I. Prelude' },
@@ -952,7 +950,6 @@ export const seedPieces: SeedPiece[] = [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Nessun_dorma', label: 'Wikipedia — Nessun dorma' },
       { type: 'spotify', url: 'https://open.spotify.com/track/6zagJMi6gpqVQSX8yWNe3F', label: 'Jonathan Tetelman / PKF Prague Philharmonia — Rising star tenor' },
       { type: 'spotify', url: 'https://open.spotify.com/track/74WjYdm3Lvbwnds4thYPUU', label: 'Luciano Pavarotti / Mehta / LPO' },
-      { type: 'internet_archive', url: 'https://archive.org/details/78_nessun-dorma-none-shall-sleep_jussi-bjrling-adami-simoni-puccini-nils-grevilli_gbia7015432a', label: 'Jussi Björling — 1946 historic landmark' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

GitHub's merge of #11 only included parent 2a88136 (the YouTube repopulation commit) and silently dropped parent 7710277 (the SoundCloud oembed check + pruning), leaving ~85 dead SoundCloud URLs on production. Users saw "You have not provided a valid SoundCloud URL" in the embedded player on those pieces.

This PR reapplies the soundcloud oembed check to \`validate-seed-urls.ts\` and re-runs \`--fix\` to remove the URLs.

- 85 dead SoundCloud URLs removed
- 1 real SoundCloud URL remains in seed.ts
- Final validation: 1644/1644 URLs reachable

## Test plan
- [x] \`bun run scripts/validate-seed-urls.ts\` — all URLs OK
- [ ] Spot-check on live site after merge — confirm no more SoundCloud player errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)