### PR TITLE
feat(queue): contributor approval queue at /notifications

### DIFF
--- a/scripts/magic-link.ts
+++ b/scripts/magic-link.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env bun
+// Generates a magic-link URL for a local-dev user. Opens a browser window
+// (or prints the URL) so you can sign in without the Google-OAuth flow.
+//
+// Usage:
+//   bun --env-file=.env.development.local run scripts/magic-link.ts <email>
+//   bun --env-file=.env.development.local run scripts/magic-link.ts haji@local.test --open
+
+import { createClient } from '@supabase/supabase-js';
+import { spawn } from 'node:child_process';
+
+const url = process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.');
+  process.exit(1);
+}
+const [email] = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+if (!email) {
+  console.error('Usage: bun --env-file=.env.development.local run scripts/magic-link.ts <email> [--open]');
+  process.exit(1);
+}
+
+const admin = createClient(url, serviceKey, { auth: { autoRefreshToken: false, persistSession: false } });
+const { data, error } = await admin.auth.admin.generateLink({
+  type: 'magiclink',
+  email,
+  options: { redirectTo: 'http://localhost:4321/notifications' },
+});
+if (error) {
+  console.error(`generateLink: ${error.message}`);
+  process.exit(1);
+}
+
+// The action_link points at the Supabase auth endpoint; opening it sets the
+// session cookie and redirects to redirectTo.
+const link = data.properties?.action_link;
+if (!link) {
+  console.error('No action_link returned.');
+  process.exit(1);
+}
+
+console.log(`\nMagic link for ${email}:\n`);
+console.log(link);
+console.log('\nThe link redirects to /notifications after sign-in.\n');
+
+if (process.argv.includes('--open')) {
+  spawn('open', [link], { stdio: 'ignore', detached: true }).unref();
+}

--- a/scripts/seed-local-queue.ts
+++ b/scripts/seed-local-queue.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+// Seeds the local Supabase stack with fixtures so the /notifications queue
+// has something to show when you visit the dev server.
+//
+// Creates:
+//   - a contributor (haji@local.test / password: hajilocal)
+//   - a staff user   (staff@local.test / password: stafflocal)
+//   - one submitted pending draft on an existing piece
+//
+// Idempotent — re-running refreshes the draft. Safe to run anytime.
+//
+// Usage:
+//   bun --env-file=.env.development.local run scripts/seed-local-queue.ts
+
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.');
+  console.error('Run with: bun --env-file=.env.development.local run scripts/seed-local-queue.ts');
+  process.exit(1);
+}
+
+const admin = createClient(url, serviceKey, { auth: { autoRefreshToken: false, persistSession: false } });
+
+async function ensureUser(email: string, password: string, patch: Record<string, unknown>): Promise<string> {
+  const { data: listData } = await admin.auth.admin.listUsers({ perPage: 1000 });
+  let user = listData.users.find((u) => u.email?.toLowerCase() === email.toLowerCase());
+  if (!user) {
+    const { data: created, error } = await admin.auth.admin.createUser({ email, password, email_confirm: true });
+    if (error) throw new Error(`createUser ${email}: ${error.message}`);
+    user = created.user!;
+  }
+  await admin.from('users').update(patch).eq('id', user.id);
+  return user.id;
+}
+
+const hajiId = await ensureUser('haji@local.test', 'hajilocal', {
+  display_name: 'Haji Kim',
+  is_contributor: true,
+  contributor_active: true,
+  contributor_agreement_signed_at: new Date().toISOString(),
+  contributor_bio_short: 'cellist, NYC',
+});
+const staffId = await ensureUser('staff@local.test', 'stafflocal', {
+  display_name: 'Staff Local',
+  role: 'admin',
+});
+
+// Pick an existing piece. Falls back to creating one if the catalog is empty.
+const { data: pieces } = await admin.from('pieces').select('id, title').limit(1);
+let pieceId = pieces?.[0]?.id;
+if (!pieceId) {
+  const fixtureId = 'local-test-piece';
+  await admin.from('pieces').upsert({
+    id: fixtureId,
+    title: 'Local Test Piece',
+    composer_name: 'Anonymous',
+    era: 'Baroque',
+    form: 'sonata',
+    instruments: ['cello'],
+    difficulty: 'intermediate',
+    description: '',
+  });
+  pieceId = fixtureId;
+}
+
+// Reset any previous local test draft for this piece + contributor.
+await admin
+  .from('performers_notes')
+  .update({ current_version_id: null, status: 'removed' })
+  .eq('piece_id', pieceId)
+  .eq('contributor_id', hajiId);
+
+// Sign in as staff to call the RPC with a real JWT.
+const anonKey = process.env.PUBLIC_SUPABASE_ANON_KEY!;
+const staffClient = createClient(url, anonKey, { auth: { autoRefreshToken: false, persistSession: false } });
+const { error: signInErr } = await staffClient.auth.signInWithPassword({ email: 'staff@local.test', password: 'stafflocal' });
+if (signInErr) throw new Error(`sign-in staff: ${signInErr.message}`);
+
+const { data: noteId, error: createErr } = await staffClient.rpc('create_performers_note_draft', {
+  p_piece_id: pieceId,
+  p_contributor_id: hajiId,
+  p_body:
+    "Staff-authored draft: the opening arpeggios call for bow speed more than articulation — try broadening the second bar under a single down-bow to hear the architecture Bach wrote, then restore the printed bowing if it serves the room.",
+});
+if (createErr) throw new Error(`create draft: ${createErr.message}`);
+
+const { error: submitErr } = await staffClient.rpc('submit_performers_note', { p_note_id: noteId });
+if (submitErr) throw new Error(`submit draft: ${submitErr.message}`);
+
+console.log('Local queue seeded.');
+console.log(`  piece:       ${pieceId}`);
+console.log(`  note:        ${noteId}`);
+console.log('  contributor: haji@local.test / hajilocal');
+console.log('  staff:       staff@local.test / stafflocal');
+console.log('\nNext:');
+console.log('  1. bun run dev');
+console.log('  2. Visit http://localhost:4321');
+console.log('  3. Sign in as haji@local.test / hajilocal');
+console.log('  4. Visit http://localhost:4321/notifications');

--- a/scripts/seed-local-queue.ts
+++ b/scripts/seed-local-queue.ts
@@ -52,16 +52,17 @@ const staffId = await ensureUser('staff@local.test', 'stafflocal', {
 const { data: pieces } = await admin.from('pieces').select('id, title').limit(1);
 let pieceId = pieces?.[0]?.id;
 if (!pieceId) {
-  const fixtureId = 'local-test-piece';
+  const fixtureId = 'bach-cello-suite-1';
   await admin.from('pieces').upsert({
     id: fixtureId,
-    title: 'Local Test Piece',
-    composer_name: 'Anonymous',
+    title: 'Cello Suite No. 1 in G major',
+    composer_name: 'Bach, J.S.',
+    catalog_number: 'BWV 1007',
     era: 'Baroque',
-    form: 'sonata',
+    form: 'suite',
     instruments: ['cello'],
-    difficulty: 'intermediate',
-    description: '',
+    difficulty: 'advanced',
+    description: 'The most-played of the Six, and the one every cellist must eventually confront on their own terms.',
   });
   pieceId = fixtureId;
 }

--- a/src/components/NotificationsQueue.tsx
+++ b/src/components/NotificationsQueue.tsx
@@ -1,0 +1,403 @@
+// Contributor approval queue. Lists drafts attributed to the logged-in
+// contributor that are awaiting their review. For each draft:
+//
+//   • piece title + link, drafter meta
+//   • current proposed body in the signed-notes pattern (serif, 2px purple
+//     left border)
+//   • action row: Approve, Approve and edit (inline textarea), Reject
+//     (inline confirmation with optional freeform reason — no native dialog)
+//
+// For Slice A the queue is effectively a single-user surface (v1 contributor
+// is H. alone). RLS on performers_notes scopes reads to the caller; RPCs
+// enforce ownership on mutations. The diff block against prior versions is
+// deferred to v1.1 per the plan-eng-review decisions.
+
+import { useEffect, useState, useCallback } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+import type { Session } from '@supabase/supabase-js';
+
+type Status = 'loading' | 'unauthed' | 'not-contributor' | 'ready';
+
+interface PendingDraft {
+  noteId: string;
+  pieceId: string;
+  pieceTitle: string;
+  composerName: string;
+  drafterName: string | null;
+  body: string;
+  versionNumber: number;
+  pendingVersionId: string;
+  createdAt: string;
+}
+
+type ItemAction = null | 'approve' | 'approve-and-edit' | 'reject';
+
+export default function NotificationsQueue() {
+  const [status, setStatus] = useState<Status>('loading');
+  const [drafts, setDrafts] = useState<PendingDraft[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [actionById, setActionById] = useState<Record<string, ItemAction>>({});
+  const [busyById, setBusyById] = useState<Record<string, boolean>>({});
+
+  const loadQueue = useCallback(async (session: Session) => {
+    setError(null);
+
+    // Profile check: must be an active contributor.
+    const { data: profile, error: profileErr } = await supabase
+      .from('users')
+      .select('is_contributor, contributor_active')
+      .eq('id', session.user.id)
+      .single();
+    if (profileErr) {
+      setError(profileErr.message);
+      return;
+    }
+    if (!profile?.is_contributor || !profile.contributor_active) {
+      setStatus('not-contributor');
+      return;
+    }
+
+    // Pending drafts for this contributor.
+    const { data: notes, error: notesErr } = await supabase
+      .from('performers_notes')
+      .select('id, piece_id, created_at')
+      .eq('contributor_id', session.user.id)
+      .eq('status', 'awaiting_contributor_approval')
+      .order('created_at', { ascending: false });
+    if (notesErr) {
+      setError(notesErr.message);
+      return;
+    }
+    if (!notes || notes.length === 0) {
+      setDrafts([]);
+      setStatus('ready');
+      return;
+    }
+
+    const noteIds = notes.map((n) => n.id);
+    const pieceIds = [...new Set(notes.map((n) => n.piece_id))];
+
+    // Fetch pending versions (unapproved), pieces, and drafters in parallel.
+    const [versionsRes, piecesRes, fullNotesRes] = await Promise.all([
+      supabase
+        .from('performers_note_versions')
+        .select('id, note_id, body, version_number')
+        .in('note_id', noteIds)
+        .is('approved_at', null)
+        .order('version_number', { ascending: false }),
+      supabase.from('pieces').select('id, title, composer_name').in('id', pieceIds),
+      supabase.from('performers_notes').select('id, drafted_by').in('id', noteIds),
+    ]);
+    if (versionsRes.error) { setError(versionsRes.error.message); return; }
+    if (piecesRes.error) { setError(piecesRes.error.message); return; }
+    if (fullNotesRes.error) { setError(fullNotesRes.error.message); return; }
+
+    const draftedByIds = [
+      ...new Set(
+        (fullNotesRes.data ?? [])
+          .map((n) => n.drafted_by)
+          .filter((x): x is string => Boolean(x)),
+      ),
+    ];
+    const draftersRes = draftedByIds.length
+      ? await supabase.from('users').select('id, display_name').in('id', draftedByIds)
+      : { data: [], error: null as null | { message: string } };
+    if (draftersRes.error) { setError(draftersRes.error.message); return; }
+
+    const pieceById = new Map((piecesRes.data ?? []).map((p) => [p.id, p]));
+    const drafterById = new Map((draftersRes.data ?? []).map((u) => [u.id, u.display_name]));
+    const drafterIdByNoteId = new Map(
+      (fullNotesRes.data ?? []).map((n) => [n.id, n.drafted_by as string | null]),
+    );
+    // Keep only the highest version_number per note (first item after desc order).
+    const latestVersionByNoteId = new Map<string, { id: string; body: string; version_number: number }>();
+    for (const v of versionsRes.data ?? []) {
+      if (!latestVersionByNoteId.has(v.note_id)) {
+        latestVersionByNoteId.set(v.note_id, { id: v.id, body: v.body, version_number: v.version_number });
+      }
+    }
+
+    const rows: PendingDraft[] = [];
+    for (const n of notes) {
+      const piece = pieceById.get(n.piece_id);
+      const version = latestVersionByNoteId.get(n.id);
+      if (!piece || !version) continue;
+      const drafterId = drafterIdByNoteId.get(n.id);
+      rows.push({
+        noteId: n.id,
+        pieceId: n.piece_id,
+        pieceTitle: piece.title,
+        composerName: piece.composer_name,
+        drafterName: drafterId ? drafterById.get(drafterId) ?? null : null,
+        body: version.body,
+        versionNumber: version.version_number,
+        pendingVersionId: version.id,
+        createdAt: n.created_at,
+      });
+    }
+
+    setDrafts(rows);
+    setStatus('ready');
+  }, []);
+
+  useEffect(() => {
+    if (!hasSupabase) { setStatus('unauthed'); return; }
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) { setStatus('unauthed'); return; }
+      void loadQueue(session);
+    });
+  }, [loadQueue]);
+
+  async function refresh() {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (session) await loadQueue(session);
+  }
+
+  async function handleApprove(noteId: string) {
+    setBusyById((b) => ({ ...b, [noteId]: true }));
+    setError(null);
+    const { error: rpcErr } = await supabase.rpc('approve_performers_note', { p_note_id: noteId });
+    setBusyById((b) => ({ ...b, [noteId]: false }));
+    if (rpcErr) { setError(rpcErr.message); return; }
+    // Remove the row locally; avoids a round-trip.
+    setDrafts((rows) => rows.filter((r) => r.noteId !== noteId));
+    setActionById((a) => ({ ...a, [noteId]: null }));
+  }
+
+  async function handleApproveAndEdit(noteId: string, body: string) {
+    setBusyById((b) => ({ ...b, [noteId]: true }));
+    setError(null);
+    const { error: rpcErr } = await supabase.rpc('approve_and_edit_performers_note', {
+      p_note_id: noteId,
+      p_body: body,
+    });
+    setBusyById((b) => ({ ...b, [noteId]: false }));
+    if (rpcErr) { setError(rpcErr.message); return; }
+    setDrafts((rows) => rows.filter((r) => r.noteId !== noteId));
+    setActionById((a) => ({ ...a, [noteId]: null }));
+  }
+
+  async function handleReject(noteId: string, reason: string) {
+    setBusyById((b) => ({ ...b, [noteId]: true }));
+    setError(null);
+    const { error: rpcErr } = await supabase.rpc('reject_performers_note', {
+      p_note_id: noteId,
+      p_reason: reason || null,
+    });
+    setBusyById((b) => ({ ...b, [noteId]: false }));
+    if (rpcErr) { setError(rpcErr.message); return; }
+    setDrafts((rows) => rows.filter((r) => r.noteId !== noteId));
+    setActionById((a) => ({ ...a, [noteId]: null }));
+  }
+
+  if (status === 'loading') {
+    return <div className="text-sm text-muted font-body">Loading your queue…</div>;
+  }
+  if (status === 'unauthed') {
+    return (
+      <div className="font-body">
+        <h1 className="text-2xl font-display text-ink mb-3">Your queue</h1>
+        <p className="text-sm text-muted">You need to be signed in to see your approval queue.</p>
+      </div>
+    );
+  }
+  if (status === 'not-contributor') {
+    return (
+      <div className="font-body">
+        <h1 className="text-2xl font-display text-ink mb-3">Your queue</h1>
+        <p className="text-sm text-muted">
+          The queue is for signed contributors. If you think you should have access, reach out to the
+          Editorial Director.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="font-body">
+      <h1 className="text-[28px] font-display text-ink mb-1 tracking-tight">Your queue</h1>
+      <p className="text-sm text-muted mb-8">
+        Drafts waiting for your review. Approve as-is, edit and publish, or send back with a note.
+      </p>
+
+      {error && (
+        <div className="mb-6 rounded-lg border-[0.5px] border-[#A32D2D] bg-[#F7E4E4] px-4 py-3 text-sm text-[#A32D2D]">
+          {error}
+        </div>
+      )}
+
+      {drafts.length === 0 ? (
+        <div className="rounded-xl border-[0.5px] border-border bg-surface px-5 py-8 text-center">
+          <p className="text-sm text-muted">Nothing waiting. When staff routes a draft to you, it'll appear here.</p>
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {drafts.map((d) => {
+            const currentAction = actionById[d.noteId] ?? null;
+            const busy = busyById[d.noteId] ?? false;
+            return (
+              <li
+                key={d.noteId}
+                className="rounded-xl border-[0.5px] border-border bg-surface p-5"
+              >
+                <div className="flex items-baseline justify-between gap-4 mb-1">
+                  <a
+                    href={`/piece/${d.pieceId}`}
+                    className="text-[20px] font-display text-ink leading-tight no-underline hover:underline"
+                  >
+                    {d.pieceTitle}
+                  </a>
+                  <span className="text-xs text-tertiary shrink-0">
+                    {d.drafterName ? `drafted by ${d.drafterName}` : `v${d.versionNumber}`}
+                  </span>
+                </div>
+                <p className="text-sm text-muted mb-4">{d.composerName}</p>
+
+                <div
+                  className="pl-[18px] border-l-2 mb-5 font-display text-[16px] text-ink leading-[1.68] whitespace-pre-wrap"
+                  style={{ borderLeftColor: 'var(--color-accent)' }}
+                >
+                  {d.body}
+                </div>
+
+                {currentAction === null && (
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleApprove(d.noteId)}
+                      disabled={busy}
+                      className="inline-flex items-center px-4 py-2 bg-ink text-white text-sm font-medium rounded-lg hover:bg-[#292524] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      {busy ? 'Approving…' : 'Approve'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setActionById((a) => ({ ...a, [d.noteId]: 'approve-and-edit' }))}
+                      disabled={busy}
+                      className="inline-flex items-center px-4 py-2 bg-transparent text-ink text-sm font-medium border-[0.5px] border-border-strong rounded-lg hover:bg-[#F8F7F4] disabled:opacity-50 transition-colors"
+                    >
+                      Approve and edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setActionById((a) => ({ ...a, [d.noteId]: 'reject' }))}
+                      disabled={busy}
+                      className="inline-flex items-center px-4 py-2 bg-transparent text-ink text-sm font-medium border-[0.5px] border-border-strong rounded-lg hover:bg-[#F8F7F4] disabled:opacity-50 transition-colors"
+                    >
+                      Reject
+                    </button>
+                  </div>
+                )}
+
+                {currentAction === 'approve-and-edit' && (
+                  <EditForm
+                    initialBody={d.body}
+                    submitting={busy}
+                    onCancel={() => setActionById((a) => ({ ...a, [d.noteId]: null }))}
+                    onSubmit={(newBody) => handleApproveAndEdit(d.noteId, newBody)}
+                  />
+                )}
+
+                {currentAction === 'reject' && (
+                  <RejectForm
+                    submitting={busy}
+                    onCancel={() => setActionById((a) => ({ ...a, [d.noteId]: null }))}
+                    onSubmit={(reason) => handleReject(d.noteId, reason)}
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="mt-10">
+        <button
+          type="button"
+          onClick={refresh}
+          className="text-xs text-tertiary hover:text-ink underline underline-offset-4"
+        >
+          Refresh
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EditForm(props: {
+  initialBody: string;
+  submitting: boolean;
+  onSubmit: (body: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(props.initialBody);
+  return (
+    <div>
+      <textarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        rows={6}
+        className="w-full px-3 py-2 text-[15px] font-display leading-[1.68] text-ink border-[0.5px] border-border-strong rounded-lg focus:outline-none focus:ring-1 focus:ring-accent resize-y"
+      />
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={() => props.onSubmit(value)}
+          disabled={props.submitting || value.trim() === ''}
+          className="inline-flex items-center px-4 py-2 bg-ink text-white text-sm font-medium rounded-lg hover:bg-[#292524] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {props.submitting ? 'Publishing…' : 'Publish edited'}
+        </button>
+        <button
+          type="button"
+          onClick={props.onCancel}
+          disabled={props.submitting}
+          className="inline-flex items-center px-4 py-2 bg-transparent text-ink text-sm font-medium border-[0.5px] border-border-strong rounded-lg hover:bg-[#F8F7F4] disabled:opacity-50 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RejectForm(props: {
+  submitting: boolean;
+  onSubmit: (reason: string) => void;
+  onCancel: () => void;
+}) {
+  const [reason, setReason] = useState('');
+  return (
+    <div>
+      <label className="block text-xs text-muted mb-2 uppercase tracking-wider font-medium">
+        Reason (optional, visible to staff)
+      </label>
+      <textarea
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        rows={3}
+        placeholder="e.g. The second sentence reads as too prescriptive."
+        className="w-full px-3 py-2 text-sm font-body text-ink border-[0.5px] border-border-strong rounded-lg focus:outline-none focus:ring-1 focus:ring-accent resize-y"
+      />
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={() => props.onSubmit(reason)}
+          disabled={props.submitting}
+          className="inline-flex items-center px-4 py-2 bg-ink text-white text-sm font-medium rounded-lg hover:bg-[#292524] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {props.submitting ? 'Sending back…' : 'Send back'}
+        </button>
+        <button
+          type="button"
+          onClick={props.onCancel}
+          disabled={props.submitting}
+          className="inline-flex items-center px-4 py-2 bg-transparent text-ink text-sm font-medium border-[0.5px] border-border-strong rounded-lg hover:bg-[#F8F7F4] disabled:opacity-50 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NotificationsQueue.tsx
+++ b/src/components/NotificationsQueue.tsx
@@ -23,6 +23,7 @@ interface PendingDraft {
   pieceId: string;
   pieceTitle: string;
   composerName: string;
+  catalogNumber: string | null;
   drafterName: string | null;
   body: string;
   versionNumber: number;
@@ -30,10 +31,16 @@ interface PendingDraft {
   createdAt: string;
 }
 
+interface ContributorProfile {
+  displayName: string;
+  bioShort: string | null;
+}
+
 type ItemAction = null | 'approve' | 'approve-and-edit' | 'reject';
 
 export default function NotificationsQueue() {
   const [status, setStatus] = useState<Status>('loading');
+  const [profile, setProfile] = useState<ContributorProfile | null>(null);
   const [drafts, setDrafts] = useState<PendingDraft[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [actionById, setActionById] = useState<Record<string, ItemAction>>({});
@@ -43,19 +50,23 @@ export default function NotificationsQueue() {
     setError(null);
 
     // Profile check: must be an active contributor.
-    const { data: profile, error: profileErr } = await supabase
+    const { data: profileRow, error: profileErr } = await supabase
       .from('users')
-      .select('is_contributor, contributor_active')
+      .select('is_contributor, contributor_active, display_name, contributor_bio_short')
       .eq('id', session.user.id)
       .single();
     if (profileErr) {
       setError(profileErr.message);
       return;
     }
-    if (!profile?.is_contributor || !profile.contributor_active) {
+    if (!profileRow?.is_contributor || !profileRow.contributor_active) {
       setStatus('not-contributor');
       return;
     }
+    setProfile({
+      displayName: profileRow.display_name,
+      bioShort: profileRow.contributor_bio_short ?? null,
+    });
 
     // Pending drafts for this contributor.
     const { data: notes, error: notesErr } = await supabase
@@ -85,7 +96,7 @@ export default function NotificationsQueue() {
         .in('note_id', noteIds)
         .is('approved_at', null)
         .order('version_number', { ascending: false }),
-      supabase.from('pieces').select('id, title, composer_name').in('id', pieceIds),
+      supabase.from('pieces').select('id, title, composer_name, catalog_number').in('id', pieceIds),
       supabase.from('performers_notes').select('id, drafted_by').in('id', noteIds),
     ]);
     if (versionsRes.error) { setError(versionsRes.error.message); return; }
@@ -128,6 +139,7 @@ export default function NotificationsQueue() {
         pieceId: n.piece_id,
         pieceTitle: piece.title,
         composerName: piece.composer_name,
+        catalogNumber: piece.catalog_number ?? null,
         drafterName: drafterId ? drafterById.get(drafterId) ?? null : null,
         body: version.body,
         versionNumber: version.version_number,
@@ -218,7 +230,7 @@ export default function NotificationsQueue() {
     <div className="font-body">
       <h1 className="text-[28px] font-display text-ink mb-1 tracking-tight">Your queue</h1>
       <p className="text-sm text-muted mb-8">
-        Drafts waiting for your review. Approve as-is, edit and publish, or send back with a note.
+        Drafts waiting for your review. Approve as-is, edit and then approve, or send back with a note.
       </p>
 
       {error && (
@@ -241,24 +253,52 @@ export default function NotificationsQueue() {
                 key={d.noteId}
                 className="rounded-xl border-[0.5px] border-border bg-surface p-5"
               >
-                <div className="flex items-baseline justify-between gap-4 mb-1">
-                  <a
-                    href={`/piece/${d.pieceId}`}
-                    className="text-[20px] font-display text-ink leading-tight no-underline hover:underline"
-                  >
-                    {d.pieceTitle}
-                  </a>
-                  <span className="text-xs text-tertiary shrink-0">
-                    {d.drafterName ? `drafted by ${d.drafterName}` : `v${d.versionNumber}`}
-                  </span>
-                </div>
-                <p className="text-sm text-muted mb-4">{d.composerName}</p>
-
+                {/* Context: where this will appear */}
                 <div
-                  className="pl-[18px] border-l-2 mb-5 font-display text-[16px] text-ink leading-[1.68] whitespace-pre-wrap"
+                  className="text-[11px] font-medium tracking-[0.08em] uppercase mb-4"
+                  style={{ color: 'var(--color-accent)' }}
+                >
+                  Performer's note &middot; on the piece page
+                </div>
+
+                {/* Piece header — mirror the piece-page H1 + byline format */}
+                <div className="pb-4 mb-5 border-b-[0.5px] border-border">
+                  <div className="flex items-baseline flex-wrap gap-x-3 gap-y-1">
+                    <a
+                      href={`/piece/${d.pieceId}`}
+                      className="font-display text-[22px] text-ink leading-tight tracking-tight no-underline hover:underline"
+                    >
+                      {d.pieceTitle}
+                    </a>
+                    {d.catalogNumber && (
+                      <span className="text-[11px] font-mono text-tertiary tracking-wide">
+                        {d.catalogNumber}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-sm text-muted">
+                    by <span className="text-ink">{d.composerName}</span>
+                  </div>
+                </div>
+
+                {/* Preview of the signed unit exactly as it will render on the piece page */}
+                <div
+                  className="pl-[18px] border-l-2 mb-2 font-display text-[16px] text-ink leading-[1.68] whitespace-pre-wrap"
                   style={{ borderLeftColor: 'var(--color-accent)' }}
                 >
                   {d.body}
+                </div>
+                {profile && (
+                  <div className="pl-[18px] mb-1 font-body">
+                    <div className="text-sm text-ink font-medium">{profile.displayName}</div>
+                    {profile.bioShort && (
+                      <div className="text-xs text-muted">{profile.bioShort}</div>
+                    )}
+                  </div>
+                )}
+
+                <div className="text-[11px] text-tertiary mt-4 mb-4">
+                  {d.drafterName ? `drafted by ${d.drafterName}` : 'drafted on your behalf'} &middot; v{d.versionNumber}
                 </div>
 
                 {currentAction === null && (
@@ -277,7 +317,7 @@ export default function NotificationsQueue() {
                       disabled={busy}
                       className="inline-flex items-center px-4 py-2 bg-transparent text-ink text-sm font-medium border-[0.5px] border-border-strong rounded-lg hover:bg-[#F8F7F4] disabled:opacity-50 transition-colors"
                     >
-                      Approve and edit
+                      Edit and approve
                     </button>
                     <button
                       type="button"
@@ -347,7 +387,7 @@ function EditForm(props: {
           disabled={props.submitting || value.trim() === ''}
           className="inline-flex items-center px-4 py-2 bg-ink text-white text-sm font-medium rounded-lg hover:bg-[#292524] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          {props.submitting ? 'Publishing…' : 'Publish edited'}
+          {props.submitting ? 'Approving…' : 'Approve'}
         </button>
         <button
           type="button"

--- a/src/pages/notifications.astro
+++ b/src/pages/notifications.astro
@@ -1,0 +1,12 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navbar from '../components/Navbar.astro';
+import NotificationsQueue from '../components/NotificationsQueue';
+---
+
+<Layout title="Your queue" noindex={true}>
+  <Navbar />
+  <main class="max-w-[720px] mx-auto px-4 md:px-6 py-10">
+    <NotificationsQueue client:load />
+  </main>
+</Layout>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -151,9 +151,9 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:4321"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["http://localhost:4321", "http://localhost:4321/notifications", "http://127.0.0.1:4321"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
Slice A **step 4** per the rollout plan. H. now has an in-browser approval path for staff/AI-drafted performer's notes routed to her queue.

## What ships
- \`src/pages/notifications.astro\` — wraps \`<NotificationsQueue client:load />\` inside the standard Layout + Navbar. \`noindex\` so it doesn't leak into search.
- \`src/components/NotificationsQueue.tsx\` — React client island. Fetches drafts scoped by RLS, joins client-side to pieces + latest unapproved version + drafter names. For each draft:
  - piece title + composer, link to piece page
  - proposed body in the **signed-notes pattern** (Source Serif 4, 2px purple left border, 18px padding, 1.68 line-height)
  - action row: **Approve**, **Approve and edit**, **Reject**
  - edit-and-approve reveals an inline textarea prefilled with the body
  - reject reveals an inline textarea for an optional freeform reason (no native dialog)
  - all three call the Slice A RPCs directly via \`supabase.rpc()\` and remove the row on success
- \`scripts/seed-local-queue.ts\` — dev helper. Creates \`haji@local.test\` contributor + \`staff@local.test\` staff + a submitted pending draft in local Supabase. Idempotent.

## States
| State | Shown |
|---|---|
| Loading | \`Loading your queue…\` |
| Not signed in | Sign-in nudge |
| Signed in, not a contributor | "The queue is for signed contributors" |
| Signed in, no pending drafts | Empty-state card |
| Signed in with drafts | Ordered list of cards |
| Any RPC error | Semantic-danger banner at top |

## How to verify locally
\`\`\`bash
# Local Supabase already running from earlier sessions
bun --env-file=.env.development.local run scripts/seed-local-queue.ts
bun run dev
# visit http://localhost:4321
# sign in: haji@local.test / hajilocal
# visit http://localhost:4321/notifications
\`\`\`

Dev server is already running on \`:4321\` (PID $(cat /tmp/astro-dev.pid 2>/dev/null || echo unknown)).

## Not merging until your sign-off
Per this repo's verify-before-push convention — UI work needs an in-browser walkthrough before hitting main. After you walk through Approve + Approve-and-edit + Reject from your own browser, I'll merge.

## Depends on
- #33 (RPCs) — merged + deployed
- #34 (shared email template) — merged + deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)