### PR TITLE
chore: ignore .claude/ and outreach-emails.csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage/
 .dev.vars
 supabase/.temp/
 .context/
+.claude/
+outreach-emails.csv


### PR DESCRIPTION
## Summary
- Adds `.claude/` (local Claude Code session data) and `outreach-emails.csv` (local outreach working file) to `.gitignore` so they stop showing up as untracked changes.

## Test plan
- [x] `git status` no longer lists `.claude/` or `outreach-emails.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)