### PR TITLE
feat(piece-page): render published performer's notes + owner affordances

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
+    "dev:local": "PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0 SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU astro dev",
     "build": "astro build && printf '_worker.js\n_routes.json\n' > dist/.assetsignore",
     "preview": "astro preview",
     "check": "astro check",

--- a/src/components/PerformersNotes.tsx
+++ b/src/components/PerformersNotes.tsx
@@ -1,0 +1,354 @@
+// Published performer's notes on a piece page, plus contributor-authored
+// affordances (write a note, edit your own, remove your own).
+//
+// Reads are SSR'd by the parent PiecePageLayout (passed in via
+// `initialNotes`). This island hydrates with that same data so there's no
+// flicker, then checks auth to decide whether to show:
+//   - "Write a note" entry (contributor without an existing published note
+//     on this piece)
+//   - Edit + Remove affordances on a card the caller owns
+//
+// All mutations go through the Slice A security-definer RPCs via
+// supabase.rpc(); no Astro API layer.
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+import type { PublishedPerformersNote } from '../lib/performersNotes';
+
+interface Props {
+  pieceId: string;
+  initialNotes: PublishedPerformersNote[];
+}
+
+interface Viewer {
+  userId: string | null;
+  isContributor: boolean;
+  displayName: string | null;
+  bioShort: string | null;
+}
+
+type Mode = null | 'write' | { action: 'edit'; noteId: string };
+
+export default function PerformersNotes({ pieceId, initialNotes }: Props) {
+  const [notes, setNotes] = useState<PublishedPerformersNote[]>(initialNotes);
+  const [viewer, setViewer] = useState<Viewer | null>(null);
+  const [mode, setMode] = useState<Mode>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadViewer = useCallback(async () => {
+    if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
+
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.user) {
+      setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null });
+      return;
+    }
+
+    const { data } = await supabase
+      .from('users')
+      .select('display_name, is_contributor, contributor_active, contributor_bio_short')
+      .eq('id', session.user.id)
+      .single();
+
+    setViewer({
+      userId: session.user.id,
+      isContributor: Boolean(data?.is_contributor && data?.contributor_active),
+      displayName: data?.display_name ?? null,
+      bioShort: data?.contributor_bio_short ?? null,
+    });
+  }, []);
+
+  useEffect(() => { void loadViewer(); }, [loadViewer]);
+
+  async function refetchNotes() {
+    const { data } = await supabase
+      .from('performers_notes')
+      .select('id, contributor_id, current_version_id, approved_by_contributor_at')
+      .eq('piece_id', pieceId)
+      .eq('status', 'published')
+      .order('approved_by_contributor_at', { ascending: true });
+    if (!data || data.length === 0) { setNotes([]); return; }
+
+    const versionIds = data.map((n) => n.current_version_id).filter((x): x is string => Boolean(x));
+    const contribIds = [...new Set(data.map((n) => n.contributor_id))];
+
+    const [versionsRes, contribsRes] = await Promise.all([
+      supabase.from('v_performers_note_versions_published').select('id, body, version_number, approved_at').in('id', versionIds),
+      supabase.from('users').select('id, display_name, contributor_bio_short').in('id', contribIds),
+    ]);
+    const vById = new Map((versionsRes.data ?? []).map((v) => [v.id, v]));
+    const cById = new Map((contribsRes.data ?? []).map((c) => [c.id, c]));
+
+    const rows: PublishedPerformersNote[] = [];
+    for (const n of data) {
+      if (!n.current_version_id) continue;
+      const v = vById.get(n.current_version_id);
+      const c = cById.get(n.contributor_id);
+      if (!v || !c) continue;
+      rows.push({
+        noteId: n.id,
+        versionId: v.id,
+        body: v.body,
+        versionNumber: v.version_number,
+        approvedAt: v.approved_at,
+        contributor: { id: c.id, displayName: c.display_name, bioShort: c.contributor_bio_short ?? null },
+      });
+    }
+    setNotes(rows);
+  }
+
+  async function handleWrite(body: string) {
+    if (body.trim().length === 0) { setError('Body required.'); return; }
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('publish_contributor_note', { p_piece_id: pieceId, p_body: body });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    setMode(null);
+    await refetchNotes();
+  }
+
+  async function handleEdit(noteId: string, body: string) {
+    if (body.trim().length === 0) { setError('Body required.'); return; }
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('publish_contributor_edit', { p_note_id: noteId, p_body: body });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    setMode(null);
+    await refetchNotes();
+  }
+
+  async function handleRemove(noteId: string) {
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('remove_performers_note', { p_note_id: noteId });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    await refetchNotes();
+  }
+
+  // Can the viewer write a brand-new note? Only if they're an active
+  // contributor AND they don't already have a published note on this piece.
+  const viewerHasNote = Boolean(
+    viewer?.userId && notes.some((n) => n.contributor.id === viewer.userId),
+  );
+  const canWrite = Boolean(viewer?.isContributor && !viewerHasNote);
+
+  return (
+    <div>
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border-[0.5px] px-3 py-2 text-sm"
+          style={{ background: 'var(--color-error-bg)', color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {notes.length === 0 ? (
+        <p className="empty-state">No performer's notes yet.</p>
+      ) : (
+        <div className="performers-notes-list">
+          {notes.map((note, idx) => {
+            const isOwner = viewer?.userId === note.contributor.id;
+            const isEditing = typeof mode === 'object' && mode?.action === 'edit' && mode.noteId === note.noteId;
+            // First note is primary accent; any siblings get the muted
+            // contrasting-voice treatment per DESIGN.md.
+            const signedClass = idx === 0 ? 'signed' : 'signed alt';
+            return (
+              <div key={note.noteId} className={signedClass}>
+                {!isEditing && (
+                  <>
+                    <div className="prose">
+                      {note.body.split(/\n\s*\n/).map((para, i) => <p key={i}>{para}</p>)}
+                    </div>
+                    <div className="by">
+                      <span className="name">{note.contributor.displayName}</span>
+                      {note.contributor.bioShort && (
+                        <>
+                          <span className="dot" aria-hidden="true"></span>
+                          <span>{note.contributor.bioShort}</span>
+                        </>
+                      )}
+                    </div>
+                    {isOwner && (
+                      <div className="owner-actions">
+                        <button
+                          type="button"
+                          onClick={() => { setMode({ action: 'edit', noteId: note.noteId }); setError(null); }}
+                          className="owner-btn"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRemove(note.noteId)}
+                          disabled={busy}
+                          className="owner-btn"
+                        >
+                          {busy ? 'Removing…' : 'Remove'}
+                        </button>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {isEditing && viewer && (
+                  <EditForm
+                    initial={note.body}
+                    contributor={{ name: viewer.displayName ?? note.contributor.displayName, bio: viewer.bioShort }}
+                    submitting={busy}
+                    onCancel={() => { setMode(null); setError(null); }}
+                    onSubmit={(body) => handleEdit(note.noteId, body)}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Write-a-note entry (only for contributors without a published note here) */}
+      {mode !== 'write' && canWrite && (
+        <button
+          type="button"
+          onClick={() => { setMode('write'); setError(null); }}
+          className="write-entry"
+        >
+          Write a performer's note &rarr;
+        </button>
+      )}
+      {mode === 'write' && viewer && (
+        <div className="mt-6 signed">
+          <EditForm
+            initial=""
+            placeholder="Write the note the way you'd want to read it on another musician's piece page."
+            contributor={{ name: viewer.displayName ?? 'You', bio: viewer.bioShort }}
+            submitting={busy}
+            onCancel={() => { setMode(null); setError(null); }}
+            onSubmit={handleWrite}
+            submitLabel="Publish"
+            submittingLabel="Publishing…"
+          />
+        </div>
+      )}
+
+      <style>{`
+        .performers-notes-list { display: flex; flex-direction: column; gap: 32px; }
+        .owner-actions { display: flex; gap: 8px; margin-top: 10px; }
+        .owner-btn {
+          background: transparent;
+          border: 0.5px solid var(--border-strong);
+          color: var(--muted);
+          font-family: var(--font-sans);
+          font-size: 11px;
+          padding: 4px 10px;
+          border-radius: 6px;
+          cursor: pointer;
+          transition: color 0.12s, border-color 0.12s;
+        }
+        .owner-btn:hover { color: var(--ink); border-color: var(--ink); }
+        .owner-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .write-entry {
+          margin-top: 24px;
+          background: transparent;
+          border: 0;
+          color: var(--accent);
+          font-family: var(--font-sans);
+          font-size: 13px;
+          padding: 0;
+          cursor: pointer;
+          text-decoration: none;
+        }
+        .write-entry:hover { color: var(--ink); }
+      `}</style>
+    </div>
+  );
+}
+
+function EditForm(props: {
+  initial: string;
+  placeholder?: string;
+  contributor: { name: string; bio: string | null };
+  submitting: boolean;
+  onCancel: () => void;
+  onSubmit: (body: string) => void;
+  submitLabel?: string;
+  submittingLabel?: string;
+}) {
+  const [value, setValue] = useState(props.initial);
+  const submitLabel = props.submitLabel ?? 'Save';
+  const submittingLabel = props.submittingLabel ?? 'Saving…';
+
+  return (
+    <div>
+      <textarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        rows={6}
+        placeholder={props.placeholder}
+        style={{
+          width: '100%',
+          fontFamily: 'var(--font-serif)',
+          fontSize: '16px',
+          lineHeight: 1.65,
+          color: 'var(--ink)',
+          background: 'transparent',
+          border: '0.5px solid var(--border-strong)',
+          borderRadius: '8px',
+          padding: '10px 12px',
+          resize: 'vertical',
+        }}
+      />
+      <div className="by" style={{ marginTop: '12px' }}>
+        <span className="name">{props.contributor.name}</span>
+        {props.contributor.bio && (
+          <>
+            <span className="dot" aria-hidden="true"></span>
+            <span>{props.contributor.bio}</span>
+          </>
+        )}
+      </div>
+      <div style={{ marginTop: '12px', display: 'flex', gap: '8px' }}>
+        <button
+          type="button"
+          onClick={() => props.onSubmit(value)}
+          disabled={props.submitting || value.trim() === ''}
+          style={{
+            background: 'var(--ink)',
+            color: '#FFFFFF',
+            border: 0,
+            fontFamily: 'var(--font-sans)',
+            fontSize: '13px',
+            fontWeight: 500,
+            padding: '8px 16px',
+            borderRadius: '8px',
+            cursor: props.submitting || value.trim() === '' ? 'not-allowed' : 'pointer',
+            opacity: props.submitting || value.trim() === '' ? 0.5 : 1,
+          }}
+        >
+          {props.submitting ? submittingLabel : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={props.onCancel}
+          disabled={props.submitting}
+          style={{
+            background: 'transparent',
+            color: 'var(--ink)',
+            border: '0.5px solid var(--border-strong)',
+            fontFamily: 'var(--font-sans)',
+            fontSize: '13px',
+            fontWeight: 500,
+            padding: '8px 16px',
+            borderRadius: '8px',
+            cursor: props.submitting ? 'not-allowed' : 'pointer',
+            opacity: props.submitting ? 0.5 : 1,
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PiecePageLayout.astro
+++ b/src/components/PiecePageLayout.astro
@@ -20,12 +20,15 @@
 import '../styles/piece-page.css';
 import type { PieceFull } from '../lib/pieces';
 import { difficultyAxes, type DifficultyAxis } from '../data/difficulty-axes';
+import { getPublishedPerformersNotes } from '../lib/performersNotes';
+import PerformersNotes from './PerformersNotes';
 
 interface Props {
   piece: PieceFull;
 }
 
 const { piece } = Astro.props;
+const performersNotes = await getPublishedPerformersNotes(piece.id);
 const axes = difficultyAxes[piece.id];
 const axisOrder: Array<{ key: keyof typeof axes; label: string }> = [
   { key: 'technical', label: 'Technical' },
@@ -93,10 +96,10 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     </div>
   )}
 
-  {/* ---------- Performer's notes (empty state until schema lands) ---------- */}
-  <section class="block">
+  {/* ---------- Performer's notes ---------- */}
+  <section class="block" id="performers-notes">
     <div class="kicker">Performer's notes</div>
-    <p class="empty-state">No performer's notes yet.</p>
+    <PerformersNotes client:load pieceId={piece.id} initialNotes={performersNotes} />
   </section>
 
   {/* ---------- Structural landmarks ---------- */}

--- a/src/lib/performersNotes.ts
+++ b/src/lib/performersNotes.ts
@@ -1,0 +1,83 @@
+// Helpers for fetching published performer's notes on a piece.
+// Thin wrapper over supabase-js; see the Slice A RPC migration for the
+// security-definer functions that handle mutations.
+
+import { supabase, hasSupabase } from './supabase';
+
+export interface PublishedPerformersNote {
+  noteId: string;
+  versionId: string;
+  body: string;
+  versionNumber: number;
+  approvedAt: string | null;
+  contributor: {
+    id: string;
+    displayName: string;
+    bioShort: string | null;
+  };
+}
+
+/**
+ * Fetch all published performer's notes for a piece, joined to the current
+ * version body + the bylined contributor's profile. RLS scopes this to
+ * status='published' for anonymous callers, so it's safe to call from SSR.
+ *
+ * Three round-trips (notes, versions, contributors) instead of a nested
+ * select — PostgREST can't disambiguate the two FKs between notes and
+ * versions (note_id and the composite current-version FK), and separate
+ * `in(...)` queries keep the plan readable.
+ */
+export async function getPublishedPerformersNotes(pieceId: string): Promise<PublishedPerformersNote[]> {
+  if (!hasSupabase) return [];
+
+  const notesRes = await supabase
+    .from('performers_notes')
+    .select('id, contributor_id, current_version_id, approved_by_contributor_at')
+    .eq('piece_id', pieceId)
+    .eq('status', 'published')
+    .order('approved_by_contributor_at', { ascending: true });
+  if (notesRes.error || !notesRes.data || notesRes.data.length === 0) return [];
+
+  const versionIds = notesRes.data.map((n) => n.current_version_id).filter((x): x is string => Boolean(x));
+  const contributorIds = [...new Set(notesRes.data.map((n) => n.contributor_id))];
+
+  // Use the `v_performers_note_versions_published` view: RLS on the base
+  // version table deliberately blocks anon reads, and the view is granted
+  // to anon + authenticated.
+  const [versionsRes, contribsRes] = await Promise.all([
+    supabase
+      .from('v_performers_note_versions_published')
+      .select('id, body, version_number, approved_at')
+      .in('id', versionIds),
+    supabase
+      .from('users')
+      .select('id, display_name, contributor_bio_short')
+      .in('id', contributorIds),
+  ]);
+  if (versionsRes.error || !versionsRes.data) return [];
+  if (contribsRes.error || !contribsRes.data) return [];
+
+  const versionById = new Map(versionsRes.data.map((v) => [v.id, v]));
+  const contribById = new Map(contribsRes.data.map((c) => [c.id, c]));
+
+  const rows: PublishedPerformersNote[] = [];
+  for (const n of notesRes.data) {
+    if (!n.current_version_id) continue;
+    const version = versionById.get(n.current_version_id);
+    const contributor = contribById.get(n.contributor_id);
+    if (!version || !contributor) continue;
+    rows.push({
+      noteId: n.id,
+      versionId: version.id,
+      body: version.body,
+      versionNumber: version.version_number,
+      approvedAt: version.approved_at,
+      contributor: {
+        id: contributor.id,
+        displayName: contributor.display_name,
+        bioShort: contributor.contributor_bio_short ?? null,
+      },
+    });
+  }
+  return rows;
+}


### PR DESCRIPTION
Slice A **step 6**. First step that puts signed content on the public piece page — replaces the empty state with published performer's notes in the DESIGN.md signed-notes pattern, plus contributor affordances.

## What ships
- \`src/lib/performersNotes.ts\` — \`getPublishedPerformersNotes(pieceId)\` SSR helper. Uses the \`v_performers_note_versions_published\` view (created in the schema migration) for anon-safe body reads since the base versions table deliberately blocks anon.
- \`src/components/PerformersNotes.tsx\` — React client island. Hydrates with the SSR'd initialNotes so anon users see content immediately with zero flicker. On mount checks auth + contributor status and adds:
  - **contributor without an own note here**: "Write a performer's note →" entry that opens an inline editor and posts to \`publish_contributor_note\`
  - **contributor viewing their own card**: Edit / Remove affordances that call \`publish_contributor_edit\` / \`remove_performers_note\`
  - anon and non-contributor viewers: clean read-only render
- \`src/components/PiecePageLayout.astro\` — SSR-fetches in the frontmatter, passes to the island. Section now has \`id="performers-notes"\` so digest email deep-links land correctly.
- \`package.json\` — new \`dev:local\` script that sets PUBLIC_SUPABASE_URL inline so both SSR and client point at local Supabase.

## Render pattern
- First note: 2px accent-purple left border (primary voice)
- Subsequent notes: 0.5px \`border-strong\` left border (contrasting-voice treatment per DESIGN.md §Signed notes)
- Byline renders immediately under the prose: name (weight 500) · one-line bio (muted)

## Not merging until your sign-off

Walkthrough (magic link opened — you're signed in as Haji viewing \`/piece/bach-cello-suite-1\`):
- [ ] See the approved note rendered in signed-notes style
- [ ] As Haji, you should see Edit + Remove on your own card
- [ ] Click Edit → make a small change → Save → new version publishes, body updates
- [ ] Click Remove → note disappears (status=removed, trigger auto-clears notifications)
- [ ] Empty state now shows "Write a performer's note →"
- [ ] Click Write → compose a new note → Publish → appears with your byline
- [ ] Sign out and refresh — the Write entry + owner actions disappear, read stays

Any polish / wording / layout tweaks, flag before merge.

## Depends on
- #37 (admin view) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)