### PR TITLE
feat(email): shared Claude-kit email template + weekly digest reskin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage/
 .dev.vars
 supabase/.temp/
 supabase/.branches/
+dist-preview/
 .context/
 .claude/
 outreach-emails.csv

--- a/scripts/preview-email.ts
+++ b/scripts/preview-email.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env bun
+// Renders sample emails to HTML files for visual review. No network calls —
+// pure local rendering of whatever's shipped in supabase/functions/_lib/.
+//
+// Usage:
+//   bun run scripts/preview-email.ts                 # write + print paths
+//   bun run scripts/preview-email.ts --open          # also open in browser
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+import {
+  card,
+  esc,
+  heading,
+  kicker,
+  paragraph,
+  primaryButton,
+  renderEmailLayout,
+  TOKENS,
+} from '../supabase/functions/_lib/email-template';
+
+const OUT_DIR = resolve(import.meta.dir, '..', 'dist-preview');
+
+// Sample data — matches current prod catalog shape
+const sampleWeeklyDigest = renderWeeklyDigestSample();
+const sampleNotificationDigest = renderNotificationDigestSample();
+const sampleSwatches = renderSwatches();
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  await writeFile(resolve(OUT_DIR, 'weekly-digest.html'), sampleWeeklyDigest);
+  await writeFile(resolve(OUT_DIR, 'notification-digest.html'), sampleNotificationDigest);
+  await writeFile(resolve(OUT_DIR, 'swatches.html'), sampleSwatches);
+
+  console.log('Rendered previews:');
+  console.log(`  ${resolve(OUT_DIR, 'weekly-digest.html')}`);
+  console.log(`  ${resolve(OUT_DIR, 'notification-digest.html')}`);
+  console.log(`  ${resolve(OUT_DIR, 'swatches.html')}`);
+
+  if (process.argv.includes('--open')) {
+    for (const file of ['weekly-digest.html', 'notification-digest.html', 'swatches.html']) {
+      spawn('open', [resolve(OUT_DIR, file)], { stdio: 'ignore', detached: true }).unref();
+    }
+  }
+}
+
+function renderWeeklyDigestSample(): string {
+  const pieces = [
+    {
+      id: 'bach-cello-1',
+      title: 'Cello Suite No. 1 in G major',
+      composer_name: 'Bach, J.S.',
+      catalog_number: 'BWV 1007',
+      instruments: ['cello'],
+      era: 'Baroque',
+      description: 'The most-played of the Six, and the one every cellist must eventually confront on their own terms.',
+    },
+    {
+      id: 'dvorak-cello-concerto',
+      title: 'Cello Concerto in B minor',
+      composer_name: 'Dvořák, Antonín',
+      catalog_number: 'Op. 104',
+      instruments: ['cello', 'orchestra'],
+      era: 'Romantic',
+      description: 'The concerto that convinced Brahms to wish he had written one. The Adagio ma non troppo is the passage cellists return to for the rest of their lives.',
+    },
+  ];
+
+  const piecesHtml = pieces.map(renderPieceCardSample).join('\n');
+
+  const bodyHtml = `
+    <div style="padding-bottom:12px;">${paragraph('Dear Haji,')}</div>
+    <div style="padding-bottom:20px;">${paragraph('2 new pieces added to the catalog this week. The catalog now holds 19 pieces.', { muted: true })}</div>
+    ${renderStatBlockSample(19, 2)}
+    <div style="padding-bottom:12px;">${kicker('New this week')}</div>
+    ${piecesHtml}
+    <div align="center" style="padding:24px 0 8px;">
+      ${primaryButton({ text: 'Explore Irregular Pearl', href: 'https://irregularpearl.org' })}
+    </div>
+  `;
+
+  return renderEmailLayout({
+    title: 'Irregular Pearl — Weekly Digest · April 13–20, 2026',
+    preheader: '2 new pieces added to the catalog this week. The catalog now holds 19 pieces.',
+    subtitle: 'Weekly Digest',
+    bodyHtml,
+    footerNote: "You're receiving this because you opted in to weekly digests.",
+    footerLink: { text: 'Unsubscribe', href: 'https://irregularpearl.org/settings#email' },
+  });
+}
+
+function renderPieceCardSample(p: {
+  id: string;
+  title: string;
+  composer_name: string;
+  catalog_number: string | null;
+  instruments: string[];
+  era: string;
+  description: string;
+}): string {
+  const meta = [p.instruments.slice(0, 2).join(', '), p.era].filter(Boolean).join(' · ');
+  const desc = p.description.length > 140
+    ? p.description.slice(0, 140).replace(/\s+\S*$/, '') + '...'
+    : p.description;
+  const url = `https://irregularpearl.org/piece/${p.id}`;
+
+  const inner = `
+    <div style="display:flex;justify-content:space-between;font-family:${TOKENS.sans};font-size:11px;color:${TOKENS.accent};letter-spacing:0.08em;font-weight:500;text-transform:uppercase;">
+      <span>${esc(meta)}</span>
+      ${p.catalog_number ? `<span style="color:${TOKENS.muted};">${esc(p.catalog_number)}</span>` : ''}
+    </div>
+    <div style="padding-top:6px;">${heading(p.title, { level: 'h3', href: url })}</div>
+    <div style="padding-top:4px;">${paragraph(p.composer_name, { muted: true })}</div>
+    ${desc ? `<div style="padding-top:10px;">${paragraph(desc, { family: 'serif' })}</div>` : ''}
+  `;
+
+  return card({ html: inner, accent: true });
+}
+
+function renderStatBlockSample(total: number, newCount: number): string {
+  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom:20px;">
+<tr>
+  <td width="50%" align="center" style="padding:14px 0;border:1px solid ${TOKENS.border};border-radius:8px 0 0 8px;border-right:0;">
+    <div style="font-family:${TOKENS.serif};font-size:26px;color:${TOKENS.ink};">${total}</div>
+    <div style="font-family:${TOKENS.sans};font-size:10px;color:${TOKENS.muted};text-transform:uppercase;letter-spacing:0.08em;padding-top:2px;">Pieces</div>
+  </td>
+  <td width="50%" align="center" style="padding:14px 0;border:1px solid ${TOKENS.border};border-radius:0 8px 8px 0;">
+    <div style="font-family:${TOKENS.serif};font-size:26px;color:${TOKENS.ink};">${newCount}</div>
+    <div style="font-family:${TOKENS.sans};font-size:10px;color:${TOKENS.muted};text-transform:uppercase;letter-spacing:0.08em;padding-top:2px;">New this week</div>
+  </td>
+</tr>
+</table>`;
+}
+
+// Stub for the Slice A daily digest — same template primitives, different body.
+function renderNotificationDigestSample(): string {
+  const items = [
+    {
+      piece: 'Cello Suite No. 1 in G major',
+      url: 'https://irregularpearl.org/piece/bach-cello-1#performers-notes',
+      excerpt: 'A draft performer\'s note awaits your review.',
+    },
+    {
+      piece: 'Dvořák Cello Concerto',
+      url: 'https://irregularpearl.org/piece/dvorak-cello-concerto#performers-notes',
+      excerpt: 'A revised draft is ready after your earlier notes.',
+    },
+  ];
+
+  const itemsHtml = items.map((item) => {
+    const inner = `
+      ${heading(item.piece, { level: 'h3', href: item.url })}
+      <div style="padding-top:6px;">${paragraph(item.excerpt, { muted: true })}</div>
+    `;
+    return card({ html: inner, accent: true });
+  }).join('\n');
+
+  const bodyHtml = `
+    <div style="padding-bottom:12px;">${paragraph('Dear Haji,')}</div>
+    <div style="padding-bottom:20px;">${paragraph('You have 2 un-cleared notifications waiting in your queue.', { muted: true })}</div>
+    <div style="padding-bottom:12px;">${kicker('Awaiting your review')}</div>
+    ${itemsHtml}
+    <div align="center" style="padding:24px 0 8px;">
+      ${primaryButton({ text: 'Open your queue', href: 'https://irregularpearl.org/notifications' })}
+    </div>
+  `;
+
+  return renderEmailLayout({
+    title: 'Irregular Pearl — 2 items await your review',
+    preheader: 'You have 2 un-cleared notifications waiting in your queue.',
+    subtitle: 'Daily digest',
+    bodyHtml,
+    footerNote: 'You\'re receiving this because drafts are waiting for your approval.',
+    footerLink: { text: 'Email preferences', href: 'https://irregularpearl.org/settings#email' },
+  });
+}
+
+function renderSwatches(): string {
+  const colors = [
+    ['bg', TOKENS.bg],
+    ['ink', TOKENS.ink],
+    ['muted', TOKENS.muted],
+    ['hint', TOKENS.hint],
+    ['border', TOKENS.border],
+    ['borderStrong', TOKENS.borderStrong],
+    ['accent', TOKENS.accent],
+    ['accentSoft', TOKENS.accentSoft],
+  ];
+
+  const rows = colors.map(([name, hex]) =>
+    `<tr><td style="padding:8px 16px;width:160px;background:${hex};border:1px solid ${TOKENS.border};">&nbsp;</td><td style="padding:8px 16px;font-family:${TOKENS.sans};font-size:13px;">${esc(name)} = <code>${esc(hex)}</code></td></tr>`
+  ).join('\n');
+
+  return renderEmailLayout({
+    title: 'Email template swatches',
+    subtitle: 'Swatches',
+    bodyHtml: `
+      <div style="padding-bottom:16px;">${paragraph('Claude-kit email tokens as rendered on a real email client surface.')}</div>
+      <table role="presentation" cellspacing="0" cellpadding="0" border="0">${rows}</table>
+    `,
+  });
+}
+
+await main();

--- a/src/tests/email-template.test.ts
+++ b/src/tests/email-template.test.ts
@@ -1,0 +1,161 @@
+// Unit tests for the shared email template primitives.
+// The template module lives under supabase/functions/_lib/ so edge functions
+// can import it at runtime, but it's pure TypeScript with no Deno APIs —
+// safe to import directly from a bun test.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  TOKENS,
+  esc,
+  kicker,
+  heading,
+  paragraph,
+  primaryButton,
+  link,
+  divider,
+  card,
+  renderEmailLayout,
+} from '../../supabase/functions/_lib/email-template';
+
+describe('esc', () => {
+  test('escapes all five HTML-unsafe chars', () => {
+    expect(esc(`<a href="x">&'`)).toBe('&lt;a href=&quot;x&quot;&gt;&amp;&#39;');
+  });
+});
+
+describe('kicker', () => {
+  test('renders with accent color and uppercase transform', () => {
+    const html = kicker('new this week');
+    expect(html).toContain(TOKENS.accent);
+    expect(html).toContain('text-transform:uppercase');
+    expect(html).toContain('new this week');
+  });
+});
+
+describe('heading', () => {
+  test('wraps in anchor when href supplied', () => {
+    const html = heading('Cello Suite No. 1', { href: 'https://example.com/a' });
+    expect(html).toContain('<a href="https://example.com/a"');
+    expect(html).toContain('Cello Suite No. 1');
+  });
+
+  test('no anchor when href omitted', () => {
+    const html = heading('No link');
+    expect(html).not.toContain('<a ');
+  });
+
+  test('h1 uses larger size than default', () => {
+    const h1 = heading('Big', { level: 'h1' });
+    const h3 = heading('Small', { level: 'h3' });
+    expect(h1).toContain('font-size:28px');
+    expect(h3).toContain('font-size:18px');
+  });
+});
+
+describe('paragraph', () => {
+  test('default uses sans', () => {
+    expect(paragraph('body')).toContain('Inter');
+  });
+
+  test('serif mode uses Source Serif 4', () => {
+    const html = paragraph('editorial', { family: 'serif' });
+    expect(html).toContain('Source Serif 4');
+    expect(html).toContain('line-height:1.68');
+  });
+
+  test('muted mode uses muted color', () => {
+    const html = paragraph('x', { muted: true });
+    expect(html).toContain(TOKENS.muted);
+  });
+});
+
+describe('primaryButton', () => {
+  test('uses dark-ink background, white text, href as given', () => {
+    const html = primaryButton({ text: 'Explore', href: 'https://example.com' });
+    expect(html).toContain(`background:${TOKENS.ink}`);
+    expect(html).toContain('color:#FFFFFF');
+    expect(html).toContain('href="https://example.com"');
+  });
+});
+
+describe('link', () => {
+  test('muted link uses hint color', () => {
+    const html = link({ text: 'Unsubscribe', href: 'https://example.com/u', muted: true });
+    expect(html).toContain(TOKENS.hint);
+  });
+
+  test('default link uses accent color', () => {
+    const html = link({ text: 'Settings', href: 'https://example.com/s' });
+    expect(html).toContain(TOKENS.accent);
+  });
+});
+
+describe('divider', () => {
+  test('renders a 1px rule in border color by default', () => {
+    expect(divider()).toContain(`border-top:1px solid ${TOKENS.border}`);
+  });
+
+  test('custom color overrides default', () => {
+    expect(divider({ color: '#FF0000' })).toContain('border-top:1px solid #FF0000');
+  });
+});
+
+describe('card', () => {
+  test('default uses 1px border, no accent left', () => {
+    const html = card({ html: 'inner' });
+    expect(html).toContain(`border:1px solid ${TOKENS.border}`);
+    expect(html).not.toContain(`border-left:2px solid ${TOKENS.accent}`);
+    expect(html).toContain('inner');
+  });
+
+  test('accent mode adds 2px purple left border', () => {
+    const html = card({ html: 'inner', accent: true });
+    expect(html).toContain(`border-left:2px solid ${TOKENS.accent}`);
+  });
+});
+
+describe('renderEmailLayout', () => {
+  test('includes title, preheader, body, and wordmark', () => {
+    const html = renderEmailLayout({
+      title: 'Irregular Pearl — Test',
+      preheader: 'Preview snippet here.',
+      subtitle: 'Weekly Digest',
+      bodyHtml: '<p>BODY_MARKER</p>',
+    });
+    expect(html).toContain('<title>Irregular Pearl — Test</title>');
+    expect(html).toContain('Preview snippet here.');
+    expect(html).toContain('BODY_MARKER');
+    expect(html).toContain('IrregularPearl'); // wordmark, non-italic
+    expect(html).toContain('Weekly Digest'); // subtitle
+  });
+
+  test('omits footer when no footerNote or footerLink given', () => {
+    const html = renderEmailLayout({ title: 't', bodyHtml: 'body' });
+    expect(html).not.toContain('Unsubscribe');
+  });
+
+  test('includes footer note + link when provided', () => {
+    const html = renderEmailLayout({
+      title: 't',
+      bodyHtml: 'body',
+      footerNote: 'Opt-in reminder.',
+      footerLink: { text: 'Unsubscribe', href: 'https://example.com/u' },
+    });
+    expect(html).toContain('Opt-in reminder.');
+    expect(html).toContain('Unsubscribe');
+  });
+
+  test('output has no amber #B45309 — Claude kit reskin complete', () => {
+    const html = renderEmailLayout({ title: 't', bodyHtml: paragraph('test') });
+    expect(html.toUpperCase()).not.toContain('#B45309');
+    expect(html.toUpperCase()).not.toContain('#B4530');
+  });
+
+  test('output contains the Claude-kit accent purple', () => {
+    const html = renderEmailLayout({
+      title: 't',
+      bodyHtml: kicker('Section'),
+    });
+    expect(html).toContain(TOKENS.accent);
+  });
+});

--- a/supabase/functions/_lib/email-template.ts
+++ b/supabase/functions/_lib/email-template.ts
@@ -1,0 +1,162 @@
+// Shared email template primitives for Irregular Pearl transactional and
+// digest mail. Pure TypeScript, no Deno-specific APIs — importable from
+// edge functions and from bun-based unit tests alike.
+//
+// Aesthetic follows DESIGN.md's Claude-kit direction:
+//   - purple accent #6B4E7C, used sparingly
+//   - Source Serif 4 for editorial prose (Georgia email-safe fallback)
+//   - Inter for UI/meta (Arial email-safe fallback)
+//   - neutral white background #FFFFFF
+//   - 1px borders in #E5E3DE (0.5px is the web ideal; email clients round it up)
+//   - wordmark: "IrregularPearl" in Inter medium, non-italic
+//
+// Keep the shape narrow — add primitives only when a real email surface needs
+// them. Every added knob is an email client quirk waiting to happen.
+
+export const TOKENS = {
+  bg: "#FFFFFF",
+  ink: "#1A1A1A",
+  muted: "#6F6F6F",
+  hint: "#9A9A9A",
+  border: "#E5E3DE",
+  borderStrong: "#CCC9C2",
+  accent: "#6B4E7C",
+  accentSoft: "#F2EEF5",
+  serif: "'Source Serif 4', Georgia, 'Times New Roman', serif",
+  sans: "Inter, Arial, sans-serif",
+} as const;
+
+export function esc(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ============================================================
+// Primitives
+// ============================================================
+
+/** A small-caps section label. Accent-purple, Inter, letter-spaced. */
+export function kicker(text: string): string {
+  return `<div style="font-family:${TOKENS.sans};font-size:11px;font-weight:500;color:${TOKENS.accent};letter-spacing:0.08em;text-transform:uppercase;">${esc(text)}</div>`;
+}
+
+/** Editorial heading (Source Serif). Sizes 18/22/28 cover most uses. */
+export function heading(text: string, opts: { level?: "h1" | "h2" | "h3"; href?: string } = {}): string {
+  const size = opts.level === "h1" ? 28 : opts.level === "h3" ? 18 : 22;
+  const lineHeight = 1.25;
+  const content = opts.href
+    ? `<a href="${esc(opts.href)}" style="text-decoration:none;color:${TOKENS.ink};" target="_blank" rel="noopener">${esc(text)}</a>`
+    : esc(text);
+  return `<div style="font-family:${TOKENS.serif};font-size:${size}px;color:${TOKENS.ink};line-height:${lineHeight};">${content}</div>`;
+}
+
+/** Body paragraph. Serif for editorial prose, sans for UI/meta. */
+export function paragraph(text: string, opts: { family?: "serif" | "sans"; muted?: boolean } = {}): string {
+  const family = opts.family === "serif" ? TOKENS.serif : TOKENS.sans;
+  const size = opts.family === "serif" ? 15 : 14;
+  const lineHeight = opts.family === "serif" ? 1.68 : 1.55;
+  const color = opts.muted ? TOKENS.muted : TOKENS.ink;
+  return `<div style="font-family:${family};font-size:${size}px;color:${color};line-height:${lineHeight};">${esc(text)}</div>`;
+}
+
+/** Primary CTA button. Dark-ink solid, not accent-purple (matches web convention). */
+export function primaryButton(opts: { text: string; href: string }): string {
+  return `<a href="${esc(opts.href)}" style="display:inline-block;font-family:${TOKENS.sans};font-size:14px;font-weight:500;color:#FFFFFF;text-decoration:none;padding:12px 28px;border-radius:8px;background:${TOKENS.ink};" target="_blank" rel="noopener">${esc(opts.text)}</a>`;
+}
+
+/** Secondary link. Muted, underlined. */
+export function link(opts: { text: string; href: string; muted?: boolean }): string {
+  const color = opts.muted ? TOKENS.hint : TOKENS.accent;
+  return `<a href="${esc(opts.href)}" style="color:${color};text-decoration:underline;" target="_blank" rel="noopener">${esc(opts.text)}</a>`;
+}
+
+/** Thin divider rule — matches the web's 0.5px border (1px is the email minimum). */
+export function divider(opts: { color?: string } = {}): string {
+  return `<div style="border-top:1px solid ${opts.color ?? TOKENS.border};"></div>`;
+}
+
+/**
+ * Card block. White, 1px border, 12px radius, 16px padding. Signed notes and
+ * other accent-emphasis uses pass `accent: true` for a 2px purple left border.
+ */
+export function card(opts: { html: string; accent?: boolean }): string {
+  const borderLeft = opts.accent ? `border-left:2px solid ${TOKENS.accent};` : "";
+  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom:12px;background:${TOKENS.bg};border:1px solid ${TOKENS.border};${borderLeft}border-radius:8px;">
+<tr><td style="padding:16px 20px;">${opts.html}</td></tr>
+</table>`;
+}
+
+// ============================================================
+// Layout
+// ============================================================
+
+export interface EmailLayoutOpts {
+  /** <title> and default subject fallback. */
+  title: string;
+  /** Preheader — the preview snippet most clients show next to the subject. */
+  preheader?: string;
+  /** Subtitle under the wordmark, e.g. "Weekly Digest". Inter caps. */
+  subtitle?: string;
+  /** Main body HTML, stacked inside the centered 600px column. */
+  bodyHtml: string;
+  /** Optional small footer note above the divider (e.g. "You're receiving…"). */
+  footerNote?: string;
+  /** Optional footer action link (e.g. unsubscribe). Rendered muted. */
+  footerLink?: { text: string; href: string };
+}
+
+/** Wraps a body in the full email HTML layout with wordmark header + footer. */
+export function renderEmailLayout(opts: EmailLayoutOpts): string {
+  const preheader = opts.preheader
+    ? `<div style="display:none;max-height:0;overflow:hidden;">${esc(opts.preheader)}</div>`
+    : "";
+
+  const subtitle = opts.subtitle
+    ? `<div style="font-family:${TOKENS.sans};font-size:11px;font-weight:500;color:${TOKENS.hint};letter-spacing:0.12em;text-transform:uppercase;padding:8px 0 16px;">${esc(opts.subtitle)}</div>`
+    : "";
+
+  const footer = (opts.footerNote || opts.footerLink)
+    ? `<tr><td class="wi" align="center" style="padding:24px 24px 0;">${divider()}</td></tr>
+<tr><td class="wi" align="center" style="padding:16px 24px 0;">
+  ${opts.footerNote ? `<div style="font-family:${TOKENS.sans};font-size:11px;color:${TOKENS.hint};line-height:1.6;">${esc(opts.footerNote)}</div>` : ""}
+  ${opts.footerLink ? `<div style="font-family:${TOKENS.sans};font-size:11px;margin-top:6px;">${link({ ...opts.footerLink, muted: true })}</div>` : ""}
+</td></tr>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<title>${esc(opts.title)}</title>
+<style>body,table,td,a{-webkit-text-size-adjust:100%}table,td{border-collapse:collapse}body{margin:0;padding:0;background:${TOKENS.bg}}
+@media only screen and (max-width:620px){.w{width:100%!important}.wi{padding:0 16px!important}}</style>
+</head>
+<body style="margin:0;padding:0;background:${TOKENS.bg};-webkit-font-smoothing:antialiased;">
+${preheader}
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background:${TOKENS.bg};">
+<tr><td align="center" valign="top" style="padding:32px 0 48px;">
+<table role="presentation" class="w" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width:600px;">
+
+<!-- HEADER -->
+<tr><td class="wi" align="center" style="padding:0 24px 20px;">
+  <div style="font-family:${TOKENS.sans};font-size:22px;font-weight:500;color:${TOKENS.ink};padding:12px 0 0;">
+    <a href="https://irregularpearl.org" style="text-decoration:none;color:${TOKENS.ink};" target="_blank" rel="noopener">IrregularPearl</a>
+  </div>
+  ${subtitle}
+  ${divider()}
+</td></tr>
+
+<!-- BODY -->
+<tr><td class="wi" style="padding:20px 24px 0;">
+${opts.bodyHtml}
+</td></tr>
+
+${footer}
+
+</table>
+</td></tr></table>
+</body></html>`;
+}

--- a/supabase/functions/send-weekly-digest/index.ts
+++ b/supabase/functions/send-weekly-digest/index.ts
@@ -1,20 +1,26 @@
 // Supabase Edge Function: send-weekly-digest
 // Triggered weekly via GitHub Actions cron (Mondays 03:00 UTC).
-// Fetches all users with email_weekly_digest=true, renders a digest for each,
+// Fetches users with email_weekly_digest=true, renders a digest for each,
 // and sends via Resend.
 //
 // Invoke: POST /functions/v1/send-weekly-digest
 // Auth: requires SUPABASE_SERVICE_ROLE_KEY in Authorization header
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  TOKENS,
+  card,
+  esc,
+  heading,
+  kicker,
+  paragraph,
+  primaryButton,
+  renderEmailLayout,
+} from "../_lib/email-template.ts";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-
-function esc(str: string): string {
-  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
 
 interface DigestPiece {
   id: string;
@@ -28,24 +34,40 @@ interface DigestPiece {
 
 function renderPieceCard(p: DigestPiece): string {
   const meta = [p.instruments.slice(0, 2).join(", "), p.era].filter(Boolean).join(" · ");
-  const desc = p.description.length > 140 ? p.description.slice(0, 140).replace(/\s+\S*$/, "") + "..." : p.description;
+  const desc = p.description.length > 140
+    ? p.description.slice(0, 140).replace(/\s+\S*$/, "") + "..."
+    : p.description;
   const url = `https://irregularpearl.org/piece/${p.id}`;
 
-  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom:12px;background:#FFF;border:1px solid #E7E5E4;border-left:3px solid #B45309;">
-<tr><td style="padding:18px 20px;border-radius:8px;">
-  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-    <tr><td style="font-family:'Courier New',monospace;font-size:10px;color:#B45309;letter-spacing:0.06em;text-transform:uppercase;">${esc(meta)}</td>
-    ${p.catalog_number ? `<td align="right" style="font-family:'Courier New',monospace;font-size:10px;color:#78716C;">${esc(p.catalog_number)}</td>` : ""}</tr>
-    <tr><td colspan="2" style="padding-top:6px;padding-bottom:4px;font-family:Georgia,serif;font-size:18px;color:#1C1917;line-height:1.25;">
-      <a href="${url}" style="text-decoration:none;color:#1C1917;" target="_blank">${esc(p.title)}</a>
-    </td></tr>
-    <tr><td colspan="2" style="padding-bottom:${desc ? "10px" : "0"};font-family:Arial,sans-serif;font-size:13px;color:#78716C;">${esc(p.composer_name)}</td></tr>
-    ${desc ? `<tr><td colspan="2" style="font-family:Arial,sans-serif;font-size:13px;color:#1C1917;line-height:1.55;">${esc(desc)}</td></tr>` : ""}
-  </table>
-</td></tr></table>`;
+  const inner = `
+    <div style="display:flex;justify-content:space-between;font-family:${TOKENS.sans};font-size:11px;color:${TOKENS.accent};letter-spacing:0.08em;font-weight:500;text-transform:uppercase;">
+      <span>${esc(meta)}</span>
+      ${p.catalog_number ? `<span style="color:${TOKENS.muted};">${esc(p.catalog_number)}</span>` : ""}
+    </div>
+    <div style="padding-top:6px;">${heading(p.title, { level: "h3", href: url })}</div>
+    <div style="padding-top:4px;">${paragraph(p.composer_name, { muted: true })}</div>
+    ${desc ? `<div style="padding-top:10px;">${paragraph(desc, { family: "serif" })}</div>` : ""}
+  `;
+
+  return card({ html: inner, accent: true });
 }
 
-function renderDigest(opts: {
+function renderStatBlock(opts: { totalPieces: number; piecesCount: number }): string {
+  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom:20px;">
+<tr>
+  <td width="50%" align="center" style="padding:14px 0;border:1px solid ${TOKENS.border};border-radius:8px 0 0 8px;border-right:0;">
+    <div style="font-family:${TOKENS.serif};font-size:26px;color:${TOKENS.ink};">${opts.totalPieces}</div>
+    <div style="font-family:${TOKENS.sans};font-size:10px;color:${TOKENS.muted};text-transform:uppercase;letter-spacing:0.08em;padding-top:2px;">Pieces</div>
+  </td>
+  <td width="50%" align="center" style="padding:14px 0;border:1px solid ${TOKENS.border};border-radius:0 8px 8px 0;">
+    <div style="font-family:${TOKENS.serif};font-size:26px;color:${TOKENS.ink};">${opts.piecesCount}</div>
+    <div style="font-family:${TOKENS.sans};font-size:10px;color:${TOKENS.muted};text-transform:uppercase;letter-spacing:0.08em;padding-top:2px;">New this week</div>
+  </td>
+</tr>
+</table>`;
+}
+
+function renderWeeklyDigest(opts: {
   recipientName: string;
   weekRange: string;
   summary: string;
@@ -54,78 +76,26 @@ function renderDigest(opts: {
   totalPieces: number;
   unsubscribeUrl: string;
 }): string {
-  return `<!DOCTYPE html>
-<html lang="en"><head>
-<meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/>
-<title>Irregular Pearl — Weekly Digest</title>
-<style>body,table,td,a{-webkit-text-size-adjust:100%}table,td{border-collapse:collapse}body{margin:0;padding:0;background:#FAF8F5}
-@media only screen and (max-width:620px){.w{width:100%!important}.wi{padding:0 16px!important}}</style>
-</head>
-<body style="margin:0;padding:0;background:#FAF8F5;-webkit-font-smoothing:antialiased;">
-<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background:#FAF8F5;">
-<tr><td align="center" valign="top" style="padding:32px 0 48px;">
-<table role="presentation" class="w" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width:600px;">
-
-<!-- HEADER -->
-<tr><td class="wi" align="center" style="padding:0 24px 24px;">
-  <div style="font-family:Georgia,serif;font-size:34px;font-style:italic;color:#1C1917;padding:20px 0 8px;">
-    <a href="https://irregularpearl.org" style="text-decoration:none;color:#1C1917;">Irregular Pearl</a>
+  const bodyHtml = `
+  <div style="padding-bottom:12px;">${paragraph(`Dear ${opts.recipientName},`)}</div>
+  <div style="padding-bottom:20px;">${paragraph(opts.summary, { muted: true })}</div>
+  ${renderStatBlock({ totalPieces: opts.totalPieces, piecesCount: opts.piecesCount })}
+  ${opts.piecesHtml
+    ? `<div style="padding-bottom:12px;">${kicker("New this week")}</div>${opts.piecesHtml}`
+    : ""}
+  <div align="center" style="padding:24px 0 8px;">
+    ${primaryButton({ text: "Explore Irregular Pearl", href: "https://irregularpearl.org" })}
   </div>
-  <div style="font-family:Arial,sans-serif;font-size:11px;color:#78716C;letter-spacing:0.12em;text-transform:uppercase;padding-bottom:20px;">Weekly Digest</div>
-  <div style="border-top:1px solid #E7E5E4;"></div>
-</td></tr>
+  `;
 
-<!-- GREETING -->
-<tr><td class="wi" style="padding:0 24px 8px;font-family:Arial,sans-serif;font-size:15px;color:#1C1917;">
-  Dear ${esc(opts.recipientName)},
-</td></tr>
-
-<!-- SUMMARY -->
-<tr><td class="wi" style="padding:0 24px 20px;font-family:Arial,sans-serif;font-size:14px;color:#57534E;line-height:1.65;">
-  ${esc(opts.summary)}
-</td></tr>
-
-<!-- AT A GLANCE -->
-<tr><td class="wi" style="padding:0 24px 20px;">
-  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-    <tr>
-      <td width="50%" align="center" style="padding:12px 0;border:1px solid #E7E5E4;border-radius:8px 0 0 8px;">
-        <div style="font-family:'Courier New',monospace;font-size:24px;color:#B45309;font-weight:500;">${opts.totalPieces}</div>
-        <div style="font-family:Arial,sans-serif;font-size:10px;color:#78716C;text-transform:uppercase;letter-spacing:0.08em;">Pieces</div>
-      </td>
-      <td width="50%" align="center" style="padding:12px 0;border:1px solid #E7E5E4;border-left:0;border-radius:0 8px 8px 0;">
-        <div style="font-family:'Courier New',monospace;font-size:24px;color:#B45309;font-weight:500;">${opts.piecesCount}</div>
-        <div style="font-family:Arial,sans-serif;font-size:10px;color:#78716C;text-transform:uppercase;letter-spacing:0.08em;">New This Week</div>
-      </td>
-    </tr>
-  </table>
-</td></tr>
-
-<!-- NEW PIECES -->
-${opts.piecesHtml ? `<tr><td class="wi" style="padding:0 24px 20px;">
-  <div style="font-family:Georgia,serif;font-size:18px;color:#1C1917;padding-bottom:12px;border-bottom:2px solid #B45309;">New Pieces</div>
-  <div style="margin-top:12px;">${opts.piecesHtml}</div>
-</td></tr>` : ""}
-
-<!-- CTA -->
-<tr><td align="center" style="padding:12px 24px 48px;">
-  <a href="https://irregularpearl.org" style="display:inline-block;font-family:Arial,sans-serif;font-size:14px;font-weight:500;color:#FFF;text-decoration:none;padding:13px 32px;border-radius:8px;background:#B45309;" target="_blank">Explore Irregular Pearl</a>
-</td></tr>
-
-<!-- FOOTER -->
-<tr><td class="wi" align="center" style="padding:0 24px 8px;">
-  <div style="font-family:Georgia,serif;font-size:18px;font-style:italic;color:#78716C;margin-bottom:12px;">Irregular Pearl</div>
-  <div style="font-family:Arial,sans-serif;font-size:11px;color:#A8A29E;margin-top:16px;line-height:1.6;">
-    You're receiving this because you opted in to weekly digests.<br/>
-    <a href="${esc(opts.unsubscribeUrl)}" style="color:#A8A29E;text-decoration:underline;" target="_blank">Unsubscribe</a>
-  </div>
-</td></tr>
-
-<tr><td class="wi" style="padding:24px 24px 0;"><div style="border-top:2px solid #B45309;"></div></td></tr>
-
-</table>
-</td></tr></table>
-</body></html>`;
+  return renderEmailLayout({
+    title: `Irregular Pearl — Weekly Digest · ${opts.weekRange}`,
+    preheader: opts.summary,
+    subtitle: "Weekly Digest",
+    bodyHtml,
+    footerNote: "You're receiving this because you opted in to weekly digests.",
+    footerLink: { text: "Unsubscribe", href: opts.unsubscribeUrl },
+  });
 }
 
 async function fetchAndSendDigests(): Promise<{ sent: number; skipped: number; errors: string[] }> {
@@ -181,7 +151,7 @@ async function fetchAndSendDigests(): Promise<{ sent: number; skipped: number; e
       const firstName = (recipient.display_name || "").split(" ")[0] || "there";
       const unsubscribeUrl = `https://irregularpearl.org/settings#email`;
 
-      const html = renderDigest({
+      const html = renderWeeklyDigest({
         recipientName: firstName,
         weekRange,
         summary,


### PR DESCRIPTION
Slice A **step 3** per the rollout plan. Closes the amber-era DESIGN.md drift in the weekly digest and lays the template groundwork the daily notification digest (step 8) will consume.

## What ships
- \`supabase/functions/_lib/email-template.ts\` — pure-TS primitives, no Deno APIs. Tokens + \`renderEmailLayout\`, \`kicker\`, \`heading\`, \`paragraph\`, \`primaryButton\`, \`link\`, \`divider\`, \`card\`, \`esc\`.
- \`supabase/functions/send-weekly-digest/index.ts\` — refactored to consume the shared template. Same sections as the old digest (header, greeting, summary, at-a-glance stats, new pieces, CTA, footer) rendered in the Claude-kit aesthetic.
- \`src/tests/email-template.test.ts\` — 20 unit tests covering every primitive + composition. Explicitly asserts amber \`#B45309\` is gone and accent purple is present.
- \`scripts/preview-email.ts\` — renders three samples (weekly digest, daily notification digest stub, token swatches) to \`dist-preview/*.html\` for visual review. \`--open\` flag launches them.

## Aesthetic (per DESIGN.md)
- Accent purple \`#6B4E7C\` (was amber \`#B45309\`)
- Source Serif 4 with Georgia fallback for editorial prose (was Georgia direct)
- Inter with Arial fallback for UI/meta (was a mix of Courier New + Arial)
- "IrregularPearl" wordmark in Inter medium, non-italic (was italic serif)
- 1px borders in \`#E5E3DE\` (web 0.5px rounds to 1px in email clients)
- Neutral white background \`#FFFFFF\`

## Verification
\`\`\`
$ bun run test:integration    → 30/30 pass
$ bun run test                → 106 pass, 7 fail (pre-existing on main)
\`\`\`
The 7 failures are unrelated: seed data drift + UsernameEditor component tests. Separate cleanup PR.

## Visual review
Ran \`bun run scripts/preview-email.ts --open\` on my end; the three preview HTMLs are in your default browser. Check the weekly-digest.html sample before we merge — this goes out to real recipients on the next Monday 03:00 UTC cron after deploy.

## Depends on
- #33 (merged) — plan update that called for this shared helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)