### PR TITLE
fix(migration): guard realtime publication drops (no IF EXISTS)

### DIFF
--- a/supabase/migrations/20260419000000_drop_legacy_features.sql
+++ b/supabase/migrations/20260419000000_drop_legacy_features.sql
@@ -2,12 +2,22 @@
 -- Scope: events + event_performances, discussions + reports, activity_log,
 -- applause. See PRD.md for the scoped-down product direction.
 
--- Realtime publication removals (safe if already removed)
-alter publication supabase_realtime drop table if exists public.discussions;
-alter publication supabase_realtime drop table if exists public.activity_log;
-alter publication supabase_realtime drop table if exists public.applause;
-alter publication supabase_realtime drop table if exists public.events;
-alter publication supabase_realtime drop table if exists public.event_performances;
+-- Realtime publication removals (guarded because ALTER PUBLICATION ... DROP
+-- TABLE does not accept IF EXISTS)
+do $$
+declare
+  t text;
+begin
+  for t in select unnest(array['discussions', 'activity_log', 'applause', 'events', 'event_performances'])
+  loop
+    if exists (
+      select 1 from pg_publication_tables
+      where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = t
+    ) then
+      execute format('alter publication supabase_realtime drop table public.%I', t);
+    end if;
+  end loop;
+end $$;
 
 -- Triggers and functions tied to activity emails
 drop trigger if exists on_activity_log_send_email on public.activity_log;


### PR DESCRIPTION
## Summary

Postgres rejects `ALTER PUBLICATION ... DROP TABLE IF EXISTS` — `IF EXISTS` is not supported in that form. The migration from #17 hit a `SQLSTATE 42601` on the first statement when I pushed it.

Fix: replace the five idempotent publication drops with a `DO` block that checks `pg_publication_tables` first, so the migration is safely re-runnable against any environment (including fresh DBs set up from scratch).

## State of the world

- Migration already executed against prod on 2026-04-19 after applying this fix locally.
- Remote `supabase_migrations.schema_migrations` has `20260419000000` recorded as applied.
- This PR aligns the committed file with the version that actually ran.

## Test plan
- [ ] Check out this branch, run `supabase db reset` against a throwaway local DB, confirm migration applies cleanly
- [ ] Verify `pg_publication_tables` shows no dropped tables in `supabase_realtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)