### PR TITLE
docs: piece page is one responsive surface, not two products

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,7 +20,7 @@
 4. **Sentence case everywhere.** Headings, button labels, nav items, tags. Never Title Case, never ALL CAPS, except small kicker eyebrows and the wordmark if set in caps.
 5. **Two weights only.** 400 regular for body; 500 medium for emphasis, headings, button labels, and names. Never 600 or 700. They read as heavy on the quiet surfaces the site uses.
 6. **Ink on parchment or white.** Primary reading is ink on parchment (#FAF8F5). Cards, sidebars, and modals use white (#FFFFFF) for gentle separation. Color is reserved for semantic meaning (warning flags, interpretive accents) and small editorial chrome.
-7. **Mobile and desktop are different products.** The piece page on mobile leads with landmarks and flags above editions and recordings. Desktop can present more discovery-friendly hierarchy. Both are first-class. Neither is a port of the other.
+7. **One responsive page, not two products.** The piece page is a single responsive surface — the same markup and information architecture reflowed across viewports via CSS. Narrow viewports may collapse multi-column sections into stacks and compress chrome, but the content, ordering, and hierarchy are shared. No viewport-specific React branches, no duplicate mobile routes, no "mobile app" inside the web app.
 
 ## Logo / Wordmark
 - **Font:** Instrument Serif italic
@@ -162,3 +162,4 @@ Claude is an executor of this system, not its author. When the system needs to c
 | 2026-04-18 | Two weights only (400, 500) | Adopted from design-system.md. Heavier weights read as loud on parchment surface. |
 | 2026-04-18 | Sentence case everywhere | Codified. Never Title Case, never ALL CAPS except kicker eyebrows and wordmark. |
 | 2026-04-19 | Removed applause, discussion, activity log, events, community directory | Scope narrowed to piece-page-centric knowledge base per PRD revision 2. Artist profile reduced to minimal bio + instruments. |
+| 2026-04-19 | Piece page is one responsive surface, not two products | Reversed principle 7. Maintaining two piece-page products doubles the work and drifts the information architecture. A single page reflowed with CSS keeps content, ordering, and hierarchy shared across viewports. Supersedes PRD.md "Piece page, mobile" language about a separate product. |

--- a/PRD.md
+++ b/PRD.md
@@ -421,17 +421,15 @@ The entities below are the atomic units of the product. Relationships between th
 
 The surfaces below are the user-facing views of the product. Each surface has a job-to-be-done, a primary audience, and a priority tier. Tier 1 surfaces ship in the first public release. Tier 2 surfaces ship in the first nine months. Tier 3 surfaces are planned but not committed.
 
-**Revision 2 narrows Tier 1 to seven surfaces that together support the first real user's daily-use loop and produce the first signed content on the site. Surfaces previously in Tier 1 that do not serve this loop are moved to Tier 2.**
+**Revision 2 narrows Tier 1 to six surfaces that together support the first real user's daily-use loop and produce the first signed content on the site. Surfaces previously in Tier 1 that do not serve this loop are moved to Tier 2. (The piece page is one responsive surface across desktop and mobile; earlier drafts counted it as two.)**
 
 ## **Tier 1 — first release**
 
-### **Piece page, desktop**
+### **Piece page**
 
-Job: the definitive reference for the piece. Audience: the first real user, then performers deciding and preparing, teachers planning, students studying. Primary surface: a single scrollable page, anchored by sections. Header with title, composer, catalog, era pills. Four-axis difficulty panel. One or more signed performer's notes with distinct visual treatment per contributor (single voice in v1, plural as contributors land). Structural landmarks with per-movement flags and signed practice notes. Interpretive schools as a multi-column grid of signed positions. Editions section with a prominent passage-comparison surface. Recordings section organized around landmark tempi. Pedagogical arc section linking prepare-with and natural-next pieces.
+Job: the definitive reference for the piece, from the desk and from the music stand. Audience: the first real user, then performers deciding and preparing, teachers planning, students studying, and the same musician returning on a phone between takes. Primary surface: a single responsive page, anchored by sections. Header with title, composer, catalog, era pills. Four-axis difficulty panel. One or more signed performer's notes with distinct visual treatment per contributor (single voice in v1, plural as contributors land). Structural landmarks with per-movement flags and signed practice notes. Interpretive schools as a multi-column grid of signed positions on wide viewports, collapsing to stacked cards on narrow ones. Editions section with a prominent passage-comparison surface. Recordings section organized around landmark tempi. Pedagogical arc section linking prepare-with and natural-next pieces.
 
-### **Piece page, mobile**
-
-Job: serve the Tuesday-morning-between-takes moment. Audience: musicians practicing, phone on the stand. Primary surface: inverted information hierarchy. Landmarks and flags above the fold; performer's notes and editions below. Compact tab bar (Landmarks, Schools, Editions, Notes — where Notes is the user's own reflections). Cold-start to structural landmarks under one second, on a three-year-old phone on cellular. This is a separate product from the desktop page, not a port.
+The page is one product across viewports, not two. Content, ordering, and hierarchy are shared; narrow viewports reflow multi-column sections into stacks and compress chrome, but do not re-rank sections or hide information. Cold-start to structural landmarks under one second on a three-year-old phone on cellular is a Tier 1 performance target for the shared page, not a separate mobile build.
 
 ### **Structural landmarks**
 


### PR DESCRIPTION
## Summary
- Flip DESIGN.md principle 7 to "One responsive page, not two products" — shared markup, IA, and hierarchy reflowed via CSS
- Merge PRD "Piece page, desktop" + "Piece page, mobile" into a single "Piece page" entry; the <1s landmarks cold-start moves into the shared page as a Tier 1 perf target
- Tier 1 surface count drops from seven to six
- No code changes — the existing piece page already has no mobile-specific branches

## Test plan
- [x] git diff main touches only DESIGN.md and PRD.md
- [x] No references to "Piece page, mobile" or "separate product" remain
- [x] DESIGN.md decisions log has a dated entry for the reversal

Co-Authored-By: Claude Opus 4.7 (1M context)