### PR TITLE
test(contributor-pipeline): 30 integration tests + skip Astro API layer

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+# Local Supabase stack (supabase start). Not secret — default development keys
+# shared across every Supabase CLI installation. Do not use in production.
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage/
 *.log
 .env*
 !.env.example
+!.env.test
 .gstack/
 .wrangler/
 .dev.vars

--- a/PLAN-contributor-pipeline-slice-a.md
+++ b/PLAN-contributor-pipeline-slice-a.md
@@ -204,29 +204,32 @@ A published note is never mutated in place. Any edit is a new version row + `cur
 
 ## 5. API / route surface
 
-All under `src/pages/api/`. Astro endpoints, session auth via `supabase.auth.getUser()` from request cookies. State-changing endpoints call Postgres RPCs (`security definer`) that encapsulate the transition, audit writes, and notification side effects atomically.
+**Decision — no Astro API route layer. UI calls RPCs directly via `supabase.rpc(...)` from the browser.** The security-definer functions enforce every guard that an Astro route would (auth, ownership, state machine). PostgREST automatically exposes each grantable RPC at `POST /rest/v1/rpc/<function_name>`, which is curl-compatible with a user JWT. Adding a pass-through Astro layer would be boilerplate with no additional security or functional value for Slice A. If Slice B+ needs server-side orchestration (cron triggers, multi-RPC transactions, rate limiting), we add routes then.
 
-| Path | Method | Auth | Body | Purpose |
-|---|---|---|---|---|
-| `api/performers-notes` | POST | contributor | `{piece_id, body}` | `publish_contributor_note` — self-author, publishes immediately. |
-| `api/performers-notes/[id]/edit` | POST | contributor (owner) | `{body}` | `publish_contributor_edit` — new version, stays published. |
-| `api/admin/performers-notes` | POST | staff | `{piece_id, contributor_id, body}` | `create_performers_note_draft`. |
-| `api/admin/performers-notes/[id]/submit` | POST | staff | — | `draft → awaiting_contributor_approval`. |
-| `api/admin/performers-notes/[id]/retract` | POST | staff | — | Retract to draft, sets `retracted_by`. |
-| `api/performers-notes/[id]/approve` | POST | contributor (owner) | — | `approve_performers_note`. |
-| `api/performers-notes/[id]/approve-and-edit` | POST | contributor (owner) | `{body}` | `approve_and_edit_performers_note`. |
-| `api/performers-notes/[id]/reject` | POST | contributor (owner) | `{reason?}` | `reject_performers_note`. |
-| `api/performers-notes/[id]/remove` | POST | contributor (owner) | — | `remove_performers_note`, sets `removed_by`. |
-| `api/notifications` | GET | any authed | — | List un-cleared for bell/queue. |
-| `api/notifications/[id]/clear` | POST | recipient | — | Set `cleared_at`. |
+Listing the RPC surface for reference:
 
-No DELETE verbs — removal is a state transition, not a row delete.
+| RPC | Caller | Args | Effect |
+|---|---|---|---|
+| `publish_contributor_note` | contributor | `p_piece_id, p_body` | create + publish v1 atomically |
+| `publish_contributor_edit` | contributor (owner) | `p_note_id, p_body` | new version, stays published |
+| `remove_performers_note` | contributor (owner) | `p_note_id` | `published → removed` |
+| `create_performers_note_draft` | staff | `p_piece_id, p_contributor_id, p_body` | new note in `draft` state |
+| `update_performers_note_draft` | staff | `p_note_id, p_body` | new version, stays `draft` |
+| `submit_performers_note` | staff | `p_note_id` | `draft → awaiting`, inserts notification |
+| `retract_performers_note` | staff | `p_note_id` | `awaiting → draft`, clears notification |
+| `approve_performers_note` | contributor (owner) | `p_note_id` | `awaiting → published` |
+| `approve_and_edit_performers_note` | contributor (owner) | `p_note_id, p_body` | new version + publish in one call |
+| `reject_performers_note` | contributor (owner) | `p_note_id, p_reason?` | `awaiting → draft`, reason on version |
+| `clear_notification` | recipient | `p_notification_id` | set `cleared_at` |
+| `clear_all_notifications` | recipient | — | clear all, return count |
+
+All grant `execute` to `authenticated`; internal helpers (`_require_*`, `_insert_performers_note_version`, `_clear_notifications_for_note`) are revoked from `public`. No DELETE verbs — removal is a state transition, not a row delete.
 
 ## 6. Component inventory
 
 All components consume existing DESIGN.md tokens. Astro where static, React where there's local state.
 
-- **`src/components/NavbarBell.tsx`** — React island inside `Navbar.astro`, placed immediately left of `AuthButton`. Props: none (self-fetches). Poll-only for Slice A: fetches `/api/notifications` on mount, on `visibilitychange` when the tab becomes visible, and after any local action that could create/clear notifications. Badge rules: hidden at 0, exact count `1`–`9`, `9+` at 10 or more. Popover on click, click-outside closes. Each popover item is a link to the piece page (or `/notifications`) plus an inline `Clear` button. Footer `Clear all` button sets `cleared_at` on every un-cleared notification for the recipient.
+- **`src/components/NavbarBell.tsx`** — React island inside `Navbar.astro`, placed immediately left of `AuthButton`. Props: none (self-fetches). Poll-only for Slice A: queries `notifications` (via supabase client, RLS scopes to recipient) on mount, on `visibilitychange` when the tab becomes visible, and after any local action that could create/clear notifications. Badge rules: hidden at 0, exact count `1`–`9`, `9+` at 10 or more. Popover on click, click-outside closes. Each popover item is a link to the piece page (or `/notifications`) plus an inline `Clear` button. Footer `Clear all` button sets `cleared_at` on every un-cleared notification for the recipient.
 - **`src/pages/notifications.astro`** — hosts `<NotificationsQueue client:load />`. For v1 this page *is* the contributor approval queue (un-cleared notifications are all pending drafts). Title "Your queue".
 - **`src/components/NotificationsQueue.tsx`** — React. For each pending draft: piece title, byline-to-be, current proposed body (serif, signed-notes pattern). Diff block against prior versions is deferred to v1.1 — Slice A shows the current body only. Action row: `Approve`, `Approve and edit` (toggles an inline textarea), `Reject` (inline confirmation with freeform reason, not a native dialog).
 - **`src/pages/admin/performers-notes.astro`** + **`src/components/admin/PerformersNotesAdmin.tsx`** — staff authoring. Select piece (existing `Autocomplete`), select contributor (default to the single `is_contributor=true AND contributor_active=true` user if there's exactly one; require explicit pick otherwise; disable Send button with an inline note if zero contributors). Textarea, `Save draft` and `Send to contributor` buttons. List of existing drafts with status, rejection notes inline on rejected-version rows, and a `Retract` button on `awaiting_contributor_approval` rows. Deliberately unpolished — PRD says Tier 1 is data-model + admin view, not styled product.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "preview": "astro preview",
     "check": "astro check",
     "test": "bun test src/lib src/data src/components src/tests",
+    "test:integration": "bun --env-file=.env.test test src/integration",
     "test:e2e": "bun test src/e2e",
-    "test:all": "bun run test && bun run test:e2e",
+    "test:all": "bun run test && bun run test:integration && bun run test:e2e",
     "validate:urls": "bun run scripts/validate-seed-urls.ts"
   },
   "dependencies": {

--- a/src/integration/contributorPipeline.rls.test.ts
+++ b/src/integration/contributorPipeline.rls.test.ts
@@ -1,0 +1,291 @@
+// RLS + iron-rule regression tests for the contributor pipeline.
+//
+// Verifies:
+//   • Anonymous clients see only status='published' notes + no version rows.
+//   • Contributors see only their own drafts/pending notes; other contributors'
+//     pending work is invisible.
+//   • Notifications are scoped to the recipient (no cross-user reads).
+//   • IRON RULE: contributor-self-authored paths never create notifications.
+//   • Byline CHECK: is_contributor=true requires display_name (it's NOT NULL
+//     on the users table, so this is guaranteed by schema — verified here
+//     for safety).
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import {
+  admin,
+  anon,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+  countNotifications,
+} from './helpers';
+
+const PIECE = 'rls-test-piece';
+
+let contributor: Awaited<ReturnType<typeof createAuthUser>>;
+let otherContributor: Awaited<ReturnType<typeof createAuthUser>>;
+let staff: Awaited<ReturnType<typeof createAuthUser>>;
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'RLS Test Piece');
+  contributor = await createAuthUser({ isContributor: true, displayName: 'RLS Contributor' });
+  otherContributor = await createAuthUser({ isContributor: true, displayName: 'RLS Other Contributor' });
+  staff = await createAuthUser({ isStaff: true, displayName: 'RLS Staff' });
+});
+
+afterAll(async () => {
+  await admin.from('performers_notes').update({ current_version_id: null }).eq('piece_id', PIECE);
+  await admin.from('performers_note_versions').delete().eq('piece_id', PIECE);
+  await admin.from('performers_notes').delete().eq('piece_id', PIECE);
+  await deleteTestPiece(PIECE);
+  await deleteAuthUser(contributor.id);
+  await deleteAuthUser(otherContributor.id);
+  await deleteAuthUser(staff.id);
+});
+
+describe('RLS — performers_notes', () => {
+  test('anonymous sees only status=published', async () => {
+    const { data: publishedId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'public body',
+    });
+    const { data: draftId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'private draft',
+    });
+
+    const anonClient = anon();
+    const { data: anonRows } = await anonClient
+      .from('performers_notes')
+      .select('id, status')
+      .eq('piece_id', PIECE);
+    const ids = anonRows!.map((r) => r.id);
+    expect(ids).toContain(publishedId);
+    expect(ids).not.toContain(draftId);
+    expect(anonRows!.every((r) => r.status === 'published')).toBe(true);
+  });
+
+  test('non-owner contributor cannot read another contributor\'s pending draft', async () => {
+    const { data: draftId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'owned by contributor',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: draftId! });
+
+    const { data: othersView } = await otherContributor.client
+      .from('performers_notes')
+      .select('id, status')
+      .eq('id', draftId!);
+    expect(othersView).toEqual([]);
+  });
+
+  test('owner contributor sees their own pending draft', async () => {
+    const { data: draftId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'own draft visibility',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: draftId! });
+
+    const { data: ownersView } = await contributor.client
+      .from('performers_notes')
+      .select('id, status')
+      .eq('id', draftId!);
+    expect(ownersView!.length).toBe(1);
+    expect(ownersView![0].status).toBe('awaiting_contributor_approval');
+  });
+
+  test('staff sees all notes regardless of status', async () => {
+    const { data: draftRows } = await staff.client
+      .from('performers_notes')
+      .select('id, status')
+      .eq('piece_id', PIECE);
+    const statuses = new Set(draftRows!.map((r) => r.status));
+    expect(statuses.size).toBeGreaterThan(1);
+  });
+});
+
+describe('RLS — performers_note_versions', () => {
+  test('anonymous cannot read version rows', async () => {
+    const anonClient = anon();
+    const { data, error } = await anonClient.from('performers_note_versions').select('id').limit(1);
+    // Either empty or filtered — we want no rows returned for anon scope
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+  });
+
+  test('owner contributor reads their own version rows', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'owned versions',
+    });
+    const { data } = await contributor.client
+      .from('performers_note_versions')
+      .select('id, body')
+      .eq('note_id', noteId!);
+    expect(data!.length).toBe(1);
+    expect(data![0].body).toBe('owned versions');
+  });
+
+  test('non-owner contributor cannot read another\'s version rows', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'keep out',
+    });
+    const { data } = await otherContributor.client
+      .from('performers_note_versions')
+      .select('id')
+      .eq('note_id', noteId!);
+    expect(data).toEqual([]);
+  });
+});
+
+describe('RLS — notifications', () => {
+  test('recipient sees only their own notifications', async () => {
+    const { data: draftId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'nf test',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: draftId! });
+
+    const { data: contribView } = await contributor.client
+      .from('notifications')
+      .select('id, recipient_id')
+      .eq('performers_note_id', draftId!);
+    expect(contribView!.length).toBe(1);
+    expect(contribView![0].recipient_id).toBe(contributor.id);
+
+    const { data: otherView } = await otherContributor.client
+      .from('notifications')
+      .select('id')
+      .eq('performers_note_id', draftId!);
+    expect(otherView).toEqual([]);
+  });
+});
+
+describe('IRON RULE: contributor-authored paths never create notifications', () => {
+  test('publish_contributor_note creates zero notification rows', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'self authored',
+    });
+    expect(await countNotifications(noteId!)).toBe(0);
+  });
+
+  test('publish_contributor_edit creates zero notification rows', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'initial',
+    });
+    await contributor.client.rpc('publish_contributor_edit', { p_note_id: noteId!, p_body: 'edited' });
+    expect(await countNotifications(noteId!)).toBe(0);
+  });
+
+  test('control: submit_performers_note DOES create one notification', async () => {
+    const { data: noteId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'control',
+    });
+    expect(await countNotifications(noteId!)).toBe(0); // create alone doesn't notify
+    await staff.client.rpc('submit_performers_note', { p_note_id: noteId! });
+    expect(await countNotifications(noteId!, { onlyUncleared: true })).toBe(1);
+  });
+});
+
+describe('byline integrity', () => {
+  test('schema enforces is_contributor requires display_name', async () => {
+    // users.display_name is NOT NULL at the schema level, and the CHECK
+    // constraint `contributor_has_display_name` guards the is_contributor flip.
+    // Attempt to update a user to is_contributor=true with display_name=null
+    // via admin bypass should fail.
+    const { error } = await admin
+      .from('users')
+      .update({ is_contributor: true, display_name: null as unknown as string })
+      .eq('id', contributor.id);
+    expect(error).not.toBeNull();
+  });
+
+  test('clearing display_name on an existing contributor is rejected', async () => {
+    const { error } = await admin
+      .from('users')
+      .update({ display_name: null as unknown as string })
+      .eq('id', contributor.id);
+    expect(error).not.toBeNull();
+  });
+});
+
+describe('notification clearing RPCs', () => {
+  test('clear_notification sets cleared_at for the recipient', async () => {
+    const { data: noteId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'clear-me',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: noteId! });
+    const { data: rows } = await contributor.client
+      .from('notifications')
+      .select('id')
+      .eq('performers_note_id', noteId!);
+    const notifId = rows![0].id;
+
+    const { error } = await contributor.client.rpc('clear_notification', { p_notification_id: notifId });
+    expect(error).toBeNull();
+
+    const { data: after } = await admin
+      .from('notifications')
+      .select('cleared_at')
+      .eq('id', notifId)
+      .single();
+    expect(after!.cleared_at).not.toBeNull();
+  });
+
+  test('clear_all_notifications clears everything for the caller, returns count', async () => {
+    // Submit two drafts to stack notifications
+    const draft1 = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'd1',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: draft1.data! });
+    const draft2 = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'd2',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: draft2.data! });
+
+    const { data: count, error } = await contributor.client.rpc('clear_all_notifications');
+    expect(error).toBeNull();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    const { data: remaining } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact' })
+      .eq('recipient_id', contributor.id)
+      .is('cleared_at', null);
+    expect(remaining).toEqual([]);
+  });
+
+  test('cannot clear another user\'s notification', async () => {
+    const { data: draftId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'not-yours',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: draftId! });
+    const { data: rows } = await admin
+      .from('notifications')
+      .select('id')
+      .eq('performers_note_id', draftId!);
+    const notifId = rows![0].id;
+
+    const { error } = await otherContributor.client.rpc('clear_notification', { p_notification_id: notifId });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not owned by caller/i);
+  });
+});

--- a/src/integration/contributorPipeline.test.ts
+++ b/src/integration/contributorPipeline.test.ts
@@ -1,0 +1,353 @@
+// State-machine integration tests for the contributor approval pipeline
+// RPCs. Exercises every legal transition and a representative set of
+// forbidden transitions, on both the contributor-authored and staff-drafted
+// paths, against a real local Supabase stack.
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import {
+  admin,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+  countNotifications,
+} from './helpers';
+
+const PIECE = 'contrib-pipeline-test';
+
+let contributor: Awaited<ReturnType<typeof createAuthUser>>;
+let otherContributor: Awaited<ReturnType<typeof createAuthUser>>;
+let staff: Awaited<ReturnType<typeof createAuthUser>>;
+let normalUser: Awaited<ReturnType<typeof createAuthUser>>;
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'Contributor Pipeline Test Piece');
+  contributor = await createAuthUser({ isContributor: true, displayName: 'Test Contributor' });
+  otherContributor = await createAuthUser({ isContributor: true, displayName: 'Other Contributor' });
+  staff = await createAuthUser({ isStaff: true, displayName: 'Test Staff' });
+  normalUser = await createAuthUser({ displayName: 'Test Normal User' });
+});
+
+afterAll(async () => {
+  await deleteTestPiece(PIECE);
+  await deleteAuthUser(contributor.id);
+  await deleteAuthUser(otherContributor.id);
+  await deleteAuthUser(staff.id);
+  await deleteAuthUser(normalUser.id);
+});
+
+afterEach(async () => {
+  // Each test creates notes against the same piece; clean between tests.
+  await admin.from('performers_notes').update({ current_version_id: null }).eq('piece_id', PIECE);
+  await admin.from('notifications').delete().eq('performers_note_id', 'any'); // no-op unless needed
+  await admin.from('performers_note_versions').delete().eq('piece_id', PIECE);
+  await admin.from('performers_notes').delete().eq('piece_id', PIECE);
+});
+
+describe('contributor-authored path', () => {
+  test('publish_contributor_note creates + publishes atomically, no notification', async () => {
+    const { data: noteId, error } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'The prelude asks for bow speed more than articulation.',
+    });
+    expect(error).toBeNull();
+    expect(noteId).toBeTruthy();
+
+    const { data: note } = await admin
+      .from('performers_notes')
+      .select('status, drafted_by, approved_by, current_version_id')
+      .eq('id', noteId!)
+      .single();
+    expect(note!.status).toBe('published');
+    expect(note!.drafted_by).toBeNull();
+    expect(note!.approved_by).toBe(contributor.id);
+    expect(note!.current_version_id).toBeTruthy();
+
+    const { data: versions } = await admin
+      .from('performers_note_versions')
+      .select('version_number, approved_at, authored_by')
+      .eq('note_id', noteId!);
+    expect(versions!.length).toBe(1);
+    expect(versions![0].version_number).toBe(1);
+    expect(versions![0].approved_at).not.toBeNull();
+    expect(versions![0].authored_by).toBe(contributor.id);
+
+    expect(await countNotifications(noteId!)).toBe(0);
+  });
+
+  test('publish_contributor_edit advances current_version_id, no notification', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'v1 body',
+    });
+    const { data: v2Id, error } = await contributor.client.rpc('publish_contributor_edit', {
+      p_note_id: noteId!,
+      p_body: 'v2 body',
+    });
+    expect(error).toBeNull();
+
+    const { data: note } = await admin
+      .from('performers_notes')
+      .select('status, current_version_id')
+      .eq('id', noteId!)
+      .single();
+    expect(note!.status).toBe('published');
+    expect(note!.current_version_id).toBe(v2Id);
+
+    const { data: versions } = await admin
+      .from('performers_note_versions')
+      .select('version_number, body, approved_at')
+      .eq('note_id', noteId!)
+      .order('version_number');
+    expect(versions!.length).toBe(2);
+    expect(versions![1].version_number).toBe(2);
+    expect(versions![1].body).toBe('v2 body');
+    expect(versions![1].approved_at).not.toBeNull();
+
+    expect(await countNotifications(noteId!)).toBe(0);
+  });
+
+  test('remove_performers_note soft-removes, sets removed_by', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'to be removed',
+    });
+    const { error } = await contributor.client.rpc('remove_performers_note', { p_note_id: noteId! });
+    expect(error).toBeNull();
+
+    const { data: note } = await admin
+      .from('performers_notes')
+      .select('status, removed_by, removed_at')
+      .eq('id', noteId!)
+      .single();
+    expect(note!.status).toBe('removed');
+    expect(note!.removed_by).toBe(contributor.id);
+    expect(note!.removed_at).not.toBeNull();
+  });
+});
+
+describe('staff-drafted path', () => {
+  test('create + submit + approve lifecycle', async () => {
+    const { data: noteId, error: createErr } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'Staff draft body',
+    });
+    expect(createErr).toBeNull();
+
+    const { data: afterCreate } = await admin
+      .from('performers_notes')
+      .select('status, drafted_by')
+      .eq('id', noteId!)
+      .single();
+    expect(afterCreate!.status).toBe('draft');
+    expect(afterCreate!.drafted_by).toBe(staff.id);
+
+    const { error: submitErr } = await staff.client.rpc('submit_performers_note', { p_note_id: noteId! });
+    expect(submitErr).toBeNull();
+
+    const { data: afterSubmit } = await admin
+      .from('performers_notes')
+      .select('status, submitted_by')
+      .eq('id', noteId!)
+      .single();
+    expect(afterSubmit!.status).toBe('awaiting_contributor_approval');
+    expect(afterSubmit!.submitted_by).toBe(staff.id);
+    expect(await countNotifications(noteId!, { onlyUncleared: true })).toBe(1);
+
+    const { error: approveErr } = await contributor.client.rpc('approve_performers_note', { p_note_id: noteId! });
+    expect(approveErr).toBeNull();
+
+    const { data: afterApprove } = await admin
+      .from('performers_notes')
+      .select('status, approved_by, current_version_id')
+      .eq('id', noteId!)
+      .single();
+    expect(afterApprove!.status).toBe('published');
+    expect(afterApprove!.approved_by).toBe(contributor.id);
+    expect(afterApprove!.current_version_id).toBeTruthy();
+    expect(await countNotifications(noteId!, { onlyUncleared: true })).toBe(0);
+  });
+
+  test('reject loop: reject with reason, staff revises, approve', async () => {
+    const { data: noteId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'First draft',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: noteId! });
+    await contributor.client.rpc('reject_performers_note', {
+      p_note_id: noteId!,
+      p_reason: 'Too prescriptive.',
+    });
+
+    const { data: v1 } = await admin
+      .from('performers_note_versions')
+      .select('rejection_note, approved_at')
+      .eq('note_id', noteId!)
+      .single();
+    expect(v1!.rejection_note).toBe('Too prescriptive.');
+    expect(v1!.approved_at).toBeNull();
+    expect(await countNotifications(noteId!, { onlyUncleared: true })).toBe(0);
+
+    await staff.client.rpc('update_performers_note_draft', { p_note_id: noteId!, p_body: 'Revised draft' });
+    const { data: versions } = await admin
+      .from('performers_note_versions')
+      .select('version_number, body, rejection_note')
+      .eq('note_id', noteId!)
+      .order('version_number');
+    expect(versions!.length).toBe(2);
+    expect(versions![0].rejection_note).toBe('Too prescriptive.'); // preserved on v1
+    expect(versions![1].body).toBe('Revised draft');
+
+    await staff.client.rpc('submit_performers_note', { p_note_id: noteId! });
+    await contributor.client.rpc('approve_performers_note', { p_note_id: noteId! });
+
+    const { data: final } = await admin
+      .from('performers_notes')
+      .select('status, current_version_id')
+      .eq('id', noteId!)
+      .single();
+    expect(final!.status).toBe('published');
+    // current should be v2
+    const { data: currentVersion } = await admin
+      .from('performers_note_versions')
+      .select('version_number')
+      .eq('id', final!.current_version_id!)
+      .single();
+    expect(currentVersion!.version_number).toBe(2);
+  });
+
+  test('approve_and_edit publishes contributor body as new version', async () => {
+    const { data: noteId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'Staff wording',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: noteId! });
+
+    const { data: v2Id, error } = await contributor.client.rpc('approve_and_edit_performers_note', {
+      p_note_id: noteId!,
+      p_body: 'Contributor edited wording',
+    });
+    expect(error).toBeNull();
+
+    const { data: note } = await admin
+      .from('performers_notes')
+      .select('status, current_version_id')
+      .eq('id', noteId!)
+      .single();
+    expect(note!.status).toBe('published');
+    expect(note!.current_version_id).toBe(v2Id);
+
+    const { data: v2 } = await admin
+      .from('performers_note_versions')
+      .select('body, authored_by, approved_at')
+      .eq('id', v2Id!)
+      .single();
+    expect(v2!.body).toBe('Contributor edited wording');
+    expect(v2!.authored_by).toBe(contributor.id);
+    expect(v2!.approved_at).not.toBeNull();
+
+    expect(await countNotifications(noteId!, { onlyUncleared: true })).toBe(0);
+  });
+
+  test('staff retract clears notification, sets retracted_by', async () => {
+    const { data: noteId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'To retract',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: noteId! });
+    expect(await countNotifications(noteId!, { onlyUncleared: true })).toBe(1);
+
+    const { error } = await staff.client.rpc('retract_performers_note', { p_note_id: noteId! });
+    expect(error).toBeNull();
+
+    const { data: note } = await admin
+      .from('performers_notes')
+      .select('status, retracted_by, retracted_at')
+      .eq('id', noteId!)
+      .single();
+    expect(note!.status).toBe('draft');
+    expect(note!.retracted_by).toBe(staff.id);
+    expect(note!.retracted_at).not.toBeNull();
+    expect(await countNotifications(noteId!, { onlyUncleared: true })).toBe(0);
+  });
+});
+
+describe('forbidden transitions', () => {
+  test('non-contributor cannot call publish_contributor_note', async () => {
+    const { error } = await normalUser.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'should fail',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain('not an active contributor');
+  });
+
+  test('non-staff cannot call create_performers_note_draft', async () => {
+    const { error } = await contributor.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'should fail',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain('not staff');
+  });
+
+  test('contributor cannot approve another contributor\'s draft', async () => {
+    const { data: noteId } = await staff.client.rpc('create_performers_note_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'target draft',
+    });
+    await staff.client.rpc('submit_performers_note', { p_note_id: noteId! });
+
+    const { error } = await otherContributor.client.rpc('approve_performers_note', { p_note_id: noteId! });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not owned by caller/i);
+  });
+
+  test('cannot approve a note not in awaiting state', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'already published',
+    });
+    const { error } = await contributor.client.rpc('approve_performers_note', { p_note_id: noteId! });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/pending version|awaiting|submitted/i);
+  });
+
+  test('cannot retract a published note', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'already published',
+    });
+    const { error } = await staff.client.rpc('retract_performers_note', { p_note_id: noteId! });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/submitted draft/i);
+  });
+
+  test('publish_contributor_edit on non-owned note fails', async () => {
+    const { data: noteId } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: 'owner body',
+    });
+    const { error } = await otherContributor.client.rpc('publish_contributor_edit', {
+      p_note_id: noteId!,
+      p_body: 'hijack',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not owned by caller/i);
+  });
+
+  test('publish_contributor_note requires non-empty body', async () => {
+    const { error } = await contributor.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE,
+      p_body: '   ',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain('body required');
+  });
+});

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -1,0 +1,123 @@
+// Integration-test helpers for the contributor pipeline RPCs.
+//
+// These tests run against a real local Supabase stack (`supabase start`) via
+// the bun test runner. They create real auth users, real pieces, exercise the
+// security-definer RPCs, and clean up after themselves.
+//
+// Env: SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY (loaded
+// from .env.test via --env-file at the bun invocation).
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const URL = process.env.SUPABASE_URL!;
+const ANON = process.env.SUPABASE_ANON_KEY!;
+const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+if (!URL || !ANON || !SERVICE) {
+  throw new Error(
+    'Integration tests require SUPABASE_URL, SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY.\n' +
+      'Run via `bun run test:integration` which loads .env.test.',
+  );
+}
+
+export const admin: SupabaseClient = createClient(URL, SERVICE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+export function anon(): SupabaseClient {
+  return createClient(URL, ANON, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+// Creates a fresh auth user and returns a client signed in as that user.
+// Optionally promotes to contributor (via direct admin UPDATE — bypasses the
+// seed-contributor script's public.users path for test brevity).
+export async function createAuthUser(opts: {
+  email?: string;
+  password?: string;
+  isContributor?: boolean;
+  isStaff?: boolean; // sets users.role = 'admin'
+  contributorBioShort?: string;
+  displayName?: string;
+}): Promise<{ id: string; email: string; client: SupabaseClient }> {
+  const email = opts.email ?? `test-${crypto.randomUUID()}@example.com`;
+  const password = opts.password ?? 'test-password-1234';
+
+  const { data: created, error: createErr } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: opts.displayName ? { display_name: opts.displayName } : undefined,
+  });
+  if (createErr) throw new Error(`createUser: ${createErr.message}`);
+
+  const userId = created.user!.id;
+
+  // The auto_create_user_profile trigger already inserted into public.users.
+  // Patch the fields we care about for this test.
+  const patch: Record<string, unknown> = {};
+  if (opts.displayName) patch.display_name = opts.displayName;
+  if (opts.isContributor) {
+    patch.is_contributor = true;
+    patch.contributor_active = true;
+    patch.contributor_agreement_signed_at = new Date().toISOString();
+  }
+  if (opts.contributorBioShort) patch.contributor_bio_short = opts.contributorBioShort;
+  if (opts.isStaff) patch.role = 'admin';
+
+  if (Object.keys(patch).length > 0) {
+    const { error: updateErr } = await admin.from('users').update(patch).eq('id', userId);
+    if (updateErr) throw new Error(`update users: ${updateErr.message}`);
+  }
+
+  // Sign in to get a JWT'd client. The returned client's calls will see
+  // `auth.uid() = userId` inside RPCs.
+  const client = createClient(URL, ANON, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const { error: signInErr } = await client.auth.signInWithPassword({ email, password });
+  if (signInErr) throw new Error(`signIn: ${signInErr.message}`);
+
+  return { id: userId, email, client };
+}
+
+export async function deleteAuthUser(id: string): Promise<void> {
+  // auth.users cascade to public.users and everything below.
+  await admin.auth.admin.deleteUser(id);
+}
+
+export async function createTestPiece(id: string, title = 'Test Piece'): Promise<void> {
+  const { error } = await admin.from('pieces').upsert({
+    id,
+    title,
+    composer_name: 'Anonymous',
+    era: 'Baroque',
+    form: 'test',
+    instruments: [],
+    difficulty: 'intermediate',
+    description: '',
+  });
+  if (error) throw new Error(`insert piece: ${error.message}`);
+}
+
+export async function deleteTestPiece(id: string): Promise<void> {
+  // Null current_version_id first so we can delete version rows, then the
+  // composite FK cascade handles the rest.
+  await admin.from('performers_notes').update({ current_version_id: null, status: 'removed' }).eq('piece_id', id);
+  await admin.from('performers_note_versions').delete().eq('piece_id', id);
+  await admin.from('performers_notes').delete().eq('piece_id', id);
+  await admin.from('pieces').delete().eq('id', id);
+}
+
+// Convenience: count notifications scoped to a note.
+export async function countNotifications(
+  noteId: string,
+  opts: { onlyUncleared?: boolean } = {},
+): Promise<number> {
+  let q = admin.from('notifications').select('id', { count: 'exact', head: true }).eq('performers_note_id', noteId);
+  if (opts.onlyUncleared) q = q.is('cleared_at', null);
+  const { count, error } = await q;
+  if (error) throw new Error(`count notifications: ${error.message}`);
+  return count ?? 0;
+}


### PR DESCRIPTION
Slice A **step 2 completion** — RPC behavior covered end-to-end against local Supabase.

## Key decision: drop the Astro API layer

The plan originally called for 11 thin Astro endpoints that would session-check then call RPCs. After review, those add zero security or functional value beyond what the security-definer RPCs already enforce. PostgREST automatically exposes each RPC at \`POST /rest/v1/rpc/<function_name>\` with a user JWT, which is what the browser supabase-js client uses under the hood and what curl tests can hit directly.

If Slice B+ needs server-side orchestration (cron-triggered actions, multi-RPC transactions, rate limits) we add routes then. For now: UI calls \`supabase.rpc(...)\` directly.

## What ships
- \`src/integration/helpers.ts\` — createAuthUser (via admin API + promote), deleteAuthUser, createTestPiece, countNotifications
- \`src/integration/contributorPipeline.test.ts\` — **14 state-machine tests**:
  - Contributor-authored path: create + publish, edit, remove
  - Staff-drafted path: create → submit → approve
  - Reject loop with staff revision via \`update_performers_note_draft\`
  - Approve-and-edit publishes contributor's body as new version
  - Staff retract clears notification + sets audit column
  - Forbidden: non-contributor self-publish, non-staff create, non-owner approve, double-approve, retract-after-publish, non-owner edit, empty body
- \`src/integration/contributorPipeline.rls.test.ts\` — **16 RLS + integrity tests**:
  - Anonymous sees only \`status=published\`
  - Non-owner contributor blocked from pending drafts
  - Owner contributor + staff see their scoped views
  - Version rows invisible to anonymous and non-owners
  - Notifications scoped to recipient
  - **Iron-rule regression**: \`publish_contributor_note\` and \`publish_contributor_edit\` create zero notifications (with a control that \`submit_performers_note\` does create one)
  - Byline integrity: cannot set \`display_name=null\` on a contributor
  - \`clear_notification\` / \`clear_all_notifications\` ownership

## Test run
\`\`\`
$ bun run test:integration
 30 pass, 0 fail, 98 expect() calls, 1407ms
\`\`\`

## Plumbing
- new \`bun run test:integration\` loads \`.env.test\` pointing at local Supabase (127.0.0.1:54321)
- \`test:all\` chains unit → integration → e2e
- \`.env.test\` committed with the Supabase CLI's well-known demo keys (not secrets — every install ships them)

## Plan updates
- §5 API / route surface — replaced route table with RPC reference table + explicit decision note
- §6 NavbarBell — queries notifications via supabase client directly instead of fetching \`/api/notifications\`

## Depends on
- #32 (RPC migration, merged + deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)