### PR TITLE
design(piece): move description inline under pills, drop "About this piece" heading

### DIFF
--- a/src/components/PiecePageLayout.astro
+++ b/src/components/PiecePageLayout.astro
@@ -61,6 +61,10 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <span class="pill">{piece.difficulty}</span>
   </div>
 
+  {piece.description && (
+    <p class="piece-intro">{piece.description}</p>
+  )}
+
   {/* ---------- Performer's notes (empty state until schema lands) ---------- */}
   <section class="block">
     <div class="kicker">Performer's notes</div>
@@ -91,14 +95,6 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <div class="kicker">Interpretive schools</div>
     <p class="empty-state">No interpretive schools recorded yet.</p>
   </section>
-
-  {/* ---------- Description (seed content until a richer editorial surface replaces it) ---------- */}
-  {piece.description && (
-    <section class="block">
-      <div class="kicker">About this piece</div>
-      <p class="prose">{piece.description}</p>
-    </section>
-  )}
 
   {/* ---------- Editions ---------- */}
   <section class="block">
@@ -181,14 +177,16 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     margin: 0;
   }
 
-  /* Description prose block (transitional — replaced by richer editorial surfaces) */
-  .prose {
+  /* Piece intro — prose description sitting directly under the metadata pills
+     as part of the piece definition. Transitional content until richer editorial
+     surfaces (performer's notes, schools) replace it. */
+  .piece-intro {
     font-family: var(--font-serif);
     font-size: 16px;
     line-height: var(--lh-serif-prose);
     color: var(--ink);
-    max-width: var(--content-max-editorial);
-    margin: 0;
+    max-width: 640px;
+    margin: 0 0 48px;
   }
 
   /* Movement title */


### PR DESCRIPTION
## Summary

The piece description was rendered as its own section with an "About this piece" kicker, which read as editorial chrome explaining the section rather than letting the prose do the work. Moving it inline so it reads as part of the piece definition itself, directly under the metadata pills.

- Description is serif prose, no heading, no kicker
- New `.piece-intro` class (scoped): Source Serif 4, 16px, serif-prose line-height, 640px max width, 48px bottom margin
- `.prose` class removed (was only used by this section)

Matches the feedback-memory rule: section headings stand alone, no meta-captions. The ensuing section headings ("Performer's notes", "Landmarks", "Editions") are enough; the description above doesn't need one because it's not a section, it's part of the piece header.

## Test plan
- [x] Local render confirms order: pills → piece-intro → Performer's notes kicker → ...
- [x] "About this piece" string removed from rendered HTML
- [ ] Visual QA across all 19 curated pieces on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)