### PR TITLE
design(piece): 4-axis difficulty, movement key+meter, edition types + publisher links

### DIFF
--- a/src/components/PiecePageLayout.astro
+++ b/src/components/PiecePageLayout.astro
@@ -19,12 +19,20 @@
 
 import '../styles/piece-page.css';
 import type { PieceFull } from '../lib/pieces';
+import { difficultyAxes, type DifficultyAxis } from '../data/difficulty-axes';
 
 interface Props {
   piece: PieceFull;
 }
 
 const { piece } = Astro.props;
+const axes = difficultyAxes[piece.id];
+const axisOrder: Array<{ key: keyof typeof axes; label: string }> = [
+  { key: 'technical', label: 'Technical' },
+  { key: 'stamina', label: 'Stamina' },
+  { key: 'interpretive', label: 'Interpretive' },
+  { key: 'ensemble', label: 'Ensemble' },
+];
 
 const composedHint = piece.era && piece.form ? `${piece.era} · ${piece.form}` : (piece.era || piece.form || '');
 
@@ -65,6 +73,26 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <p class="piece-intro">{piece.description}</p>
   )}
 
+  {axes && (
+    <div class="diff-panel">
+      {axisOrder.map(({ key, label }) => {
+        const a: DifficultyAxis = axes[key];
+        return (
+          <div class="diff-axis">
+            <div class="lab">{label}</div>
+            <div class="bars">
+              {[1, 2, 3, 4, 5].map(n => (
+                <span class={n <= a.level ? 'on' : ''}></span>
+              ))}
+            </div>
+            <div class="val">{a.label}</div>
+            <div class="note">{a.note}</div>
+          </div>
+        );
+      })}
+    </div>
+  )}
+
   {/* ---------- Performer's notes (empty state until schema lands) ---------- */}
   <section class="block">
     <div class="kicker">Performer's notes</div>
@@ -76,14 +104,18 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <div class="kicker">Structural landmarks</div>
     {piece.movements && piece.movements.length > 0 ? (
       <div class="movements">
-        {piece.movements.map((m) => (
-          <div class="mvmt">
-            <div class="mvmt-head">
-              <h3 class="mvmt-title">{m.name}</h3>
+        {piece.movements.map((m) => {
+          const meta = [m.key, m.meter].filter(Boolean).join(' · ');
+          return (
+            <div class="mvmt">
+              <div class="mvmt-head">
+                <h3>{m.name}</h3>
+                {meta && <span class="meta">{meta}</span>}
+              </div>
+              <p class="empty-state">Landmarks not yet curated for this movement.</p>
             </div>
-            <p class="empty-state">Landmarks not yet curated for this movement.</p>
-          </div>
-        ))}
+          );
+        })}
       </div>
     ) : (
       <p class="empty-state">Landmarks not yet curated.</p>
@@ -101,15 +133,24 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <div class="kicker">Editions</div>
     {piece.editions.length > 0 ? (
       <div class="editions">
-        {piece.editions.map((e) => (
-          <div class="ed">
-            <div class="ed-body">
-              <h3>{e.publisher}</h3>
-              <div class="meta">{e.editor}{e.year ? ` · ${e.year}` : ''}</div>
-              {e.description && <p class="desc">{e.description}</p>}
-            </div>
-          </div>
-        ))}
+        {piece.editions.map((e) => {
+          const Wrapper: any = e.url ? 'a' : 'div';
+          const wrapProps = e.url ? { href: e.url, target: '_blank', rel: 'noopener', class: 'ed' } : { class: 'ed' };
+          return (
+            <Wrapper {...wrapProps}>
+              <div class="ed-body">
+                <h3>{e.publisher}</h3>
+                <div class="meta">{e.editor}{e.year ? ` · ${e.year}` : ''}</div>
+                {e.description && <p class="desc">{e.description}</p>}
+              </div>
+              {e.type && (
+                <div class="right">
+                  <span class="type-chip">{e.type}</span>
+                </div>
+              )}
+            </Wrapper>
+          );
+        })}
       </div>
     ) : (
       <p class="empty-state">No editions listed yet.</p>
@@ -189,14 +230,6 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     margin: 0 0 48px;
   }
 
-  /* Movement title */
-  .mvmt-title {
-    font-family: var(--font-serif);
-    font-size: 17px;
-    font-weight: 500;
-    margin: 0 0 4px;
-  }
-
   /* External reference list (IMSLP, Wikipedia) */
   .ext-refs {
     list-style: none;
@@ -212,7 +245,7 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     gap: 10px;
   }
 
-  /* Edition card body wrapper (single-column cards for now; kit's right-rail will return when we wire edition-type chips to data) */
+  /* Edition card list */
   .editions {
     display: flex;
     flex-direction: column;
@@ -220,6 +253,16 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
   }
   .ed-body {
     flex: 1;
+  }
+  /* When the edition card is rendered as a link, strip anchor chrome and inherit colour
+     so the kit's .ed card styling stays intact. */
+  a.ed {
+    color: inherit;
+    text-decoration: none;
+  }
+  a.ed:hover .type-chip {
+    background: var(--accent);
+    color: #fff;
   }
 
   /* Responsive */

--- a/src/data/difficulty-axes.ts
+++ b/src/data/difficulty-axes.ts
@@ -1,0 +1,142 @@
+// Four-axis difficulty data for the 19 curated pieces.
+// PRD Tier 1: every piece page carries a Technical / Stamina / Interpretive / Ensemble
+// readout. Values here are first-draft editorial estimates for a cellist audience;
+// when the contributor approval pipeline lands (P1 in TODOS.md), bylined contributors
+// can override per piece.
+//
+// Level convention: 0 = n/a, 1 = Light, 2-3 = Moderate / Intermediate,
+// 4 = Advanced / Demanding, 5 = Professional. Labels are editorial free-text,
+// not mechanically derived from the level.
+
+export interface DifficultyAxis {
+  /** 0 to 5 — bars filled in the UI. 0 renders as empty bars. */
+  level: number;
+  /** Short editorial label shown below the bars (e.g., "Intermediate", "Advanced", "n/a"). */
+  label: string;
+  /** One-line practical note. What makes this axis score what it scores? */
+  note: string;
+}
+
+export interface PieceDifficultyAxes {
+  technical: DifficultyAxis;
+  stamina: DifficultyAxis;
+  interpretive: DifficultyAxis;
+  ensemble: DifficultyAxis;
+}
+
+export const difficultyAxes: Record<string, PieceDifficultyAxes> = {
+  'bach-cello-suite-1': {
+    technical: { level: 3, label: 'Intermediate', note: 'String crossings, bariolage; no extended technique.' },
+    stamina: { level: 2, label: 'Moderate', note: 'Eighteen minutes unaccompanied.' },
+    interpretive: { level: 5, label: 'Advanced', note: 'Implied voices, unmarked phrasing.' },
+    ensemble: { level: 0, label: 'n/a', note: 'Solo work.' },
+  },
+  'bach-cello-suite-2': {
+    technical: { level: 3, label: 'Intermediate', note: 'D-minor range sits comfortably; Sarabande voicing demands attention.' },
+    stamina: { level: 3, label: 'Moderate', note: 'Twenty-two minutes unaccompanied, weight on the bow arm.' },
+    interpretive: { level: 5, label: 'Advanced', note: 'Minor-key shadow, Sarabande gravity, Gigue lift.' },
+    ensemble: { level: 0, label: 'n/a', note: 'Solo work.' },
+  },
+  'bach-cello-suite-3': {
+    technical: { level: 4, label: 'Advanced', note: 'Scalar Prélude passagework and Bourrée agility; C-major sings but exposes everything.' },
+    stamina: { level: 3, label: 'Moderate', note: 'Twenty-three minutes at a more active tempo than the first two.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Extroverted, harmonically rich, popular Bourrées invite cliché.' },
+    ensemble: { level: 0, label: 'n/a', note: 'Solo work.' },
+  },
+  'bach-cello-suite-4': {
+    technical: { level: 4, label: 'Advanced', note: 'E-flat sits less resonantly; intonation and string-crossing precision are load-bearing.' },
+    stamina: { level: 3, label: 'Moderate', note: 'Twenty-five minutes, with the long French-overture Prélude up front.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Sarabande harmonic richness; Prélude architecture.' },
+    ensemble: { level: 0, label: 'n/a', note: 'Solo work.' },
+  },
+  'bach-cello-suite-5': {
+    technical: { level: 5, label: 'Professional', note: 'Scordatura tuning (A string down to G), fugal Prélude, chordal writing.' },
+    stamina: { level: 4, label: 'Demanding', note: 'Twenty-seven minutes; scordatura bow balance and concentration.' },
+    interpretive: { level: 5, label: 'Advanced', note: 'Darkest of the six; single-line Sarabande that holds the audience by nothing.' },
+    ensemble: { level: 0, label: 'n/a', note: 'Solo work.' },
+  },
+  'bach-cello-suite-6': {
+    technical: { level: 5, label: 'Professional', note: 'Written for a five-string instrument; the high register on four strings is brutal.' },
+    stamina: { level: 4, label: 'Demanding', note: 'Thirty minutes, the longest and most physically costly of the set.' },
+    interpretive: { level: 5, label: 'Advanced', note: 'Virtuosic Prélude; Gavottes joyful without becoming glib.' },
+    ensemble: { level: 0, label: 'n/a', note: 'Solo work.' },
+  },
+  'bach-viola-da-gamba-sonata-1': {
+    technical: { level: 3, label: 'Intermediate', note: 'Conservative range, fugal writing; the keyboardist has most of the acrobatics.' },
+    stamina: { level: 2, label: 'Moderate', note: 'About fourteen minutes, four compact movements.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Reads as chamber between equals, not soloist-with-continuo.' },
+    ensemble: { level: 4, label: 'Demanding', note: 'Keyboard is fully written-out; the trio-sonata texture has to breathe together.' },
+  },
+  'bach-viola-da-gamba-sonata-2': {
+    technical: { level: 3, label: 'Intermediate', note: 'Outgoing and song-like; dance rhythms rather than athletic demands.' },
+    stamina: { level: 2, label: 'Moderate', note: 'Sixteen minutes, four movements.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Lyrical B-minor Andante; outer movements dance without slackening.' },
+    ensemble: { level: 4, label: 'Demanding', note: 'Walking-bass keyboard under a singing cello line; tempo alignment is everything.' },
+  },
+  'bach-viola-da-gamba-sonata-3': {
+    technical: { level: 4, label: 'Advanced', note: 'Concerto-like driving figure; double fugue in the finale.' },
+    stamina: { level: 3, label: 'Moderate', note: 'Fifteen minutes at higher density than BWV 1027/1028.' },
+    interpretive: { level: 5, label: 'Advanced', note: 'Darkest of the three; siciliana Adagio; architectural finale.' },
+    ensemble: { level: 5, label: 'Professional', note: 'Concerto-scale, the keyboardist and cellist are genuinely co-soloists.' },
+  },
+  'bach-chaconne-cello-arr': {
+    technical: { level: 5, label: 'Professional', note: 'Double stops and chordal writing adapted into the cello\'s lower register.' },
+    stamina: { level: 4, label: 'Demanding', note: 'Fifteen unbroken minutes; no breath.' },
+    interpretive: { level: 5, label: 'Advanced', note: 'Sixty-four variations arguing with themselves across a single bass pattern.' },
+    ensemble: { level: 0, label: 'n/a', note: 'Solo work.' },
+  },
+  'haydn-cello-concerto-1': {
+    technical: { level: 5, label: 'Professional', note: 'First-movement bariolage, high-register writing, cadenza athletics.' },
+    stamina: { level: 3, label: 'Moderate', note: 'Twenty-five minutes, with tutti rests that let the bow arm recover.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Classical finesse demands light articulation; the piece unmasks poor phrasing.' },
+    ensemble: { level: 3, label: 'Moderate', note: 'Standard concerto coordination with a classical-sized orchestra.' },
+  },
+  'vivaldi-rv-544': {
+    technical: { level: 4, label: 'Advanced', note: 'Baroque idiom; the clef-swap notation ("Il Proteo") demands fluent reading.' },
+    stamina: { level: 2, label: 'Moderate', note: 'Twelve minutes, three short movements.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Baroque articulation and ornamentation; the joke on the page has to still land musically.' },
+    ensemble: { level: 5, label: 'Professional', note: 'Tight duo concerto; violin and cello trade material constantly over string continuo.' },
+  },
+  'saint-saens-cello-concerto-1': {
+    technical: { level: 5, label: 'Professional', note: 'Rapid-fire opening, ricochet bowing, sustained fingerboard work.' },
+    stamina: { level: 3, label: 'Moderate', note: 'Twenty minutes continuous, no breaks between sections.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'French Romantic lyricism inside a compact single-movement arc.' },
+    ensemble: { level: 3, label: 'Moderate', note: 'Concerto coordination; orchestra mostly accompanies rather than dialogues.' },
+  },
+  'elgar-cello-concerto': {
+    technical: { level: 5, label: 'Professional', note: 'Broad lines, register leaps, cadenza demands. Technically taxing across all four movements.' },
+    stamina: { level: 4, label: 'Demanding', note: 'Thirty minutes of emotional weight as much as physical — the cello carries most of it.' },
+    interpretive: { level: 5, label: 'Advanced', note: 'Autumnal color, rubato choices, and the famous cadenza that defines careers.' },
+    ensemble: { level: 4, label: 'Demanding', note: 'Elaborate orchestral dialogue; the Adagio rests on conductor and cellist agreeing on stillness.' },
+  },
+  'strauss-cello-sonata': {
+    technical: { level: 5, label: 'Professional', note: 'Late-Romantic demands; wide-interval writing, sustained lyric lines, brisk finale.' },
+    stamina: { level: 4, label: 'Demanding', note: 'Twenty-eight minutes with both players fully engaged throughout.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Brahmsian vein rather than post-Romantic tone poem; demands restraint, not flash.' },
+    ensemble: { level: 4, label: 'Demanding', note: 'True chamber duo; piano is an equal voice, not accompaniment.' },
+  },
+  'mendelssohn-song-without-words-cello': {
+    technical: { level: 2, label: 'Intermediate', note: 'Technical demands are modest; it is the simplicity that exposes the player.' },
+    stamina: { level: 1, label: 'Light', note: 'Five minutes, single arc.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Sustained singing line; the whole piece is one expressive breath.' },
+    ensemble: { level: 2, label: 'Intermediate', note: 'Piano accompaniment with a clear supporting role.' },
+  },
+  'faure-papillon': {
+    technical: { level: 5, label: 'Professional', note: 'Rapid figuration at controlled speed; the Andantino demands to land cleanly.' },
+    stamina: { level: 1, label: 'Light', note: 'Three minutes of dazzle.' },
+    interpretive: { level: 3, label: 'Moderate', note: 'Short character piece; the interpretive frame is "butterfly" rather than essay.' },
+    ensemble: { level: 2, label: 'Intermediate', note: 'Piano provides simple accompaniment; ensemble asks are minimal.' },
+  },
+  'crumb-sonata-solo-cello': {
+    technical: { level: 4, label: 'Advanced', note: 'Post-Bartók idiom; rhythmic drive, folk-inflected intervallic writing.' },
+    stamina: { level: 3, label: 'Moderate', note: 'Fifteen minutes across three contrasting movements.' },
+    interpretive: { level: 4, label: 'Advanced', note: 'Formal architecture clear; expressive demands are idiomatic 20th-century.' },
+    ensemble: { level: 0, label: 'n/a', note: 'Solo work.' },
+  },
+  'crumb-vox-balaenae': {
+    technical: { level: 5, label: 'Professional', note: 'Extended techniques, harmonics over scordatura tuning, amplified cello bow control.' },
+    stamina: { level: 3, label: 'Moderate', note: 'Twenty-two minutes; physical demands spread across three large sections.' },
+    interpretive: { level: 5, label: 'Advanced', note: 'Graphic notation, staging in masks and blue light; the piece is a theatrical ritual.' },
+    ensemble: { level: 4, label: 'Demanding', note: 'Amplified trio (flute, cello, piano) with graphic-score coordination.' },
+  },
+};

--- a/src/data/seed.ts
+++ b/src/data/seed.ts
@@ -20,6 +20,10 @@ export interface SeedPiece {
     editor: string;
     year: number | null;
     description: string;
+    /** Editorial type per PRD vocabulary. */
+    type?: 'urtext' | 'scholarly' | 'performer' | 'facsimile' | 'critical' | 'practical';
+    /** Outbound link to the edition (IMSLP scan for public-domain originals, publisher catalog for modern). */
+    url?: string;
   }[];
   external_links: {
     type: 'imslp' | 'youtube' | 'wikipedia' | 'spotify' | 'soundcloud' | 'bandcamp' | 'internet_archive' | 'vimeo';
@@ -31,6 +35,10 @@ export interface SeedPiece {
     name: string;
     /** ID of this movement's piece in the catalog, if it exists */
     pieceId?: string;
+    /** Key signature or tonal centre (e.g., "G major", "D minor", "B-flat major"). Omit when free-tonal. */
+    key?: string;
+    /** Time signature or meter description (e.g., "4/4", "3/4", "6/8", "2/2", "graphic notation"). Omit when not applicable. */
+    meter?: string;
   }[];
   /** If this piece IS a movement of a larger work, the parent work's piece ID */
   parentWorkId?: string;
@@ -51,12 +59,15 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'professional',
     description: 'The closing movement of Bach\'s Partita No. 2 for solo violin, a monumental set of variations over a repeating bass pattern. Multiple cello arrangements exist, transposing the work into a register and idiom the cello can sustain; none is canonical. Most cellists work from their own adaptation or a colleague\'s. The Chaconne on cello retains the violin original\'s architectural logic across some sixty-four variations, three movements in one, and has become a staple of solo cello recital programming despite not being written for the instrument.',
     editions: [
-      { id: 'e-bach-chaconne-busch', publisher: 'Schott', editor: 'Hermann Busch (arr.)', year: 1984, description: 'Transcription for solo cello by the Busch brothers\' cellist. Playable in its original key with extensive double stops; a demanding but idiomatic reading.' },
-      { id: 'e-bach-chaconne-isserlis', publisher: 'Faber Music', editor: 'Steven Isserlis (arr.)', year: 2012, description: 'Isserlis\'s own performing arrangement, transposed and lightly adapted for the cello\'s sonority. Printed with his fingerings and a short preface on the adaptation choices.' }
+      { id: 'e-bach-chaconne-busch', publisher: 'Schott', editor: 'Hermann Busch (arr.)', year: 1984, description: 'Transcription for solo cello by the Busch brothers\' cellist. Playable in its original key with extensive double stops; a demanding but idiomatic reading.', type: 'performer', url: 'https://www.schott-music.com/en/' },
+      { id: 'e-bach-chaconne-isserlis', publisher: 'Faber Music', editor: 'Steven Isserlis (arr.)', year: 2012, description: 'Isserlis\'s own performing arrangement, transposed and lightly adapted for the cello\'s sonority. Printed with his fingerings and a short preface on the adaptation choices.', type: 'performer', url: 'https://www.fabermusic.com/sheet-music?q=bach+chaconne+isserlis' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Violin_Partita_No.2_in_D_minor,_BWV_1004_(Bach,_Johann_Sebastian)', label: 'IMSLP — Partita No. 2 (original violin source)' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Partita_for_Violin_No._2_(Bach)', label: 'Wikipedia — Partita No. 2 (Bach)' },
+    ],
+    movements: [
+      { name: 'Chaconne', key: 'D minor', meter: '3/4' },
     ],
   },
   {
@@ -69,28 +80,28 @@ export const seedPieces: SeedPiece[] = [
     form: 'Suite',
     duration_minutes: 20,
     difficulty: 'intermediate',
-    description: 'The first of six suites for unaccompanied cello. Composed during Bach\'s tenure as Kapellmeister in Cothen, the suite consists of six movements: Prelude, Allemande, Courante, Sarabande, Menuets I & II, and Gigue. The Prelude is especially famous for its flowing arpeggiated figures.',
+    description: 'The first of six suites for unaccompanied cello. Composed during Bach\'s tenure as Kapellmeister in Cöthen, the suite consists of six movements: Prélude, Allemande, Courante, Sarabande, Menuets I & II, and Gigue. The Prélude is especially famous for its flowing arpeggiated figures.',
     editions: [
-      { id: 'e-bach-cs1-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Critical Urtext edition based on Anna Magdalena Bach\'s copy. Minimal editorial markings, ideal for informed performers.' },
-      { id: 'e-bach-cs1-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Scholarly edition with facsimile. Includes source comparison appendix and detailed critical commentary.' },
-      { id: 'e-bach-cs1-imi', publisher: 'International Music Company', editor: 'Leonard Rose', year: 1950, description: 'Heavy romantic-era bowings and fingerings. Widely used in American pedagogy but editorially dated.' }
+      { id: 'e-bach-cs1-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Critical Urtext edition based on Anna Magdalena Bach\'s copy. Minimal editorial markings, ideal for informed performers.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Cello+Suites+BWV+1007' },
+      { id: 'e-bach-cs1-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Scholarly edition with facsimile. Includes source comparison appendix and detailed critical commentary.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1007+cello+suites' },
+      { id: 'e-bach-cs1-imi', publisher: 'International Music Company', editor: 'Leonard Rose', year: 1950, description: 'Heavy romantic-era bowings and fingerings. Widely used in American pedagogy but editorially dated.', type: 'performer', url: 'https://www.internationalmusicco.com/' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.1_in_G_major,_BWV_1007_(Bach,_Johann_Sebastian)', label: 'IMSLP — 12 editions available' },
-      { type: 'youtube', url: 'https://www.youtube.com/watch?v=PCicM6i59_I', label: 'Bach Cello Suite No.1 - Prelude' },
+      { type: 'youtube', url: 'https://www.youtube.com/watch?v=PCicM6i59_I', label: 'Bach Cello Suite No.1 - Prélude' },
       { type: 'youtube', url: 'https://www.youtube.com/watch?v=DwHpDOWhkGk', label: 'Bach - Cello Suite No. 1 in G Major BWV1007 - Mov. 1-3/6' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Suites_(Bach)', label: 'Wikipedia — Cello Suites' },
-      { type: 'internet_archive', url: 'https://archive.org/details/01No.1InGBwv10071.PreludeModerato', label: 'Pablo Casals — Prelude (historic recording)' },
+      { type: 'internet_archive', url: 'https://archive.org/details/01No.1InGBwv10071.PreludeModerato', label: 'Pablo Casals — Prélude (historic recording)' },
       { type: 'internet_archive', url: 'https://archive.org/details/bach-j.s.-suites-for-cello-cello-bwv-1007-1012-pierre-fournier', label: 'Pierre Fournier — Complete Cello Suites' },
-      { type: 'vimeo', url: 'https://vimeo.com/557158390', label: 'Jean-Guihen Queyras — Prelude (video)' },
+      { type: 'vimeo', url: 'https://vimeo.com/557158390', label: 'Jean-Guihen Queyras — Prélude (video)' },
     ],
     movements: [
-      { name: 'I. Prelude' },
-      { name: 'II. Allemande' },
-      { name: 'III. Courante' },
-      { name: 'IV. Sarabande' },
-      { name: 'V. Menuet I & II' },
-      { name: 'VI. Gigue' },
+      { name: 'I. Prélude', key: 'G major', meter: '4/4' },
+      { name: 'II. Allemande', key: 'G major', meter: '4/4' },
+      { name: 'III. Courante', key: 'G major', meter: '3/4' },
+      { name: 'IV. Sarabande', key: 'G major', meter: '3/4' },
+      { name: 'V. Menuet I & II', key: 'G major', meter: '3/4' },
+      { name: 'VI. Gigue', key: 'G major', meter: '6/8' },
     ],
   },
   {
@@ -103,11 +114,11 @@ export const seedPieces: SeedPiece[] = [
     form: 'Suite',
     duration_minutes: 22,
     difficulty: 'intermediate',
-    description: 'The second of Bach\'s six suites for unaccompanied cello, set in D minor, lending it a darker and more introspective character than the first suite. The Prelude features a distinctive arpeggiated pattern that unfolds into complex polyphonic writing. The Sarabande is particularly austere and moving, while the closing Gigue provides rhythmic vitality.',
+    description: 'The second of Bach\'s six suites for unaccompanied cello, set in D minor, lending it a darker and more introspective character than the first suite. The Prélude features a distinctive arpeggiated pattern that unfolds into complex polyphonic writing. The Sarabande is particularly austere and moving, while the closing Gigue provides rhythmic vitality.',
     editions: [
-      { id: 'e-bach-cs2-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Critical Urtext based on Anna Magdalena Bach\'s manuscript copy. Clean text with minimal editorial intervention.' },
-      { id: 'e-bach-cs2-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Scholarly edition with comprehensive critical commentary and facsimile comparison from all surviving sources.' },
-      { id: 'e-bach-cs2-wiener', publisher: 'Wiener Urtext', editor: 'Wolfgang Boettcher', year: 2004, description: 'Urtext with practical performance suggestions. Includes bowings that balance historical awareness with modern technique.' }
+      { id: 'e-bach-cs2-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Critical Urtext based on Anna Magdalena Bach\'s manuscript copy. Clean text with minimal editorial intervention.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Cello+Suites+BWV+1008' },
+      { id: 'e-bach-cs2-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Scholarly edition with comprehensive critical commentary and facsimile comparison from all surviving sources.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1008+cello+suite' },
+      { id: 'e-bach-cs2-wiener', publisher: 'Wiener Urtext', editor: 'Wolfgang Boettcher', year: 2004, description: 'Urtext with practical performance suggestions. Includes bowings that balance historical awareness with modern technique.', type: 'urtext' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.2_in_D_minor,_BWV_1008_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 2' },
@@ -115,12 +126,12 @@ export const seedPieces: SeedPiece[] = [
       { type: 'internet_archive', url: 'https://archive.org/details/lp_suites-for-unaccompanied-violoncello-no-1_pablo-casals-johann-sebastian-bach', label: 'Pablo Casals — Suites No. 1 & 2 (historic LP)' },
     ],
     movements: [
-      { name: 'I. Prelude' },
-      { name: 'II. Allemande' },
-      { name: 'III. Courante' },
-      { name: 'IV. Sarabande' },
-      { name: 'V. Menuet I & II' },
-      { name: 'VI. Gigue' },
+      { name: 'I. Prélude', key: 'D minor', meter: '4/4' },
+      { name: 'II. Allemande', key: 'D minor', meter: '4/4' },
+      { name: 'III. Courante', key: 'D minor', meter: '3/4' },
+      { name: 'IV. Sarabande', key: 'D minor', meter: '3/4' },
+      { name: 'V. Menuet I & II', key: 'D minor', meter: '3/4' },
+      { name: 'VI. Gigue', key: 'D minor', meter: '3/8' },
     ],
   },
   {
@@ -133,10 +144,10 @@ export const seedPieces: SeedPiece[] = [
     form: 'Suite',
     duration_minutes: 23,
     difficulty: 'advanced',
-    description: 'The third suite returns to a bright, expansive key and is the most extroverted of the set. The Prelude\'s brilliant scale passages and bariolage figuration exploit the full sonority of the instrument. The Bourrées are among the most popular individual movements from the suites, frequently performed as encores.',
+    description: 'The third suite returns to a bright, expansive key and is the most extroverted of the set. The Prélude\'s brilliant scale passages and bariolage figuration exploit the full sonority of the instrument. The Bourrées are among the most popular individual movements from the suites, frequently performed as encores.',
     editions: [
-      { id: 'e-bach-cs3-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Urtext edition with source-critical apparatus. Part of Henle\'s complete suites volume.' },
-      { id: 'e-bach-cs3-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'New critical edition drawing on all surviving manuscript copies with detailed editorial report.' }
+      { id: 'e-bach-cs3-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Urtext edition with source-critical apparatus. Part of Henle\'s complete suites volume.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Cello+Suites+BWV+1009' },
+      { id: 'e-bach-cs3-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'New critical edition drawing on all surviving manuscript copies with detailed editorial report.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1009+cello+suite' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.3_in_C_major,_BWV_1009_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 3' },
@@ -146,12 +157,12 @@ export const seedPieces: SeedPiece[] = [
       { type: 'internet_archive', url: 'https://archive.org/details/bach-j.s.-suites-for-cello-cello-bwv-1007-1012-pierre-fournier', label: 'Pierre Fournier — Complete Cello Suites' },
     ],
     movements: [
-      { name: 'I. Prelude' },
-      { name: 'II. Allemande' },
-      { name: 'III. Courante' },
-      { name: 'IV. Sarabande' },
-      { name: 'V. Bourrée I & II' },
-      { name: 'VI. Gigue' },
+      { name: 'I. Prélude', key: 'C major', meter: '3/4' },
+      { name: 'II. Allemande', key: 'C major', meter: '4/4' },
+      { name: 'III. Courante', key: 'C major', meter: '3/4' },
+      { name: 'IV. Sarabande', key: 'C major', meter: '3/4' },
+      { name: 'V. Bourrée I & II', key: 'C major', meter: '2/2' },
+      { name: 'VI. Gigue', key: 'C major', meter: '3/8' },
     ],
   },
   {
@@ -164,11 +175,11 @@ export const seedPieces: SeedPiece[] = [
     form: 'Suite',
     duration_minutes: 25,
     difficulty: 'advanced',
-    description: 'The fourth suite marks a shift in technical demands, with the key of E-flat major requiring less resonant string crossings and more careful intonation. The Prelude is a grand, French overture-like movement. The Sarabande is one of Bach\'s most harmonically rich slow movements, and the Bourrées provide spirited contrast.',
+    description: 'The fourth suite marks a shift in technical demands, with the key of E-flat major requiring less resonant string crossings and more careful intonation. The Prélude is a grand, French overture-like movement. The Sarabande is one of Bach\'s most harmonically rich slow movements, and the Bourrées provide spirited contrast.',
     editions: [
-      { id: 'e-bach-cs4-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Urtext based on all surviving sources with minimal editorial additions.' },
-      { id: 'e-bach-cs4-peters', publisher: 'Peters', editor: 'Hugo Becker', year: 1911, description: 'Older pedagogical edition with Romantic-era bowings and fingerings. Historically interesting but editorially heavy.' },
-      { id: 'e-bach-cs4-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Critical edition with facsimile and comprehensive source comparison.' }
+      { id: 'e-bach-cs4-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Urtext based on all surviving sources with minimal editorial additions.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Cello+Suites+BWV+1010' },
+      { id: 'e-bach-cs4-peters', publisher: 'Peters', editor: 'Hugo Becker', year: 1911, description: 'Older pedagogical edition with Romantic-era bowings and fingerings. Historically interesting but editorially heavy.', type: 'performer', url: 'https://imslp.org/wiki/Cello_Suite_No.4_in_E-flat_major,_BWV_1010_(Bach,_Johann_Sebastian)' },
+      { id: 'e-bach-cs4-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Critical edition with facsimile and comprehensive source comparison.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1010+cello+suite' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.4_in_E-flat_major,_BWV_1010_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 4' },
@@ -177,12 +188,12 @@ export const seedPieces: SeedPiece[] = [
       { type: 'internet_archive', url: 'https://archive.org/details/lp_intgrale-des-six-suites-pour-violoncelle-s_johann-sebastian-bach-janos-starker', label: 'János Starker — Complete Suites (historic)' },
     ],
     movements: [
-      { name: 'I. Prelude' },
-      { name: 'II. Allemande' },
-      { name: 'III. Courante' },
-      { name: 'IV. Sarabande' },
-      { name: 'V. Bourrée I & II' },
-      { name: 'VI. Gigue' },
+      { name: 'I. Prélude', key: 'E-flat major', meter: '4/4' },
+      { name: 'II. Allemande', key: 'E-flat major', meter: '4/4' },
+      { name: 'III. Courante', key: 'E-flat major', meter: '3/4' },
+      { name: 'IV. Sarabande', key: 'E-flat major', meter: '3/4' },
+      { name: 'V. Bourrée I & II', key: 'E-flat major', meter: '2/2' },
+      { name: 'VI. Gigue', key: 'E-flat major', meter: '12/8' },
     ],
   },
   {
@@ -195,10 +206,10 @@ export const seedPieces: SeedPiece[] = [
     form: 'Suite',
     duration_minutes: 27,
     difficulty: 'professional',
-    description: 'The fifth suite requires scordatura tuning (the A string lowered to G), giving the instrument a darker, veiled sonority. The Prelude opens with a grave French overture before launching into an elaborate fugue. The Sarabande, built from stark single notes and double stops, is one of Bach\'s most profound slow movements.',
+    description: 'The fifth suite requires scordatura tuning (the A string lowered to G), giving the instrument a darker, veiled sonority. The Prélude opens with a grave French overture before launching into an elaborate fugue. The Sarabande, built from stark single notes and double stops, is one of Bach\'s most profound slow movements.',
     editions: [
-      { id: 'e-bach-cs5-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Urtext with clear notation of scordatura tuning. Source-critical commentary included.' },
-      { id: 'e-bach-cs5-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Critical edition including both scordatura and standard tuning notations with full critical apparatus.' }
+      { id: 'e-bach-cs5-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Urtext with clear notation of scordatura tuning. Source-critical commentary included.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Cello+Suites+BWV+1011' },
+      { id: 'e-bach-cs5-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Critical edition including both scordatura and standard tuning notations with full critical apparatus.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1011+cello+suite' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.5_in_C_minor,_BWV_1011_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 5' },
@@ -206,12 +217,12 @@ export const seedPieces: SeedPiece[] = [
       { type: 'internet_archive', url: 'https://archive.org/details/suite-no.-5-in-c-minor-for-cello', label: 'Frans Helmerson — Suite No. 5 (1974)' },
     ],
     movements: [
-      { name: 'I. Prelude' },
-      { name: 'II. Allemande' },
-      { name: 'III. Courante' },
-      { name: 'IV. Sarabande' },
-      { name: 'V. Gavotte I & II' },
-      { name: 'VI. Gigue' },
+      { name: 'I. Prélude', key: 'C minor', meter: '2/2 & 3/8' },
+      { name: 'II. Allemande', key: 'C minor', meter: '4/4' },
+      { name: 'III. Courante', key: 'C minor', meter: '3/4' },
+      { name: 'IV. Sarabande', key: 'C minor', meter: '3/4' },
+      { name: 'V. Gavotte I & II', key: 'C minor', meter: '2/2' },
+      { name: 'VI. Gigue', key: 'C minor', meter: '3/8' },
     ],
   },
   {
@@ -224,11 +235,11 @@ export const seedPieces: SeedPiece[] = [
     form: 'Suite',
     duration_minutes: 30,
     difficulty: 'professional',
-    description: 'The final and most technically demanding of the six suites, likely written for a five-stringed instrument (viola pomposa or violoncello piccolo). The addition of a high E string allows passages in the soprano register that are extremely challenging on a standard four-string cello. The Prelude is a virtuosic showpiece, and the Gavottes are joyful and dance-like.',
+    description: 'The final and most technically demanding of the six suites, likely written for a five-stringed instrument (viola pomposa or violoncello piccolo). The addition of a high E string allows passages in the soprano register that are extremely challenging on a standard four-string cello. The Prélude is a virtuosic showpiece, and the Gavottes are joyful and dance-like.',
     editions: [
-      { id: 'e-bach-cs6-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Urtext with notes on the five-string instrument question. Part of the complete suites volume.' },
-      { id: 'e-bach-cs6-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Critical edition with extensive discussion of the intended instrument and tuning.' },
-      { id: 'e-bach-cs6-imi', publisher: 'International Music Company', editor: 'Leonard Rose', year: 1950, description: 'Practical edition with Rose\'s fingerings adapted for four-string cello. Standard American pedagogical edition.' }
+      { id: 'e-bach-cs6-henle', publisher: 'Henle Verlag', editor: 'Egon Voss', year: 2000, description: 'Urtext with notes on the five-string instrument question. Part of the complete suites volume.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Cello+Suites+BWV+1012' },
+      { id: 'e-bach-cs6-barenreiter', publisher: 'Bärenreiter', editor: 'Bettina Schwemer & Douglas Woodfull-Harris', year: 2012, description: 'Critical edition with extensive discussion of the intended instrument and tuning.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1012+cello+suite' },
+      { id: 'e-bach-cs6-imi', publisher: 'International Music Company', editor: 'Leonard Rose', year: 1950, description: 'Practical edition with Rose\'s fingerings adapted for four-string cello. Standard American pedagogical edition.', type: 'performer', url: 'https://www.internationalmusicco.com/' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Suite_No.6_in_D_major,_BWV_1012_(Bach,_Johann_Sebastian)', label: 'IMSLP — Cello Suite No. 6' },
@@ -237,12 +248,12 @@ export const seedPieces: SeedPiece[] = [
       { type: 'internet_archive', url: 'https://archive.org/details/01-alc-02-bach-cello-suites-2-5-6', label: 'Dimitry Markevitch — Cello Suites 2, 5 & 6' },
     ],
     movements: [
-      { name: 'I. Prelude' },
-      { name: 'II. Allemande' },
-      { name: 'III. Courante' },
-      { name: 'IV. Sarabande' },
-      { name: 'V. Gavotte I & II' },
-      { name: 'VI. Gigue' },
+      { name: 'I. Prélude', key: 'D major', meter: '12/8' },
+      { name: 'II. Allemande', key: 'D major', meter: '4/4' },
+      { name: 'III. Courante', key: 'D major', meter: '6/8' },
+      { name: 'IV. Sarabande', key: 'D major', meter: '3/2' },
+      { name: 'V. Gavotte I & II', key: 'D major', meter: '2/2' },
+      { name: 'VI. Gigue', key: 'D major', meter: '6/8' },
     ],
   },
   {
@@ -257,18 +268,18 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'advanced',
     description: 'The first of three sonatas composed at Cöthen for viola da gamba and obbligato harpsichord. On modern cello, the piece reads as chamber music between equals rather than soloist-with-continuo: Bach gives the keyboardist a fully written-out right hand that trades material with the cellist throughout. The opening Adagio is lyrical and gently ornamented; the ensuing Allegro ma non tanto is one of Bach\'s most graceful fugues. BWV 1027 survives in an earlier version as the Trio Sonata BWV 1039 for two flutes and continuo, and the gamba sonata can be read as Bach\'s reworking of that material.',
     editions: [
-      { id: 'e-bach-bwv1027-henle', publisher: 'Henle Verlag', editor: 'Hans Eppstein', year: 1987, description: 'Urtext edition with separate cello and harpsichord parts. Includes both the Leipzig and Cöthen readings in the critical commentary.' },
-      { id: 'e-bach-bwv1027-barenreiter', publisher: 'Bärenreiter', editor: 'Hans Eppstein', year: 1989, description: 'Part of the Neue Bach-Ausgabe. The most thorough scholarly text, with alternative harpsichord realisations.' }
+      { id: 'e-bach-bwv1027-henle', publisher: 'Henle Verlag', editor: 'Hans Eppstein', year: 1987, description: 'Urtext edition with separate cello and harpsichord parts. Includes both the Leipzig and Cöthen readings in the critical commentary.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=BWV+1027+Viola+da+Gamba' },
+      { id: 'e-bach-bwv1027-barenreiter', publisher: 'Bärenreiter', editor: 'Hans Eppstein', year: 1989, description: 'Part of the Neue Bach-Ausgabe. The most thorough scholarly text, with alternative harpsichord realisations.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1027+viola+da+gamba' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Viola_da_Gamba_Sonata_in_G_major,_BWV_1027_(Bach,_Johann_Sebastian)', label: 'IMSLP — Gamba Sonata No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonatas_for_viola_da_gamba_and_harpsichord_(Bach)', label: 'Wikipedia — Viola da Gamba Sonatas' },
     ],
     movements: [
-      { name: 'I. Adagio' },
-      { name: 'II. Allegro ma non tanto' },
-      { name: 'III. Andante' },
-      { name: 'IV. Allegro moderato' },
+      { name: 'I. Adagio', key: 'G major', meter: '3/2' },
+      { name: 'II. Allegro ma non tanto', key: 'G major', meter: '6/8' },
+      { name: 'III. Andante', key: 'E minor', meter: '3/4' },
+      { name: 'IV. Allegro moderato', key: 'G major', meter: '2/4' },
     ],
   },
   {
@@ -283,18 +294,18 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'advanced',
     description: 'The second gamba sonata is the most outgoing of the three. The opening Adagio is brief, almost a prelude, and gives way to an Allegro of dancing energy over a walking keyboard bass. The Andante in B minor stands out for its singing, lyrical cello line; the closing Allegro is a lively gigue-like finale. As with BWV 1027, the keyboard part is fully composed rather than figured, making the sonata a genuine duo.',
     editions: [
-      { id: 'e-bach-bwv1028-henle', publisher: 'Henle Verlag', editor: 'Hans Eppstein', year: 1987, description: 'Urtext edition with separate cello and harpsichord parts. Part of Henle\'s complete gamba sonatas volume.' },
-      { id: 'e-bach-bwv1028-barenreiter', publisher: 'Bärenreiter', editor: 'Hans Eppstein', year: 1989, description: 'Neue Bach-Ausgabe critical edition with full source-critical report.' }
+      { id: 'e-bach-bwv1028-henle', publisher: 'Henle Verlag', editor: 'Hans Eppstein', year: 1987, description: 'Urtext edition with separate cello and harpsichord parts. Part of Henle\'s complete gamba sonatas volume.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=BWV+1028+Viola+da+Gamba' },
+      { id: 'e-bach-bwv1028-barenreiter', publisher: 'Bärenreiter', editor: 'Hans Eppstein', year: 1989, description: 'Neue Bach-Ausgabe critical edition with full source-critical report.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1028+viola+da+gamba' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Viola_da_Gamba_Sonata_in_D_major,_BWV_1028_(Bach,_Johann_Sebastian)', label: 'IMSLP — Gamba Sonata No. 2' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonatas_for_viola_da_gamba_and_harpsichord_(Bach)', label: 'Wikipedia — Viola da Gamba Sonatas' },
     ],
     movements: [
-      { name: 'I. Adagio' },
-      { name: 'II. Allegro' },
-      { name: 'III. Andante' },
-      { name: 'IV. Allegro' },
+      { name: 'I. Adagio', key: 'D major', meter: '4/4' },
+      { name: 'II. Allegro', key: 'D major', meter: '3/4' },
+      { name: 'III. Andante', key: 'B minor', meter: '4/4' },
+      { name: 'IV. Allegro', key: 'D major', meter: '6/8' },
     ],
   },
   {
@@ -309,17 +320,17 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'professional',
     description: 'The darkest and most ambitious of the three gamba sonatas, cast in three movements rather than the usual four and closer in scale to a concerto. The opening Vivace is built on a driving figure passed between the instruments; the Adagio is a plaintive siciliana; the closing Allegro is a rigorous double fugue. The cellist and keyboardist are true equals throughout, and the writing rewards chamber-music-level rehearsal rather than soloist framing.',
     editions: [
-      { id: 'e-bach-bwv1029-henle', publisher: 'Henle Verlag', editor: 'Hans Eppstein', year: 1987, description: 'Urtext edition with separate parts. Includes both the keyboard realisation and the gamba part with minimal editorial additions.' },
-      { id: 'e-bach-bwv1029-barenreiter', publisher: 'Bärenreiter', editor: 'Hans Eppstein', year: 1989, description: 'Neue Bach-Ausgabe critical edition, the standard scholarly source.' }
+      { id: 'e-bach-bwv1029-henle', publisher: 'Henle Verlag', editor: 'Hans Eppstein', year: 1987, description: 'Urtext edition with separate parts. Includes both the keyboard realisation and the gamba part with minimal editorial additions.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=BWV+1029+Viola+da+Gamba' },
+      { id: 'e-bach-bwv1029-barenreiter', publisher: 'Bärenreiter', editor: 'Hans Eppstein', year: 1989, description: 'Neue Bach-Ausgabe critical edition, the standard scholarly source.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=BWV+1029+viola+da+gamba' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Viola_da_Gamba_Sonata_in_G_minor,_BWV_1029_(Bach,_Johann_Sebastian)', label: 'IMSLP — Gamba Sonata No. 3' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Sonatas_for_viola_da_gamba_and_harpsichord_(Bach)', label: 'Wikipedia — Viola da Gamba Sonatas' },
     ],
     movements: [
-      { name: 'I. Vivace' },
-      { name: 'II. Adagio' },
-      { name: 'III. Allegro' },
+      { name: 'I. Vivace', key: 'G minor', meter: '4/4' },
+      { name: 'II. Adagio', key: 'B-flat major', meter: '3/2' },
+      { name: 'III. Allegro', key: 'G minor', meter: '4/4' },
     ],
   },
   {
@@ -334,9 +345,9 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'professional',
     description: 'Lost for nearly two centuries and rediscovered in Prague in 1961, this concerto has since become a cornerstone of the cello repertoire. Its brilliant first movement, lyrical Adagio, and spirited finale display a Classical elegance that demands both technical precision and stylistic finesse. The work dates from Haydn\'s early years at Esterházy.',
     editions: [
-      { id: 'e-haydn-cc1-henle', publisher: 'Henle Verlag', editor: 'Sonja Gerlach', year: 1981, description: 'Urtext edition based on the recovered autograph. The standard scholarly text.' },
-      { id: 'e-haydn-cc1-barenreiter', publisher: 'Bärenreiter', editor: 'Sonja Gerlach', year: 1984, description: 'Critical edition from the Joseph Haydn Werke. Includes orchestral parts and cadenza suggestions.' },
-      { id: 'e-haydn-cc1-imi', publisher: 'International Music Company', editor: 'Leonard Rose', year: 1967, description: 'Performance edition with Rose\'s fingerings and bowings. Includes cadenzas by the editor.' }
+      { id: 'e-haydn-cc1-henle', publisher: 'Henle Verlag', editor: 'Sonja Gerlach', year: 1981, description: 'Urtext edition based on the recovered autograph. The standard scholarly text.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Haydn+Cello+Concerto+C+major' },
+      { id: 'e-haydn-cc1-barenreiter', publisher: 'Bärenreiter', editor: 'Sonja Gerlach', year: 1984, description: 'Critical edition from the Joseph Haydn Werke. Includes orchestral parts and cadenza suggestions.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=Haydn+cello+concerto+C' },
+      { id: 'e-haydn-cc1-imi', publisher: 'International Music Company', editor: 'Leonard Rose', year: 1967, description: 'Performance edition with Rose\'s fingerings and bowings. Includes cadenzas by the editor.', type: 'performer', url: 'https://www.internationalmusicco.com/' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Concerto_No.1_in_C_major,_Hob.VIIb:1_(Haydn,_Joseph)', label: 'IMSLP — Haydn Cello Concerto No. 1' },
@@ -344,9 +355,9 @@ export const seedPieces: SeedPiece[] = [
       { type: 'internet_archive', url: 'https://archive.org/details/HaydnCelloConcertoNo.1InCMajorHob.Viib1', label: 'Mstislav Rostropovich / ASMF (1988)' },
     ],
     movements: [
-      { name: 'I. Moderato' },
-      { name: 'II. Adagio' },
-      { name: 'III. Allegro molto' },
+      { name: 'I. Moderato', key: 'C major', meter: '4/4' },
+      { name: 'II. Adagio', key: 'F major', meter: '2/4' },
+      { name: 'III. Allegro molto', key: 'C major', meter: '4/4' },
     ],
   },
   {
@@ -361,17 +372,17 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'advanced',
     description: 'A double concerto whose nickname — "Il Proteo, or the World Upside Down" — refers to a characteristic game Vivaldi plays with the two soloists: the violin is notated in the cello\'s range and clef, and the cello in the violin\'s. Performers and listeners hear high-and-low flipped; reading performers face the concerto written the "wrong" way up. Beyond the trick, the piece is a genuine duo concerto in three movements with brilliant interplay between the soloists and the string orchestra continuo.',
     editions: [
-      { id: 'e-vivaldi-rv544-ricordi', publisher: 'Ricordi', editor: 'Gian Francesco Malipiero', year: 1955, description: 'Part of the Istituto Italiano Antonio Vivaldi complete edition. The long-standard performing edition.' },
-      { id: 'e-vivaldi-rv544-barenreiter', publisher: 'Bärenreiter', editor: 'Federico Maria Sardelli', year: 2013, description: 'Critical edition with new sources and corrections. Includes notes on the "Il Proteo" instrument-swap notation.' }
+      { id: 'e-vivaldi-rv544-ricordi', publisher: 'Ricordi', editor: 'Gian Francesco Malipiero', year: 1955, description: 'Part of the Istituto Italiano Antonio Vivaldi complete edition. The long-standard performing edition.', type: 'scholarly', url: 'https://www.ricordi.com/' },
+      { id: 'e-vivaldi-rv544-barenreiter', publisher: 'Bärenreiter', editor: 'Federico Maria Sardelli', year: 2013, description: 'Critical edition with new sources and corrections. Includes notes on the "Il Proteo" instrument-swap notation.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=Vivaldi+RV+544' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Concerto_in_F_major,_RV_544_(Vivaldi,_Antonio)', label: 'IMSLP — Concerto RV 544' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Antonio_Vivaldi', label: 'Wikipedia — Antonio Vivaldi' },
     ],
     movements: [
-      { name: 'I. Allegro' },
-      { name: 'II. Largo' },
-      { name: 'III. Allegro' },
+      { name: 'I. Allegro', key: 'F major', meter: '4/4' },
+      { name: 'II. Largo', key: 'D minor', meter: '3/4' },
+      { name: 'III. Allegro', key: 'F major', meter: '4/4' },
     ],
   },
   {
@@ -386,15 +397,20 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'professional',
     description: 'A compact, single-movement concerto in three connected sections that unfolds with irresistible momentum. The opening theme bursts in immediately with urgent energy. Saint-Saëns masterfully balances virtuoso display with elegant French lyricism, and the work has remained one of the most popular cello concertos since its 1873 premiere.',
     editions: [
-      { id: 'e-ss-cc1-durand', publisher: 'Durand', editor: 'Original publication', year: 1873, description: 'The original Durand edition, published in the composer\'s lifetime. The standard French source.' },
-      { id: 'e-ss-cc1-henle', publisher: 'Henle Verlag', editor: 'Peter Jost', year: 2016, description: 'Urtext edition based on autograph and first edition. Clear engraving with critical notes.' },
-      { id: 'e-ss-cc1-imi', publisher: 'International Music Company', editor: 'Leonard Rose', year: 1960, description: 'Practical performance edition with bowings and fingerings by one of the great American cellists.' }
+      { id: 'e-ss-cc1-durand', publisher: 'Durand', editor: 'Original publication', year: 1873, description: 'The original Durand edition, published in the composer\'s lifetime. The standard French source.', type: 'practical', url: 'https://imslp.org/wiki/Cello_Concerto_No.1,_Op.33_(Saint-Sa%C3%ABns,_Camille)' },
+      { id: 'e-ss-cc1-henle', publisher: 'Henle Verlag', editor: 'Peter Jost', year: 2016, description: 'Urtext edition based on autograph and first edition. Clear engraving with critical notes.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Saint-Saens+cello+concerto+op+33' },
+      { id: 'e-ss-cc1-imi', publisher: 'International Music Company', editor: 'Leonard Rose', year: 1960, description: 'Practical performance edition with bowings and fingerings by one of the great American cellists.', type: 'performer', url: 'https://www.internationalmusicco.com/' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Concerto_No.1,_Op.33_(Saint-Sa%C3%ABns,_Camille)', label: 'IMSLP — Saint-Saëns Cello Concerto No. 1' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_No._1_(Saint-Sa%C3%ABns)', label: 'Wikipedia — Saint-Saëns Cello Concerto No. 1' },
       { type: 'internet_archive', url: 'https://archive.org/details/lp_two-great-cello-concertos_camille-saintsans-douard-lalo-andr-navarra', label: 'André Navarra / Münch / Orchestre des Concerts Lamoureux' },
       { type: 'internet_archive', url: 'https://archive.org/details/nobel-prize-concert-2021', label: 'Sol Gabetta — 2021 Nobel Prize Concert' },
+    ],
+    movements: [
+      { name: 'I. Allegro non troppo', key: 'A minor', meter: '4/4' },
+      { name: 'II. Allegretto con moto', key: 'B-flat major', meter: '3/4' },
+      { name: 'III. Tempo primo', key: 'A minor', meter: '4/4' },
     ],
   },
   {
@@ -409,8 +425,8 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'professional',
     description: 'Elgar\'s last major work, composed in 1919 in the shadow of World War I. Its autumnal, elegiac character makes it one of the most emotionally profound concertos in the repertoire. Forever associated with Jacqueline du Pré\'s legendary 1965 recording.',
     editions: [
-      { id: 'e-elgar-cc-novello', publisher: 'Novello', editor: 'Original publication', year: 1919, description: 'The original Novello edition, overseen by Elgar. Standard performance edition.' },
-      { id: 'e-elgar-cc-barenreiter', publisher: 'Bärenreiter', editor: 'Jonathan Del Mar', year: 2020, description: 'New critical edition correcting errors in previous printings. The most accurate modern source.' }
+      { id: 'e-elgar-cc-novello', publisher: 'Novello', editor: 'Original publication', year: 1919, description: 'The original Novello edition, overseen by Elgar. Standard performance edition.', type: 'practical', url: 'https://imslp.org/wiki/Cello_Concerto,_Op.85_(Elgar,_Edward)' },
+      { id: 'e-elgar-cc-barenreiter', publisher: 'Bärenreiter', editor: 'Jonathan Del Mar', year: 2020, description: 'New critical edition correcting errors in previous printings. The most accurate modern source.', type: 'scholarly', url: 'https://www.baerenreiter.com/en/shop/?tx_solr%5Bq%5D=Elgar+cello+concerto' }
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Concerto_(Elgar)', label: 'Wikipedia — Elgar Cello Concerto' },
@@ -418,10 +434,10 @@ export const seedPieces: SeedPiece[] = [
       { type: 'vimeo', url: 'https://vimeo.com/212893480', label: 'Truls Mørk / Concertgebouw — Live Amsterdam 2017' },
     ],
     movements: [
-      { name: 'I. Adagio — Moderato' },
-      { name: 'II. Lento — Allegro molto' },
-      { name: 'III. Adagio' },
-      { name: 'IV. Allegro — Moderato — Allegro, ma non troppo' },
+      { name: 'I. Adagio — Moderato', key: 'E minor', meter: '4/4' },
+      { name: 'II. Lento — Allegro molto', key: 'G major', meter: '2/4' },
+      { name: 'III. Adagio', key: 'B-flat major', meter: '3/8' },
+      { name: 'IV. Allegro — Moderato — Allegro, ma non troppo', key: 'E minor', meter: '2/4 & 4/4' },
     ],
   },
   {
@@ -436,22 +452,22 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'professional',
     description: 'Strauss\'s only cello sonata, written at nineteen and published in 1883. The work sits just before his turn to the tone poems: it is still in the conservative Brahmsian vein, with a first movement built on broad lyrical themes, a brooding slow movement in F minor, and a dashing finale. Cellists value the sonata as one of the major late-Romantic German chamber works for the instrument, sitting in repertoire alongside the Brahms sonatas and predating the Rachmaninoff.',
     editions: [
-      { id: 'e-strauss-cs-universal', publisher: 'Universal Edition', editor: 'Original publication', year: 1883, description: 'Original Aibl edition, later acquired by Universal. The standard source text.' },
-      { id: 'e-strauss-cs-henle', publisher: 'Henle Verlag', editor: 'Norbert Gertsch', year: 2015, description: 'Urtext edition based on the autograph and first edition. Clean engraving with a short critical commentary.' }
+      { id: 'e-strauss-cs-universal', publisher: 'Universal Edition', editor: 'Original publication', year: 1883, description: 'Original Aibl edition, later acquired by Universal. The standard source text.', type: 'practical', url: 'https://imslp.org/wiki/Cello_Sonata,_Op.6_(Strauss,_Richard)' },
+      { id: 'e-strauss-cs-henle', publisher: 'Henle Verlag', editor: 'Norbert Gertsch', year: 2015, description: 'Urtext edition based on the autograph and first edition. Clean engraving with a short critical commentary.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Strauss+Cello+Sonata+op+6' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Cello_Sonata,_Op.6_(Strauss,_Richard)', label: 'IMSLP — Strauss Cello Sonata' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Cello_Sonata_(Strauss)', label: 'Wikipedia — Strauss Cello Sonata' },
     ],
     movements: [
-      { name: 'I. Allegro con brio' },
-      { name: 'II. Andante ma non troppo' },
-      { name: 'III. Finale: Allegro vivo' },
+      { name: 'I. Allegro con brio', key: 'F major', meter: '4/4' },
+      { name: 'II. Andante ma non troppo', key: 'F minor', meter: '4/4' },
+      { name: 'III. Finale: Allegro vivo', key: 'F major', meter: '4/4' },
     ],
   },
   {
     id: 'mendelssohn-song-without-words-cello',
-    title: 'Song without Words in D major',
+    title: 'Lied ohne Worte in D major',
     composer_name: 'Felix Mendelssohn',
     catalog_number: 'Op. 109',
     instruments: ['Cello', 'Piano'],
@@ -461,12 +477,15 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'intermediate',
     description: 'A brief lyric piece for cello and piano, the only one of Mendelssohn\'s "Lieder ohne Worte" (Songs without Words) composed for cello rather than piano solo. Written in 1845 and published posthumously, the work is a single unbroken melodic arc in the composer\'s most intimate vein, often programmed as an encore or as the emotional centre of a shorter recital. Its demands are interpretive rather than technical: simple surface, sustained expressive line.',
     editions: [
-      { id: 'e-mendelssohn-swow-breitkopf', publisher: 'Breitkopf & Härtel', editor: 'Julius Rietz', year: 1874, description: 'Part of Breitkopf\'s historic complete works of Mendelssohn. Standard performance text for over a century.' },
-      { id: 'e-mendelssohn-swow-henle', publisher: 'Henle Verlag', editor: 'Ernst Herttrich', year: 2009, description: 'Urtext edition based on manuscript sources. Includes a short critical report.' }
+      { id: 'e-mendelssohn-swow-breitkopf', publisher: 'Breitkopf & Härtel', editor: 'Julius Rietz', year: 1874, description: 'Part of Breitkopf\'s historic complete works of Mendelssohn. Standard performance text for over a century.', type: 'scholarly', url: 'https://imslp.org/wiki/Lied_ohne_Worte,_Op.109_(Mendelssohn,_Felix)' },
+      { id: 'e-mendelssohn-swow-henle', publisher: 'Henle Verlag', editor: 'Ernst Herttrich', year: 2009, description: 'Urtext edition based on manuscript sources. Includes a short critical report.', type: 'urtext', url: 'https://www.henle.de/en/search/?q=Mendelssohn+Op+109+Lied+ohne+Worte' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Lied_ohne_Worte,_Op.109_(Mendelssohn,_Felix)', label: 'IMSLP — Lied ohne Worte, Op. 109' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Songs_Without_Words', label: 'Wikipedia — Songs Without Words' },
+    ],
+    movements: [
+      { name: 'Andante espressivo', key: 'D major', meter: '4/4' },
     ],
   },
   {
@@ -481,12 +500,15 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'advanced',
     description: 'A short virtuoso showpiece for cello and piano, composed in 1884. Fauré reportedly disliked the nickname "Papillon" (Butterfly) his publisher insisted on and considered the title a marketing imposition on what he thought of as a technically demanding morceau. The outer sections are flurries of rapid figuration over a simple piano accompaniment; the central section drops into a lyrical Andantino, giving the performer a brief moment to breathe before the butterfly returns. Three minutes of controlled dazzle.',
     editions: [
-      { id: 'e-faure-papillon-hamelle', publisher: 'Hamelle', editor: 'Original publication', year: 1898, description: 'The original French edition. Standard historical source.' },
-      { id: 'e-faure-papillon-imc', publisher: 'International Music Company', editor: 'Maurice Eisenberg', year: 1952, description: 'American performing edition with added bowings and fingerings. Adapted for modern cello technique.' }
+      { id: 'e-faure-papillon-hamelle', publisher: 'Hamelle', editor: 'Original publication', year: 1898, description: 'The original French edition. Standard historical source.', type: 'practical', url: 'https://imslp.org/wiki/Papillon,_Op.77_(Faur%C3%A9,_Gabriel)' },
+      { id: 'e-faure-papillon-imc', publisher: 'International Music Company', editor: 'Maurice Eisenberg', year: 1952, description: 'American performing edition with added bowings and fingerings. Adapted for modern cello technique.', type: 'performer', url: 'https://www.internationalmusicco.com/' }
     ],
     external_links: [
       { type: 'imslp', url: 'https://imslp.org/wiki/Papillon,_Op.77_(Faur%C3%A9,_Gabriel)', label: 'IMSLP — Papillon, Op. 77' },
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Gabriel_Faur%C3%A9', label: 'Wikipedia — Gabriel Fauré' },
+    ],
+    movements: [
+      { name: 'Allegro vivo — Andantino — Allegro vivo', key: 'A major', meter: '3/4' },
     ],
   },
   {
@@ -501,15 +523,15 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'professional',
     description: 'Crumb\'s early (1955) sonata for unaccompanied cello, composed during his graduate years at the University of Michigan. The work predates the experimental sonorities Crumb became known for: it is written in a post-Bartók idiom with clear formal architecture, aggressive rhythmic drive, and folk-inflected melodic material. The three movements are a Fantasia, a set of character pieces titled "Tema pastorale con variazioni", and a Toccata. The sonata has become a core 20th-century solo cello work and is often paired with Kodály\'s Op. 8 and the Bach Suites in recital programmes.',
     editions: [
-      { id: 'e-crumb-ss-peters', publisher: 'C. F. Peters', editor: 'Original publication', year: 1955, description: 'The original Peters edition. Remains the only published score; no critical edition has been prepared.' }
+      { id: 'e-crumb-ss-peters', publisher: 'C. F. Peters', editor: 'Original publication', year: 1955, description: 'The original Peters edition. Remains the only published score; no critical edition has been prepared.', type: 'performer', url: 'https://www.wisemusicclassical.com/publishers/edition-peters/' }
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/George_Crumb', label: 'Wikipedia — George Crumb' },
     ],
     movements: [
-      { name: 'I. Fantasia' },
-      { name: 'II. Tema pastorale con variazioni' },
-      { name: 'III. Toccata' },
+      { name: 'I. Fantasia', meter: 'free meter' },
+      { name: 'II. Tema pastorale con variazioni', meter: '3/4' },
+      { name: 'III. Toccata', meter: '4/4' },
     ],
   },
   {
@@ -524,15 +546,15 @@ export const seedPieces: SeedPiece[] = [
     difficulty: 'professional',
     description: 'A chamber work for electric flute, electric cello, and amplified piano, composed in 1971 after Crumb heard a recording of humpback whale song. The instrumentalists are instructed to perform in black half-masks under deep blue lighting: the masks depersonalise the players so that the music feels like a voice from another species. The work unfolds in three large sections — Vocalise, Variations on Sea-Time, and Sea-Nocturne — and uses extended techniques throughout: flute singing while playing, bowed piano strings, and the cellist\'s imitation of seagull cries via high harmonics over scordatura tuning. A touchstone of late-20th-century chamber music and a central work in the cellist\'s new-music repertoire.',
     editions: [
-      { id: 'e-crumb-vox-peters', publisher: 'C. F. Peters', editor: 'Original publication', year: 1971, description: 'The original Peters score, printed with Crumb\'s signature graphic notation and staging directions. The only published edition.' }
+      { id: 'e-crumb-vox-peters', publisher: 'C. F. Peters', editor: 'Original publication', year: 1971, description: 'The original Peters score, printed with Crumb\'s signature graphic notation and staging directions. The only published edition.', type: 'performer', url: 'https://www.wisemusicclassical.com/publishers/edition-peters/' }
     ],
     external_links: [
       { type: 'wikipedia', url: 'https://en.wikipedia.org/wiki/Vox_Balaenae', label: 'Wikipedia — Vox Balaenae' },
     ],
     movements: [
-      { name: 'Vocalise (… for the beginning of time)' },
-      { name: 'Variations on Sea-Time' },
-      { name: 'Sea-Nocturne (… for the end of time)' },
+      { name: 'Vocalise (… for the beginning of time)', meter: 'graphic notation' },
+      { name: 'Variations on Sea-Time', meter: 'graphic notation' },
+      { name: 'Sea-Nocturne (… for the end of time)', meter: 'graphic notation' },
     ],
   },
 ];

--- a/src/lib/pieces.ts
+++ b/src/lib/pieces.ts
@@ -28,6 +28,8 @@ export interface Edition {
   editor: string;
   year: number | null;
   description: string;
+  type?: 'urtext' | 'scholarly' | 'performer' | 'facsimile' | 'critical' | 'practical';
+  url?: string;
 }
 
 export interface ExternalLink {
@@ -40,6 +42,8 @@ export interface ExternalLink {
 export interface Movement {
   name: string;
   pieceId?: string;
+  key?: string;
+  meter?: string;
 }
 
 export interface PieceFull extends PieceBasic {
@@ -77,6 +81,8 @@ function seedToFull(s: SeedPiece): PieceFull {
       editor: e.editor,
       year: e.year,
       description: e.description,
+      type: e.type,
+      url: e.url,
     })),
     external_links: s.external_links.map((l) => ({
       type: l.type,
@@ -87,6 +93,8 @@ function seedToFull(s: SeedPiece): PieceFull {
     movements: (s.movements ?? []).map((m) => ({
       name: m.name,
       pieceId: m.pieceId,
+      key: m.key,
+      meter: m.meter,
     })),
   };
 }


### PR DESCRIPTION
## Summary

Four additions to the ported kit piece-page layout, wired across all 19 curated pieces.

### 1. Four-axis difficulty panel
Panel sits directly under the piece description. Each axis (Technical / Stamina / Interpretive / Ensemble) carries 5 bars, a short editorial label, and a one-line practical note. Data in `src/data/difficulty-axes.ts` as a keyed record. First-draft editorial judgments; bylined contributors can override per piece once the approval pipeline ships.

### 2. Movement header with key + meter
Every movement entry now carries optional `key` and `meter` fields. Renders as `{name} — {key} · {meter}` per the kit pattern. Four single-movement works (Bach Chaconne, Saint-Saëns No. 1, Mendelssohn Op. 109, Fauré Op. 77) got movements arrays so Structural Landmarks no longer falls through to empty state.

### 3. Non-anglicized spellings
- "Prelude" → "Prélude" everywhere (movement names, descriptions, link labels)
- "Cothen" → "Cöthen" in Bach CS1 description
- Mendelssohn title: "Song without Words" → "Lied ohne Worte" (German original). URL slug unchanged.

### 4. Edition type chips + publisher links (verified)
Every edition (42 across 19 pieces) carries a type tag rendered as a chip (urtext / scholarly / performer / practical). Cards are clickable links. All URLs verified `200 OK`:
- **6 IMSLP** piece pages for public-domain first editions (Durand 1873, Novello 1919, Universal 1883, Hamelle 1898, Breitkopf 1874, Peters Becker 1911) — actual scans
- **12 Henle + 12 Bärenreiter** search URLs with catalog-number queries — their Solr search endpoints return the product
- **Publisher roots** for IMC, Schott, Ricordi, Faber Music, Wise Music (Edition Peters aggregator)
- **Wiener Urtext** URL dropped (site unresponsive during verification); type chip stays

### Schema plumbing
- `SeedPiece.editions` adds `type` + `url`
- `SeedPiece.movements` adds `key` + `meter`
- `Edition` and `Movement` interfaces in `src/lib/pieces.ts` extended to match
- `seedToFull()` propagates new fields

## Test plan
- [x] `bun run build` — clean
- [x] `bun test src/lib src/data src/components` — 81 pass / 3 fail (pre-existing UsernameEditor flakiness, unrelated)
- [x] Local dev-server verified on all 19 pieces
- [x] All 36 edition URLs `curl -sI -L` → 200 OK
- [ ] Visual QA on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)