### PR TITLE
chore(scripts): seed-contributor.ts for admin contributor promotion

### DIFF
--- a/scripts/seed-contributor.ts
+++ b/scripts/seed-contributor.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bun
+// Promote an existing auth user to a signed contributor.
+//
+// Looks up the user by email in auth.users, then sets the Slice A contributor
+// fields on public.users: is_contributor, contributor_active,
+// contributor_agreement_signed_at (now), and optionally contributor_bio_short.
+// Idempotent — re-running just refreshes the same fields.
+//
+// Usage:
+//   bun run scripts/seed-contributor.ts <email> [bio_short]
+//
+// Requires in the environment (picks up .env.local by default):
+//   SUPABASE_URL
+//   SUPABASE_SERVICE_ROLE_KEY
+
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceKey) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in environment.');
+  console.error('Load your .env.local (e.g. `bun --env-file=.env.local run scripts/seed-contributor.ts ...`).');
+  process.exit(1);
+}
+
+const [email, bioShort] = process.argv.slice(2);
+if (!email) {
+  console.error('Usage: bun run scripts/seed-contributor.ts <email> [bio_short]');
+  process.exit(1);
+}
+
+const admin = createClient(url, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const { data: listData, error: listErr } = await admin.auth.admin.listUsers({ perPage: 1000 });
+if (listErr) {
+  console.error(`Failed to list auth users: ${listErr.message}`);
+  process.exit(1);
+}
+
+const target = listData.users.find((u) => u.email?.toLowerCase() === email.toLowerCase());
+if (!target) {
+  console.error(`No auth user found for email ${email}.`);
+  process.exit(1);
+}
+
+const patch: Record<string, unknown> = {
+  is_contributor: true,
+  contributor_active: true,
+  contributor_agreement_signed_at: new Date().toISOString(),
+};
+if (bioShort) patch.contributor_bio_short = bioShort;
+
+const { data: updated, error: updateErr } = await admin
+  .from('users')
+  .update(patch)
+  .eq('id', target.id)
+  .select('id, display_name, is_contributor, contributor_active, contributor_agreement_signed_at, contributor_bio_short')
+  .single();
+
+if (updateErr) {
+  console.error(`Failed to update public.users: ${updateErr.message}`);
+  process.exit(1);
+}
+
+console.log('Contributor promoted.');
+console.log(JSON.stringify(updated, null, 2));


### PR DESCRIPTION
Slice A step 1b — admin path to promote an existing auth user to a signed contributor until the Tier 1 onboarding UI ships.

## Summary
- \`scripts/seed-contributor.ts\` — looks up user by email in auth.users, sets \`is_contributor=true\`, \`contributor_active=true\`, \`contributor_agreement_signed_at=now()\`, and optionally \`contributor_bio_short\`.
- Idempotent. Uses the Supabase service role key (from \`.env.local\`).
- Usage: \`bun --env-file=.env.local run scripts/seed-contributor.ts <email> [bio_short]\`

## Already run on prod
- Haji Kim (\`hannah.jkims@gmail.com\`) promoted with bio \"cellist, NYC\" as the first signed contributor. Slice A step 1b complete.

## Test plan
- [x] Script runs idempotently against prod (confirmed)
- [ ] No test suite — it's an admin one-shot. Future: contributor onboarding UI replaces this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)