### PR TITLE
feat(slice-b): step 2 — shared RPC helpers + 23 new RPCs

### DIFF
--- a/src/integration/interpretiveSchools.test.ts
+++ b/src/integration/interpretiveSchools.test.ts
@@ -1,0 +1,551 @@
+// State-machine integration tests for InterpretiveSchool RPCs (Slice B Step 2).
+// Mirrors src/integration/contributorPipeline.test.ts for parity — if a
+// performers-notes transition is tested there, the school version is here.
+// Additional: metadata-only update audit (4A), owner-only enforcement (CM4),
+// name uniqueness NOT enforced at DB level, multi-school-per-(piece, contributor)
+// allowed.
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import {
+  admin,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+} from './helpers';
+
+const PIECE = 'slice-b-schools-test';
+
+let contributor: Awaited<ReturnType<typeof createAuthUser>>;
+let otherContributor: Awaited<ReturnType<typeof createAuthUser>>;
+let staff: Awaited<ReturnType<typeof createAuthUser>>;
+let normalUser: Awaited<ReturnType<typeof createAuthUser>>;
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'Slice B Schools Test Piece');
+  contributor = await createAuthUser({ isContributor: true, displayName: 'Schools Contributor' });
+  otherContributor = await createAuthUser({ isContributor: true, displayName: 'Other Schools Contributor' });
+  staff = await createAuthUser({ isStaff: true, displayName: 'Schools Staff' });
+  normalUser = await createAuthUser({ displayName: 'Schools Normal' });
+});
+
+afterAll(async () => {
+  await deleteTestPiece(PIECE);
+  await deleteAuthUser(contributor.id);
+  await deleteAuthUser(otherContributor.id);
+  await deleteAuthUser(staff.id);
+  await deleteAuthUser(normalUser.id);
+});
+
+afterEach(async () => {
+  await admin.from('interpretive_schools').update({ current_version_id: null }).eq('piece_id', PIECE);
+  await admin.from('interpretive_school_versions').delete().eq('piece_id', PIECE);
+  await admin.from('interpretive_schools').delete().eq('piece_id', PIECE);
+  await admin.from('notifications').delete().eq('subject_table', 'interpretive_schools');
+});
+
+describe('contributor-authored schools', () => {
+  test('publish_contributor_interpretive_school creates + publishes atomically, no notification', async () => {
+    const { data: schoolId, error } = await contributor.client.rpc(
+      'publish_contributor_interpretive_school',
+      {
+        p_piece_id: PIECE,
+        p_name: 'Historically informed',
+        p_body: 'Bowing conventions follow early-music practice.',
+      },
+    );
+    expect(error).toBeNull();
+    expect(schoolId).toBeTruthy();
+
+    const { data: school } = await admin
+      .from('interpretive_schools')
+      .select('status, drafted_by, approved_by, current_version_id, name')
+      .eq('id', schoolId!)
+      .single();
+    expect(school!.status).toBe('published');
+    expect(school!.drafted_by).toBeNull();
+    expect(school!.approved_by).toBe(contributor.id);
+    expect(school!.current_version_id).toBeTruthy();
+    expect(school!.name).toBe('Historically informed');
+
+    const { count: notifCount } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'interpretive_schools')
+      .eq('subject_id', schoolId!);
+    expect(notifCount).toBe(0);
+  });
+
+  test('publish_contributor_interpretive_school_edit bumps version, no notification', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Chamber-symphonic',
+      p_body: 'v1 body',
+    });
+
+    const { error } = await contributor.client.rpc('publish_contributor_interpretive_school_edit', {
+      p_school_id: schoolId!,
+      p_body: 'v2 body, revised',
+    });
+    expect(error).toBeNull();
+
+    const { data: versions } = await admin
+      .from('interpretive_school_versions')
+      .select('version_number, body, approved_at')
+      .eq('school_id', schoolId!)
+      .order('version_number', { ascending: true });
+    expect(versions!.length).toBe(2);
+    expect(versions![1].version_number).toBe(2);
+    expect(versions![1].body).toContain('revised');
+    expect(versions![1].approved_at).not.toBeNull();
+
+    const { count: notifCount } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'interpretive_schools')
+      .eq('subject_id', schoolId!);
+    expect(notifCount).toBe(0);
+  });
+
+  test('REGRESSION (iron rule): self-authored paths NEVER create notifications', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Self-author test',
+      p_body: 'original',
+    });
+    await contributor.client.rpc('publish_contributor_interpretive_school_edit', {
+      p_school_id: schoolId!,
+      p_body: 'edit 1',
+    });
+    await contributor.client.rpc('publish_contributor_interpretive_school_edit', {
+      p_school_id: schoolId!,
+      p_body: 'edit 2',
+    });
+
+    const { count } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'interpretive_schools')
+      .eq('subject_id', schoolId!);
+    expect(count).toBe(0);
+  });
+
+  test('remove_interpretive_school soft-removes + trigger clears notifications', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Removal test',
+      p_body: 'body',
+    });
+
+    await contributor.client.rpc('remove_interpretive_school', { p_school_id: schoolId! });
+
+    const { data: school } = await admin
+      .from('interpretive_schools')
+      .select('status, removed_by, removed_at')
+      .eq('id', schoolId!)
+      .single();
+    expect(school!.status).toBe('removed');
+    expect(school!.removed_by).toBe(contributor.id);
+    expect(school!.removed_at).not.toBeNull();
+  });
+});
+
+describe('CM4 — update_interpretive_school_metadata owner-only', () => {
+  test('owner can update name + tempo_cues; audit columns set', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Typo verison',
+      p_body: 'body',
+    });
+
+    const { error } = await contributor.client.rpc('update_interpretive_school_metadata', {
+      p_school_id: schoolId!,
+      p_name: 'Typo version',
+      p_tempo_cues: { opening: 'quarter=72' },
+    });
+    expect(error).toBeNull();
+
+    const { data: school } = await admin
+      .from('interpretive_schools')
+      .select('name, tempo_cues, metadata_updated_by, metadata_updated_at')
+      .eq('id', schoolId!)
+      .single();
+    expect(school!.name).toBe('Typo version');
+    expect(school!.tempo_cues).toEqual({ opening: 'quarter=72' });
+    expect(school!.metadata_updated_by).toBe(contributor.id);
+    expect(school!.metadata_updated_at).not.toBeNull();
+  });
+
+  test('metadata update does NOT bump version', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Version stability',
+      p_body: 'body',
+    });
+
+    await contributor.client.rpc('update_interpretive_school_metadata', {
+      p_school_id: schoolId!,
+      p_name: 'Renamed',
+    });
+
+    const { data: versions } = await admin
+      .from('interpretive_school_versions')
+      .select('version_number')
+      .eq('school_id', schoolId!);
+    expect(versions!.length).toBe(1);
+  });
+
+  test('non-owner contributor is blocked', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Owner-only gate',
+      p_body: 'body',
+    });
+
+    const { error } = await otherContributor.client.rpc('update_interpretive_school_metadata', {
+      p_school_id: schoolId!,
+      p_name: 'Stolen rename',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not found or not owned/i);
+  });
+
+  test('staff is blocked (CM4: PRD invariant — only bylined contributor touches their byline)', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Staff cannot rename',
+      p_body: 'body',
+    });
+
+    const { error } = await staff.client.rpc('update_interpretive_school_metadata', {
+      p_school_id: schoolId!,
+      p_name: 'Staff-renamed',
+    });
+    expect(error).not.toBeNull();
+    // Staff is not a contributor — _require_active_contributor blocks.
+    expect(error!.message).toMatch(/not an active contributor|not found or not owned/i);
+  });
+
+  test('at least one of p_name or p_tempo_cues is required', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Required args',
+      p_body: 'body',
+    });
+
+    const { error } = await contributor.client.rpc('update_interpretive_school_metadata', {
+      p_school_id: schoolId!,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/at least one/i);
+  });
+});
+
+describe('staff-drafted schools — approval flow', () => {
+  test('full round trip: create → submit → approve, notification lifecycle', async () => {
+    const { data: schoolId } = await staff.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'String-native',
+      p_body: 'Body drafted by staff.',
+    });
+    expect(schoolId).toBeTruthy();
+
+    // Submit — notification fires.
+    await staff.client.rpc('submit_interpretive_school', { p_school_id: schoolId! });
+
+    const { data: notifAfterSubmit } = await admin
+      .from('notifications')
+      .select('id, subject_table, subject_id, body, cleared_at')
+      .eq('subject_table', 'interpretive_schools')
+      .eq('subject_id', schoolId!)
+      .single();
+    expect(notifAfterSubmit!.subject_table).toBe('interpretive_schools');
+    expect(notifAfterSubmit!.body).toContain("interpretive school");
+    expect(notifAfterSubmit!.body).toContain('String-native');
+    expect(notifAfterSubmit!.cleared_at).toBeNull();
+
+    // Approve — notification cleared.
+    await contributor.client.rpc('approve_interpretive_school', { p_school_id: schoolId! });
+
+    const { data: school } = await admin
+      .from('interpretive_schools')
+      .select('status, approved_by, current_version_id')
+      .eq('id', schoolId!)
+      .single();
+    expect(school!.status).toBe('published');
+    expect(school!.approved_by).toBe(contributor.id);
+    expect(school!.current_version_id).toBeTruthy();
+
+    const { data: notifAfterApprove } = await admin
+      .from('notifications')
+      .select('cleared_at')
+      .eq('id', notifAfterSubmit!.id)
+      .single();
+    expect(notifAfterApprove!.cleared_at).not.toBeNull();
+  });
+
+  test('CM3: double-submit produces ONE live notification (idempotency)', async () => {
+    const { data: schoolId } = await staff.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'Idempotent submit',
+      p_body: 'body',
+    });
+
+    await staff.client.rpc('submit_interpretive_school', { p_school_id: schoolId! });
+
+    // Force status back to draft so we can re-submit (the state machine
+    // would normally block a double-submit, so we bypass to test CM3 directly).
+    await admin.from('interpretive_schools').update({ status: 'draft' }).eq('id', schoolId!);
+
+    await staff.client.rpc('submit_interpretive_school', { p_school_id: schoolId! });
+
+    const { count } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'interpretive_schools')
+      .eq('subject_id', schoolId!)
+      .is('cleared_at', null);
+    expect(count).toBe(1);
+  });
+
+  test('approve_and_edit inserts new version + publishes in one atomic call', async () => {
+    const { data: schoolId } = await staff.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'Approve-and-edit',
+      p_body: 'staff-drafted body',
+    });
+    await staff.client.rpc('submit_interpretive_school', { p_school_id: schoolId! });
+
+    await contributor.client.rpc('approve_and_edit_interpretive_school', {
+      p_school_id: schoolId!,
+      p_body: 'contributor-revised body',
+    });
+
+    const { data: school } = await admin
+      .from('interpretive_schools')
+      .select('status, current_version_id, approved_by')
+      .eq('id', schoolId!)
+      .single();
+    expect(school!.status).toBe('published');
+    expect(school!.approved_by).toBe(contributor.id);
+
+    const { data: versions } = await admin
+      .from('interpretive_school_versions')
+      .select('id, version_number, body, authored_by, approved_at')
+      .eq('school_id', schoolId!)
+      .order('version_number', { ascending: true });
+    expect(versions!.length).toBe(2);
+    expect(versions![0].body).toBe('staff-drafted body');
+    expect(versions![0].approved_at).toBeNull();
+    expect(versions![1].body).toBe('contributor-revised body');
+    expect(versions![1].authored_by).toBe(contributor.id);
+    expect(versions![1].approved_at).not.toBeNull();
+    expect(school!.current_version_id).toBe(versions![1].id);
+  });
+
+  test('reject → revise → resubmit → approve loop', async () => {
+    const { data: schoolId } = await staff.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'Reject loop',
+      p_body: 'first staff draft',
+    });
+    await staff.client.rpc('submit_interpretive_school', { p_school_id: schoolId! });
+
+    await contributor.client.rpc('reject_interpretive_school', {
+      p_school_id: schoolId!,
+      p_reason: 'Too long',
+    });
+
+    const { data: v1 } = await admin
+      .from('interpretive_school_versions')
+      .select('rejection_note')
+      .eq('school_id', schoolId!)
+      .eq('version_number', 1)
+      .single();
+    expect(v1!.rejection_note).toBe('Too long');
+
+    const { data: school } = await admin
+      .from('interpretive_schools')
+      .select('status, rejected_by')
+      .eq('id', schoolId!)
+      .single();
+    expect(school!.status).toBe('draft');
+    expect(school!.rejected_by).toBe(contributor.id);
+
+    // Staff revises.
+    await staff.client.rpc('update_interpretive_school_draft', {
+      p_school_id: schoolId!,
+      p_body: 'revised tighter version',
+    });
+    await staff.client.rpc('submit_interpretive_school', { p_school_id: schoolId! });
+    await contributor.client.rpc('approve_interpretive_school', { p_school_id: schoolId! });
+
+    const { data: finalSchool } = await admin
+      .from('interpretive_schools')
+      .select('status')
+      .eq('id', schoolId!)
+      .single();
+    expect(finalSchool!.status).toBe('published');
+  });
+
+  test('staff retract clears notification + returns to draft', async () => {
+    const { data: schoolId } = await staff.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'Retract test',
+      p_body: 'body',
+    });
+    await staff.client.rpc('submit_interpretive_school', { p_school_id: schoolId! });
+
+    await staff.client.rpc('retract_interpretive_school', { p_school_id: schoolId! });
+
+    const { data: school } = await admin
+      .from('interpretive_schools')
+      .select('status, retracted_by, retracted_at')
+      .eq('id', schoolId!)
+      .single();
+    expect(school!.status).toBe('draft');
+    expect(school!.retracted_by).toBe(staff.id);
+    expect(school!.retracted_at).not.toBeNull();
+
+    const { count: live } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'interpretive_schools')
+      .eq('subject_id', schoolId!)
+      .is('cleared_at', null);
+    expect(live).toBe(0);
+  });
+});
+
+describe('authorization guards', () => {
+  test('normal user cannot publish_contributor_interpretive_school', async () => {
+    const { error } = await normalUser.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Should fail',
+      p_body: 'body',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not an active contributor/i);
+  });
+
+  test('normal user cannot create_interpretive_school_draft', async () => {
+    const { error } = await normalUser.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'Should fail',
+      p_body: 'body',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not staff/i);
+  });
+
+  test('other contributor cannot approve someone else\'s draft', async () => {
+    const { data: schoolId } = await staff.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'Foreign approval',
+      p_body: 'body',
+    });
+    await staff.client.rpc('submit_interpretive_school', { p_school_id: schoolId! });
+
+    const { error } = await otherContributor.client.rpc('approve_interpretive_school', {
+      p_school_id: schoolId!,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not found, not owned/i);
+  });
+});
+
+describe('plurality rules', () => {
+  test('same contributor can publish multiple schools on the same piece', async () => {
+    const { data: id1 } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Historically informed',
+      p_body: 'body 1',
+    });
+    const { data: id2 } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Chamber-symphonic',
+      p_body: 'body 2',
+    });
+    expect(id1).toBeTruthy();
+    expect(id2).toBeTruthy();
+    expect(id1).not.toBe(id2);
+
+    const { count } = await admin
+      .from('interpretive_schools')
+      .select('id', { count: 'exact', head: true })
+      .eq('piece_id', PIECE)
+      .eq('contributor_id', contributor.id)
+      .eq('status', 'published');
+    expect(count).toBe(2);
+  });
+
+  test('two contributors can hold schools with identical names (no DB uniqueness)', async () => {
+    await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Historically informed',
+      p_body: 'voice A',
+    });
+    const { data: id2, error } = await otherContributor.client.rpc(
+      'publish_contributor_interpretive_school',
+      {
+        p_piece_id: PIECE,
+        p_name: 'Historically informed',
+        p_body: 'voice B',
+      },
+    );
+    expect(error).toBeNull();
+    expect(id2).toBeTruthy();
+  });
+});
+
+describe('forbidden transitions', () => {
+  test('approve on a published school fails', async () => {
+    const { data: schoolId } = await contributor.client.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: PIECE,
+      p_name: 'Already published',
+      p_body: 'body',
+    });
+
+    const { error } = await contributor.client.rpc('approve_interpretive_school', {
+      p_school_id: schoolId!,
+    });
+    expect(error).not.toBeNull();
+  });
+
+  test('remove on a draft fails', async () => {
+    const { data: schoolId } = await staff.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'Draft removal',
+      p_body: 'body',
+    });
+
+    const { error } = await contributor.client.rpc('remove_interpretive_school', {
+      p_school_id: schoolId!,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/can only remove a published/i);
+  });
+
+  test('retract on a draft (not awaiting) fails', async () => {
+    const { data: schoolId } = await staff.client.rpc('create_interpretive_school_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_name: 'Retract draft',
+      p_body: 'body',
+    });
+
+    const { error } = await staff.client.rpc('retract_interpretive_school', {
+      p_school_id: schoolId!,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/can only retract/i);
+  });
+});

--- a/src/integration/pieceDescriptions.test.ts
+++ b/src/integration/pieceDescriptions.test.ts
@@ -1,0 +1,356 @@
+// State-machine integration tests for PieceDescription RPCs (Slice B Step 2).
+// Body-only entity — no metadata RPC (unlike schools which have name/tempo_cues).
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import {
+  admin,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+} from './helpers';
+
+const PIECE = 'slice-b-descriptions-test';
+
+let contributor: Awaited<ReturnType<typeof createAuthUser>>;
+let otherContributor: Awaited<ReturnType<typeof createAuthUser>>;
+let staff: Awaited<ReturnType<typeof createAuthUser>>;
+let normalUser: Awaited<ReturnType<typeof createAuthUser>>;
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'Slice B Descriptions Test Piece');
+  contributor = await createAuthUser({ isContributor: true, displayName: 'Descriptions Contributor' });
+  otherContributor = await createAuthUser({ isContributor: true, displayName: 'Other Descriptions Contributor' });
+  staff = await createAuthUser({ isStaff: true, displayName: 'Descriptions Staff' });
+  normalUser = await createAuthUser({ displayName: 'Descriptions Normal' });
+});
+
+afterAll(async () => {
+  await deleteTestPiece(PIECE);
+  await deleteAuthUser(contributor.id);
+  await deleteAuthUser(otherContributor.id);
+  await deleteAuthUser(staff.id);
+  await deleteAuthUser(normalUser.id);
+});
+
+afterEach(async () => {
+  await admin.from('piece_descriptions').update({ current_version_id: null }).eq('piece_id', PIECE);
+  await admin.from('piece_description_versions').delete().eq('piece_id', PIECE);
+  await admin.from('piece_descriptions').delete().eq('piece_id', PIECE);
+  await admin.from('notifications').delete().eq('subject_table', 'piece_descriptions');
+});
+
+describe('contributor-authored descriptions', () => {
+  test('publish_contributor_piece_description publishes atomically, no notification', async () => {
+    const { data: id, error } = await contributor.client.rpc('publish_contributor_piece_description', {
+      p_piece_id: PIECE,
+      p_body: 'This concerto hinges between late-Romantic lyricism and early-modernist economy.',
+    });
+    expect(error).toBeNull();
+    expect(id).toBeTruthy();
+
+    const { data: d } = await admin
+      .from('piece_descriptions')
+      .select('status, drafted_by, approved_by, current_version_id')
+      .eq('id', id!)
+      .single();
+    expect(d!.status).toBe('published');
+    expect(d!.drafted_by).toBeNull();
+    expect(d!.approved_by).toBe(contributor.id);
+    expect(d!.current_version_id).toBeTruthy();
+
+    const { count } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'piece_descriptions')
+      .eq('subject_id', id!);
+    expect(count).toBe(0);
+  });
+
+  test('publish_contributor_piece_description_edit bumps version, no notification', async () => {
+    const { data: id } = await contributor.client.rpc('publish_contributor_piece_description', {
+      p_piece_id: PIECE,
+      p_body: 'v1',
+    });
+    await contributor.client.rpc('publish_contributor_piece_description_edit', {
+      p_description_id: id!,
+      p_body: 'v2 revised',
+    });
+
+    const { data: versions } = await admin
+      .from('piece_description_versions')
+      .select('version_number, body')
+      .eq('description_id', id!)
+      .order('version_number', { ascending: true });
+    expect(versions!.length).toBe(2);
+    expect(versions![1].body).toContain('revised');
+  });
+
+  test('REGRESSION (iron rule): self-authored paths NEVER create notifications', async () => {
+    const { data: id } = await contributor.client.rpc('publish_contributor_piece_description', {
+      p_piece_id: PIECE,
+      p_body: 'initial',
+    });
+    await contributor.client.rpc('publish_contributor_piece_description_edit', {
+      p_description_id: id!,
+      p_body: 'edit 1',
+    });
+    await contributor.client.rpc('publish_contributor_piece_description_edit', {
+      p_description_id: id!,
+      p_body: 'edit 2',
+    });
+
+    const { count } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'piece_descriptions')
+      .eq('subject_id', id!);
+    expect(count).toBe(0);
+  });
+
+  test('remove_piece_description soft-removes', async () => {
+    const { data: id } = await contributor.client.rpc('publish_contributor_piece_description', {
+      p_piece_id: PIECE,
+      p_body: 'body',
+    });
+
+    await contributor.client.rpc('remove_piece_description', { p_description_id: id! });
+
+    const { data: d } = await admin
+      .from('piece_descriptions')
+      .select('status, removed_by, removed_at')
+      .eq('id', id!)
+      .single();
+    expect(d!.status).toBe('removed');
+    expect(d!.removed_by).toBe(contributor.id);
+  });
+});
+
+describe('staff-drafted descriptions — approval flow', () => {
+  test('full round trip: create → submit → approve', async () => {
+    const { data: id } = await staff.client.rpc('create_piece_description_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'Staff-drafted body.',
+    });
+    expect(id).toBeTruthy();
+
+    await staff.client.rpc('submit_piece_description', { p_description_id: id! });
+
+    const { data: notif } = await admin
+      .from('notifications')
+      .select('id, subject_table, subject_id, body, cleared_at')
+      .eq('subject_table', 'piece_descriptions')
+      .eq('subject_id', id!)
+      .single();
+    expect(notif!.subject_table).toBe('piece_descriptions');
+    expect(notif!.body).toContain('piece description');
+    expect(notif!.cleared_at).toBeNull();
+
+    await contributor.client.rpc('approve_piece_description', { p_description_id: id! });
+
+    const { data: d } = await admin
+      .from('piece_descriptions')
+      .select('status, approved_by, current_version_id')
+      .eq('id', id!)
+      .single();
+    expect(d!.status).toBe('published');
+    expect(d!.approved_by).toBe(contributor.id);
+
+    const { data: notifCleared } = await admin
+      .from('notifications')
+      .select('cleared_at')
+      .eq('id', notif!.id)
+      .single();
+    expect(notifCleared!.cleared_at).not.toBeNull();
+  });
+
+  test('CM3: double-submit produces ONE live notification (idempotency)', async () => {
+    const { data: id } = await staff.client.rpc('create_piece_description_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'body',
+    });
+
+    await staff.client.rpc('submit_piece_description', { p_description_id: id! });
+    await admin.from('piece_descriptions').update({ status: 'draft' }).eq('id', id!);
+    await staff.client.rpc('submit_piece_description', { p_description_id: id! });
+
+    const { count } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'piece_descriptions')
+      .eq('subject_id', id!)
+      .is('cleared_at', null);
+    expect(count).toBe(1);
+  });
+
+  test('approve_and_edit inserts new version + publishes atomically', async () => {
+    const { data: id } = await staff.client.rpc('create_piece_description_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'staff body',
+    });
+    await staff.client.rpc('submit_piece_description', { p_description_id: id! });
+
+    await contributor.client.rpc('approve_and_edit_piece_description', {
+      p_description_id: id!,
+      p_body: 'contributor-revised',
+    });
+
+    const { data: d } = await admin
+      .from('piece_descriptions')
+      .select('status, current_version_id')
+      .eq('id', id!)
+      .single();
+    expect(d!.status).toBe('published');
+
+    const { data: versions } = await admin
+      .from('piece_description_versions')
+      .select('id, version_number, body, authored_by, approved_at')
+      .eq('description_id', id!)
+      .order('version_number', { ascending: true });
+    expect(versions!.length).toBe(2);
+    expect(versions![1].authored_by).toBe(contributor.id);
+    expect(versions![1].body).toBe('contributor-revised');
+    expect(d!.current_version_id).toBe(versions![1].id);
+  });
+
+  test('reject → revise → resubmit → approve', async () => {
+    const { data: id } = await staff.client.rpc('create_piece_description_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'first',
+    });
+    await staff.client.rpc('submit_piece_description', { p_description_id: id! });
+
+    await contributor.client.rpc('reject_piece_description', {
+      p_description_id: id!,
+      p_reason: 'Wrong register',
+    });
+
+    const { data: v1 } = await admin
+      .from('piece_description_versions')
+      .select('rejection_note')
+      .eq('description_id', id!)
+      .eq('version_number', 1)
+      .single();
+    expect(v1!.rejection_note).toBe('Wrong register');
+
+    await staff.client.rpc('update_piece_description_draft', {
+      p_description_id: id!,
+      p_body: 'revised',
+    });
+    await staff.client.rpc('submit_piece_description', { p_description_id: id! });
+    await contributor.client.rpc('approve_piece_description', { p_description_id: id! });
+
+    const { data: d } = await admin
+      .from('piece_descriptions')
+      .select('status')
+      .eq('id', id!)
+      .single();
+    expect(d!.status).toBe('published');
+  });
+
+  test('staff retract clears notification + returns to draft', async () => {
+    const { data: id } = await staff.client.rpc('create_piece_description_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'body',
+    });
+    await staff.client.rpc('submit_piece_description', { p_description_id: id! });
+    await staff.client.rpc('retract_piece_description', { p_description_id: id! });
+
+    const { data: d } = await admin
+      .from('piece_descriptions')
+      .select('status, retracted_by, retracted_at')
+      .eq('id', id!)
+      .single();
+    expect(d!.status).toBe('draft');
+    expect(d!.retracted_by).toBe(staff.id);
+
+    const { count: live } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_table', 'piece_descriptions')
+      .eq('subject_id', id!)
+      .is('cleared_at', null);
+    expect(live).toBe(0);
+  });
+});
+
+describe('authorization guards', () => {
+  test('normal user cannot publish_contributor_piece_description', async () => {
+    const { error } = await normalUser.client.rpc('publish_contributor_piece_description', {
+      p_piece_id: PIECE,
+      p_body: 'body',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not an active contributor/i);
+  });
+
+  test('normal user cannot create_piece_description_draft', async () => {
+    const { error } = await normalUser.client.rpc('create_piece_description_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'body',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not staff/i);
+  });
+
+  test('other contributor cannot approve someone else\'s draft', async () => {
+    const { data: id } = await staff.client.rpc('create_piece_description_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'body',
+    });
+    await staff.client.rpc('submit_piece_description', { p_description_id: id! });
+
+    const { error } = await otherContributor.client.rpc('approve_piece_description', {
+      p_description_id: id!,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/not found, not owned/i);
+  });
+});
+
+describe('plurality + forbidden transitions', () => {
+  test('same contributor can publish multiple descriptions on same piece', async () => {
+    const { data: id1 } = await contributor.client.rpc('publish_contributor_piece_description', {
+      p_piece_id: PIECE,
+      p_body: 'framing A',
+    });
+    const { data: id2 } = await contributor.client.rpc('publish_contributor_piece_description', {
+      p_piece_id: PIECE,
+      p_body: 'framing B',
+    });
+    expect(id1).toBeTruthy();
+    expect(id2).toBeTruthy();
+    expect(id1).not.toBe(id2);
+  });
+
+  test('approve on published fails', async () => {
+    const { data: id } = await contributor.client.rpc('publish_contributor_piece_description', {
+      p_piece_id: PIECE,
+      p_body: 'body',
+    });
+    const { error } = await contributor.client.rpc('approve_piece_description', {
+      p_description_id: id!,
+    });
+    expect(error).not.toBeNull();
+  });
+
+  test('remove on draft fails', async () => {
+    const { data: id } = await staff.client.rpc('create_piece_description_draft', {
+      p_piece_id: PIECE,
+      p_contributor_id: contributor.id,
+      p_body: 'body',
+    });
+    const { error } = await contributor.client.rpc('remove_piece_description', {
+      p_description_id: id!,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/can only remove a published/i);
+  });
+});

--- a/supabase/migrations/20260422000000_contributor_pipeline_slice_b_rpcs.sql
+++ b/supabase/migrations/20260422000000_contributor_pipeline_slice_b_rpcs.sql
@@ -1,0 +1,1222 @@
+-- Contributor approval pipeline — Slice B Step 2: RPC families.
+--
+-- Adds shared helpers + 23 new RPCs covering InterpretiveSchool (12) and
+-- PieceDescription (11). Mirrors the Slice A shape exactly: every mutation
+-- goes through a security-definer RPC with integrated auth + state-machine
+-- validation + version inserts with retry-once on unique-violation +
+-- notification lifecycle.
+--
+-- Shared helpers added:
+--   • _insert_notification(recipient, subject_table, subject_id, body, link_path)
+--     — idempotent via ON CONFLICT DO NOTHING on uq_notifications_live_per_subject
+--     (CM3). Returns the notification row id (existing or new).
+--   • _clear_notifications_for(subject_table, subject_id) — generic clearing
+--     for the polymorphic pair (Slice A's _clear_notifications_for_note stays
+--     for the vestigial dual-write window).
+--   • _insert_interpretive_school_version / _insert_piece_description_version
+--     — per-subject version inserters with retry-once on unique_violation,
+--     mirrors _insert_performers_note_version exactly.
+--
+-- Contributor self-authored paths (publish_contributor_*) publish immediately
+-- without a notification, per the PRD invariant that authoring IS approval
+-- when the bylined contributor is the hands on the keyboard.
+--
+-- Staff/AI-drafted paths route through the approval queue: create_*_draft →
+-- submit_* → approve/reject/retract. The submit RPC is the only place new
+-- notifications are inserted.
+--
+-- CM4: update_interpretive_school_metadata is OWNER-ONLY. Staff cannot rename
+-- a published school. Audit via metadata_updated_by/at (4A).
+--
+-- See PLAN-contributor-pipeline-slice-b.md §4 for the full RPC table.
+
+-- ============================================
+-- Shared helpers — notification lifecycle
+-- ============================================
+
+-- _insert_notification: idempotent notification insert.
+-- Returns the id of the live notification for this (subject, type), whether
+-- newly created or already existing (CM3). Double-submits are no-ops.
+create or replace function public._insert_notification(
+  p_recipient_id uuid,
+  p_subject_table text,
+  p_subject_id uuid,
+  p_body text,
+  p_link_path text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_id uuid;
+  v_performers_note_id uuid := null;
+begin
+  -- Dual-write during vestigial window (CM1): populate performers_note_id
+  -- when the subject is a performers_note so Slice A consumers keep working.
+  if p_subject_table = 'performers_notes' then
+    v_performers_note_id := p_subject_id;
+  end if;
+
+  insert into public.notifications (
+    recipient_id, type, performers_note_id,
+    subject_table, subject_id, body, link_path
+  )
+  values (
+    p_recipient_id, 'draft_awaiting_approval', v_performers_note_id,
+    p_subject_table, p_subject_id, p_body, p_link_path
+  )
+  on conflict (subject_table, subject_id, type) where cleared_at is null
+  do nothing
+  returning id into v_id;
+
+  -- If nothing was inserted (live notification already exists), return the
+  -- existing row's id so callers have a stable reference.
+  if v_id is null then
+    select id into v_id
+      from public.notifications
+      where subject_table = p_subject_table
+        and subject_id = p_subject_id
+        and type = 'draft_awaiting_approval'
+        and cleared_at is null
+      limit 1;
+  end if;
+
+  return v_id;
+end;
+$$;
+
+-- _clear_notifications_for: generic polymorphic clear.
+-- Matches both the polymorphic pair AND (for performers_notes) the narrow FK
+-- so the dual-write window is fully covered.
+create or replace function public._clear_notifications_for(
+  p_subject_table text,
+  p_subject_id uuid
+)
+  returns void
+  language sql
+  security definer
+  set search_path = public
+as $$
+  update public.notifications
+    set cleared_at = now()
+    where (
+      (subject_table = p_subject_table and subject_id = p_subject_id)
+      or (p_subject_table = 'performers_notes' and performers_note_id = p_subject_id)
+    )
+      and cleared_at is null;
+$$;
+
+-- ============================================
+-- Shared helpers — per-subject version inserts (with retry-once)
+-- ============================================
+
+create or replace function public._insert_interpretive_school_version(
+  p_school_id uuid,
+  p_piece_id text,
+  p_contributor_id uuid,
+  p_body text,
+  p_authored_by uuid,
+  p_approved boolean,
+  p_rejection_note text default null
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_version_id uuid;
+  v_next int;
+  v_attempt int := 0;
+begin
+  loop
+    begin
+      select coalesce(max(version_number), 0) + 1
+        into v_next
+        from public.interpretive_school_versions
+        where school_id = p_school_id;
+
+      v_version_id := gen_random_uuid();
+      insert into public.interpretive_school_versions (
+        id, school_id, piece_id, contributor_id,
+        body, authored_by, version_number,
+        approved_at, rejection_note
+      )
+      values (
+        v_version_id, p_school_id, p_piece_id, p_contributor_id,
+        p_body, p_authored_by, v_next,
+        case when p_approved then now() else null end,
+        p_rejection_note
+      );
+      return v_version_id;
+    exception
+      when unique_violation then
+        v_attempt := v_attempt + 1;
+        if v_attempt >= 2 then raise; end if;
+    end;
+  end loop;
+end;
+$$;
+
+create or replace function public._insert_piece_description_version(
+  p_description_id uuid,
+  p_piece_id text,
+  p_contributor_id uuid,
+  p_body text,
+  p_authored_by uuid,
+  p_approved boolean,
+  p_rejection_note text default null
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_version_id uuid;
+  v_next int;
+  v_attempt int := 0;
+begin
+  loop
+    begin
+      select coalesce(max(version_number), 0) + 1
+        into v_next
+        from public.piece_description_versions
+        where description_id = p_description_id;
+
+      v_version_id := gen_random_uuid();
+      insert into public.piece_description_versions (
+        id, description_id, piece_id, contributor_id,
+        body, authored_by, version_number,
+        approved_at, rejection_note
+      )
+      values (
+        v_version_id, p_description_id, p_piece_id, p_contributor_id,
+        p_body, p_authored_by, v_next,
+        case when p_approved then now() else null end,
+        p_rejection_note
+      );
+      return v_version_id;
+    exception
+      when unique_violation then
+        v_attempt := v_attempt + 1;
+        if v_attempt >= 2 then raise; end if;
+    end;
+  end loop;
+end;
+$$;
+
+-- ============================================================================
+-- INTERPRETIVE SCHOOL RPCs (12)
+-- ============================================================================
+
+-- ============================================
+-- Contributor self-authored path (schools)
+-- ============================================
+
+create or replace function public.publish_contributor_interpretive_school(
+  p_piece_id text,
+  p_name text,
+  p_body text,
+  p_tempo_cues jsonb default null
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_school_id uuid;
+  v_version_id uuid;
+  v_contributor_id uuid := auth.uid();
+begin
+  perform public._require_active_contributor();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+  if p_name is null or length(trim(p_name)) = 0 then
+    raise exception 'name required';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found';
+  end if;
+
+  v_school_id := gen_random_uuid();
+
+  insert into public.interpretive_schools (
+    id, piece_id, contributor_id, name, tempo_cues, status, drafted_by
+  )
+  values (v_school_id, p_piece_id, v_contributor_id, trim(p_name), p_tempo_cues, 'draft', null);
+
+  v_version_id := public._insert_interpretive_school_version(
+    v_school_id, p_piece_id, v_contributor_id,
+    p_body, v_contributor_id, true
+  );
+
+  update public.interpretive_schools
+    set status = 'published',
+        current_version_id = v_version_id,
+        approved_by = v_contributor_id,
+        approved_by_contributor_at = now()
+    where id = v_school_id;
+
+  return v_school_id;
+end;
+$$;
+
+create or replace function public.publish_contributor_interpretive_school_edit(
+  p_school_id uuid,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_version_id uuid;
+  v_contributor_id uuid := auth.uid();
+  v_piece_id text;
+  v_status draft_status;
+begin
+  perform public._require_active_contributor();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+
+  select piece_id, status into v_piece_id, v_status
+    from public.interpretive_schools
+    where id = p_school_id
+      and contributor_id = v_contributor_id;
+
+  if not found then
+    raise exception 'school not found or not owned by caller';
+  end if;
+  if v_status <> 'published' then
+    raise exception 'can only edit a published school (current status: %)', v_status;
+  end if;
+
+  v_version_id := public._insert_interpretive_school_version(
+    p_school_id, v_piece_id, v_contributor_id,
+    p_body, v_contributor_id, true
+  );
+
+  update public.interpretive_schools
+    set current_version_id = v_version_id,
+        approved_by = v_contributor_id,
+        approved_by_contributor_at = now()
+    where id = p_school_id;
+
+  return v_version_id;
+end;
+$$;
+
+-- update_interpretive_school_metadata (CM4, 4A): OWNER-ONLY.
+-- Updates name / tempo_cues without bumping version. Staff cannot call.
+-- Sets metadata_updated_by/at for audit.
+create or replace function public.update_interpretive_school_metadata(
+  p_school_id uuid,
+  p_name text default null,
+  p_tempo_cues jsonb default null
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+begin
+  perform public._require_active_contributor();
+
+  if p_name is null and p_tempo_cues is null then
+    raise exception 'at least one of p_name or p_tempo_cues is required';
+  end if;
+
+  if p_name is not null and length(trim(p_name)) = 0 then
+    raise exception 'name cannot be empty';
+  end if;
+
+  -- CM4: owner-only. The WHERE contributor_id = auth.uid() is the gate.
+  update public.interpretive_schools
+    set name = coalesce(trim(p_name), name),
+        tempo_cues = case when p_tempo_cues is not null then p_tempo_cues else tempo_cues end,
+        metadata_updated_by = v_contributor_id,
+        metadata_updated_at = now()
+    where id = p_school_id
+      and contributor_id = v_contributor_id;
+
+  if not found then
+    raise exception 'school not found or not owned by caller';
+  end if;
+end;
+$$;
+
+create or replace function public.remove_interpretive_school(
+  p_school_id uuid
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+  v_status draft_status;
+begin
+  perform public._require_active_contributor();
+
+  select status into v_status
+    from public.interpretive_schools
+    where id = p_school_id
+      and contributor_id = v_contributor_id;
+
+  if not found then
+    raise exception 'school not found or not owned by caller';
+  end if;
+  if v_status <> 'published' then
+    raise exception 'can only remove a published school (current status: %)', v_status;
+  end if;
+
+  update public.interpretive_schools
+    set status = 'removed',
+        removed_by = v_contributor_id,
+        removed_at = now()
+    where id = p_school_id;
+end;
+$$;
+
+-- ============================================
+-- Staff-drafted path (schools)
+-- ============================================
+
+create or replace function public.create_interpretive_school_draft(
+  p_piece_id text,
+  p_contributor_id uuid,
+  p_name text,
+  p_body text,
+  p_tempo_cues jsonb default null
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_school_id uuid;
+  v_staff_id uuid := auth.uid();
+begin
+  perform public._require_staff();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+  if p_name is null or length(trim(p_name)) = 0 then
+    raise exception 'name required';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found';
+  end if;
+  if not exists (
+    select 1 from public.users
+    where id = p_contributor_id and is_contributor = true and contributor_active = true
+  ) then
+    raise exception 'target user is not an active contributor';
+  end if;
+
+  v_school_id := gen_random_uuid();
+  insert into public.interpretive_schools (
+    id, piece_id, contributor_id, name, tempo_cues, status, drafted_by
+  )
+  values (v_school_id, p_piece_id, p_contributor_id, trim(p_name), p_tempo_cues, 'draft', v_staff_id);
+
+  perform public._insert_interpretive_school_version(
+    v_school_id, p_piece_id, p_contributor_id,
+    p_body, v_staff_id, false
+  );
+
+  return v_school_id;
+end;
+$$;
+
+create or replace function public.update_interpretive_school_draft(
+  p_school_id uuid,
+  p_body text default null,
+  p_name text default null,
+  p_tempo_cues jsonb default null
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_version_id uuid;
+  v_staff_id uuid := auth.uid();
+  v_piece_id text;
+  v_contributor_id uuid;
+  v_status draft_status;
+begin
+  perform public._require_staff();
+
+  if p_body is null and p_name is null and p_tempo_cues is null then
+    raise exception 'at least one of p_body, p_name, p_tempo_cues is required';
+  end if;
+
+  select piece_id, contributor_id, status
+    into v_piece_id, v_contributor_id, v_status
+    from public.interpretive_schools where id = p_school_id;
+
+  if not found then
+    raise exception 'school not found';
+  end if;
+  if v_status <> 'draft' then
+    raise exception 'can only revise a draft (current status: %)', v_status;
+  end if;
+
+  -- If body changed, insert a new version row.
+  if p_body is not null then
+    if length(trim(p_body)) = 0 then
+      raise exception 'body cannot be empty';
+    end if;
+    v_version_id := public._insert_interpretive_school_version(
+      p_school_id, v_piece_id, v_contributor_id,
+      p_body, v_staff_id, false
+    );
+  end if;
+
+  -- Metadata fields (name, tempo_cues) update on the row without a version bump.
+  -- Pre-publish, this is fine — no approval contract to violate yet.
+  update public.interpretive_schools
+    set name = coalesce(nullif(trim(coalesce(p_name, '')), ''), name),
+        tempo_cues = case when p_tempo_cues is not null then p_tempo_cues else tempo_cues end,
+        drafted_by = v_staff_id,
+        updated_at = now()
+    where id = p_school_id;
+
+  return v_version_id;
+end;
+$$;
+
+create or replace function public.submit_interpretive_school(
+  p_school_id uuid
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_staff_id uuid := auth.uid();
+  v_piece_id text;
+  v_piece_title text;
+  v_contributor_id uuid;
+  v_status draft_status;
+  v_name text;
+begin
+  perform public._require_staff();
+
+  select s.piece_id, s.contributor_id, s.status, s.name, p.title
+    into v_piece_id, v_contributor_id, v_status, v_name, v_piece_title
+    from public.interpretive_schools s
+    join public.pieces p on p.id = s.piece_id
+    where s.id = p_school_id;
+
+  if not found then
+    raise exception 'school not found';
+  end if;
+  if v_status <> 'draft' then
+    raise exception 'can only submit a draft (current status: %)', v_status;
+  end if;
+
+  update public.interpretive_schools
+    set status = 'awaiting_contributor_approval',
+        submitted_by = v_staff_id
+    where id = p_school_id;
+
+  perform public._insert_notification(
+    v_contributor_id,
+    'interpretive_schools',
+    p_school_id,
+    format('A draft interpretive school (''%s'') on %s is ready for your review.', v_name, v_piece_title),
+    '/notifications'
+  );
+end;
+$$;
+
+create or replace function public.retract_interpretive_school(
+  p_school_id uuid
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_staff_id uuid := auth.uid();
+  v_status draft_status;
+begin
+  perform public._require_staff();
+
+  select status into v_status from public.interpretive_schools where id = p_school_id;
+  if not found then
+    raise exception 'school not found';
+  end if;
+  if v_status <> 'awaiting_contributor_approval' then
+    raise exception 'can only retract a submitted draft (current status: %)', v_status;
+  end if;
+
+  update public.interpretive_schools
+    set status = 'draft',
+        retracted_by = v_staff_id,
+        retracted_at = now()
+    where id = p_school_id;
+
+  perform public._clear_notifications_for('interpretive_schools', p_school_id);
+end;
+$$;
+
+-- ============================================
+-- Contributor actions on staff-drafted schools
+-- ============================================
+
+create or replace function public.approve_interpretive_school(
+  p_school_id uuid
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+  v_pending_version_id uuid;
+  v_status draft_status;
+begin
+  perform public._require_active_contributor();
+
+  select s.status, v.id
+    into v_status, v_pending_version_id
+    from public.interpretive_schools s
+    join public.interpretive_school_versions v
+      on v.school_id = s.id and v.approved_at is null
+    where s.id = p_school_id
+      and s.contributor_id = v_contributor_id
+    order by v.version_number desc
+    limit 1;
+
+  if not found then
+    raise exception 'school not found, not owned by caller, or has no pending version';
+  end if;
+  if v_status <> 'awaiting_contributor_approval' then
+    raise exception 'can only approve a submitted draft (current status: %)', v_status;
+  end if;
+
+  update public.interpretive_school_versions
+    set approved_at = now()
+    where id = v_pending_version_id;
+
+  update public.interpretive_schools
+    set status = 'published',
+        current_version_id = v_pending_version_id,
+        approved_by = v_contributor_id,
+        approved_by_contributor_at = now()
+    where id = p_school_id;
+
+  perform public._clear_notifications_for('interpretive_schools', p_school_id);
+  return v_pending_version_id;
+end;
+$$;
+
+create or replace function public.approve_and_edit_interpretive_school(
+  p_school_id uuid,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+  v_piece_id text;
+  v_status draft_status;
+  v_new_version_id uuid;
+begin
+  perform public._require_active_contributor();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+
+  select piece_id, status
+    into v_piece_id, v_status
+    from public.interpretive_schools
+    where id = p_school_id
+      and contributor_id = v_contributor_id;
+
+  if not found then
+    raise exception 'school not found or not owned by caller';
+  end if;
+  if v_status <> 'awaiting_contributor_approval' then
+    raise exception 'can only approve-and-edit a submitted draft (current status: %)', v_status;
+  end if;
+
+  v_new_version_id := public._insert_interpretive_school_version(
+    p_school_id, v_piece_id, v_contributor_id,
+    p_body, v_contributor_id, true
+  );
+
+  update public.interpretive_schools
+    set status = 'published',
+        current_version_id = v_new_version_id,
+        approved_by = v_contributor_id,
+        approved_by_contributor_at = now()
+    where id = p_school_id;
+
+  perform public._clear_notifications_for('interpretive_schools', p_school_id);
+  return v_new_version_id;
+end;
+$$;
+
+create or replace function public.reject_interpretive_school(
+  p_school_id uuid,
+  p_reason text default null
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+  v_pending_version_id uuid;
+  v_status draft_status;
+begin
+  perform public._require_active_contributor();
+
+  select s.status, v.id
+    into v_status, v_pending_version_id
+    from public.interpretive_schools s
+    join public.interpretive_school_versions v
+      on v.school_id = s.id and v.approved_at is null
+    where s.id = p_school_id
+      and s.contributor_id = v_contributor_id
+    order by v.version_number desc
+    limit 1;
+
+  if not found then
+    raise exception 'school not found, not owned by caller, or has no pending version';
+  end if;
+  if v_status <> 'awaiting_contributor_approval' then
+    raise exception 'can only reject a submitted draft (current status: %)', v_status;
+  end if;
+
+  update public.interpretive_school_versions
+    set rejection_note = p_reason
+    where id = v_pending_version_id;
+
+  update public.interpretive_schools
+    set status = 'draft',
+        rejected_by = v_contributor_id
+    where id = p_school_id;
+
+  perform public._clear_notifications_for('interpretive_schools', p_school_id);
+end;
+$$;
+
+-- ============================================================================
+-- PIECE DESCRIPTION RPCs (11 — no metadata RPC, body-only entity)
+-- ============================================================================
+
+-- ============================================
+-- Contributor self-authored path (descriptions)
+-- ============================================
+
+create or replace function public.publish_contributor_piece_description(
+  p_piece_id text,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_description_id uuid;
+  v_version_id uuid;
+  v_contributor_id uuid := auth.uid();
+begin
+  perform public._require_active_contributor();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found';
+  end if;
+
+  v_description_id := gen_random_uuid();
+
+  insert into public.piece_descriptions (
+    id, piece_id, contributor_id, status, drafted_by
+  )
+  values (v_description_id, p_piece_id, v_contributor_id, 'draft', null);
+
+  v_version_id := public._insert_piece_description_version(
+    v_description_id, p_piece_id, v_contributor_id,
+    p_body, v_contributor_id, true
+  );
+
+  update public.piece_descriptions
+    set status = 'published',
+        current_version_id = v_version_id,
+        approved_by = v_contributor_id,
+        approved_by_contributor_at = now()
+    where id = v_description_id;
+
+  return v_description_id;
+end;
+$$;
+
+create or replace function public.publish_contributor_piece_description_edit(
+  p_description_id uuid,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_version_id uuid;
+  v_contributor_id uuid := auth.uid();
+  v_piece_id text;
+  v_status draft_status;
+begin
+  perform public._require_active_contributor();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+
+  select piece_id, status into v_piece_id, v_status
+    from public.piece_descriptions
+    where id = p_description_id
+      and contributor_id = v_contributor_id;
+
+  if not found then
+    raise exception 'description not found or not owned by caller';
+  end if;
+  if v_status <> 'published' then
+    raise exception 'can only edit a published description (current status: %)', v_status;
+  end if;
+
+  v_version_id := public._insert_piece_description_version(
+    p_description_id, v_piece_id, v_contributor_id,
+    p_body, v_contributor_id, true
+  );
+
+  update public.piece_descriptions
+    set current_version_id = v_version_id,
+        approved_by = v_contributor_id,
+        approved_by_contributor_at = now()
+    where id = p_description_id;
+
+  return v_version_id;
+end;
+$$;
+
+create or replace function public.remove_piece_description(
+  p_description_id uuid
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+  v_status draft_status;
+begin
+  perform public._require_active_contributor();
+
+  select status into v_status
+    from public.piece_descriptions
+    where id = p_description_id
+      and contributor_id = v_contributor_id;
+
+  if not found then
+    raise exception 'description not found or not owned by caller';
+  end if;
+  if v_status <> 'published' then
+    raise exception 'can only remove a published description (current status: %)', v_status;
+  end if;
+
+  update public.piece_descriptions
+    set status = 'removed',
+        removed_by = v_contributor_id,
+        removed_at = now()
+    where id = p_description_id;
+end;
+$$;
+
+-- ============================================
+-- Staff-drafted path (descriptions)
+-- ============================================
+
+create or replace function public.create_piece_description_draft(
+  p_piece_id text,
+  p_contributor_id uuid,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_description_id uuid;
+  v_staff_id uuid := auth.uid();
+begin
+  perform public._require_staff();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found';
+  end if;
+  if not exists (
+    select 1 from public.users
+    where id = p_contributor_id and is_contributor = true and contributor_active = true
+  ) then
+    raise exception 'target user is not an active contributor';
+  end if;
+
+  v_description_id := gen_random_uuid();
+  insert into public.piece_descriptions (
+    id, piece_id, contributor_id, status, drafted_by
+  )
+  values (v_description_id, p_piece_id, p_contributor_id, 'draft', v_staff_id);
+
+  perform public._insert_piece_description_version(
+    v_description_id, p_piece_id, p_contributor_id,
+    p_body, v_staff_id, false
+  );
+
+  return v_description_id;
+end;
+$$;
+
+create or replace function public.update_piece_description_draft(
+  p_description_id uuid,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_version_id uuid;
+  v_staff_id uuid := auth.uid();
+  v_piece_id text;
+  v_contributor_id uuid;
+  v_status draft_status;
+begin
+  perform public._require_staff();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+
+  select piece_id, contributor_id, status
+    into v_piece_id, v_contributor_id, v_status
+    from public.piece_descriptions where id = p_description_id;
+
+  if not found then
+    raise exception 'description not found';
+  end if;
+  if v_status <> 'draft' then
+    raise exception 'can only revise a draft (current status: %)', v_status;
+  end if;
+
+  v_version_id := public._insert_piece_description_version(
+    p_description_id, v_piece_id, v_contributor_id,
+    p_body, v_staff_id, false
+  );
+
+  update public.piece_descriptions
+    set drafted_by = v_staff_id,
+        updated_at = now()
+    where id = p_description_id;
+
+  return v_version_id;
+end;
+$$;
+
+create or replace function public.submit_piece_description(
+  p_description_id uuid
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_staff_id uuid := auth.uid();
+  v_piece_id text;
+  v_piece_title text;
+  v_contributor_id uuid;
+  v_status draft_status;
+begin
+  perform public._require_staff();
+
+  select d.piece_id, d.contributor_id, d.status, p.title
+    into v_piece_id, v_contributor_id, v_status, v_piece_title
+    from public.piece_descriptions d
+    join public.pieces p on p.id = d.piece_id
+    where d.id = p_description_id;
+
+  if not found then
+    raise exception 'description not found';
+  end if;
+  if v_status <> 'draft' then
+    raise exception 'can only submit a draft (current status: %)', v_status;
+  end if;
+
+  update public.piece_descriptions
+    set status = 'awaiting_contributor_approval',
+        submitted_by = v_staff_id
+    where id = p_description_id;
+
+  perform public._insert_notification(
+    v_contributor_id,
+    'piece_descriptions',
+    p_description_id,
+    format('A draft piece description on %s is ready for your review.', v_piece_title),
+    '/notifications'
+  );
+end;
+$$;
+
+create or replace function public.retract_piece_description(
+  p_description_id uuid
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_staff_id uuid := auth.uid();
+  v_status draft_status;
+begin
+  perform public._require_staff();
+
+  select status into v_status from public.piece_descriptions where id = p_description_id;
+  if not found then
+    raise exception 'description not found';
+  end if;
+  if v_status <> 'awaiting_contributor_approval' then
+    raise exception 'can only retract a submitted draft (current status: %)', v_status;
+  end if;
+
+  update public.piece_descriptions
+    set status = 'draft',
+        retracted_by = v_staff_id,
+        retracted_at = now()
+    where id = p_description_id;
+
+  perform public._clear_notifications_for('piece_descriptions', p_description_id);
+end;
+$$;
+
+-- ============================================
+-- Contributor actions on staff-drafted descriptions
+-- ============================================
+
+create or replace function public.approve_piece_description(
+  p_description_id uuid
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+  v_pending_version_id uuid;
+  v_status draft_status;
+begin
+  perform public._require_active_contributor();
+
+  select d.status, v.id
+    into v_status, v_pending_version_id
+    from public.piece_descriptions d
+    join public.piece_description_versions v
+      on v.description_id = d.id and v.approved_at is null
+    where d.id = p_description_id
+      and d.contributor_id = v_contributor_id
+    order by v.version_number desc
+    limit 1;
+
+  if not found then
+    raise exception 'description not found, not owned by caller, or has no pending version';
+  end if;
+  if v_status <> 'awaiting_contributor_approval' then
+    raise exception 'can only approve a submitted draft (current status: %)', v_status;
+  end if;
+
+  update public.piece_description_versions
+    set approved_at = now()
+    where id = v_pending_version_id;
+
+  update public.piece_descriptions
+    set status = 'published',
+        current_version_id = v_pending_version_id,
+        approved_by = v_contributor_id,
+        approved_by_contributor_at = now()
+    where id = p_description_id;
+
+  perform public._clear_notifications_for('piece_descriptions', p_description_id);
+  return v_pending_version_id;
+end;
+$$;
+
+create or replace function public.approve_and_edit_piece_description(
+  p_description_id uuid,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+  v_piece_id text;
+  v_status draft_status;
+  v_new_version_id uuid;
+begin
+  perform public._require_active_contributor();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+
+  select piece_id, status
+    into v_piece_id, v_status
+    from public.piece_descriptions
+    where id = p_description_id
+      and contributor_id = v_contributor_id;
+
+  if not found then
+    raise exception 'description not found or not owned by caller';
+  end if;
+  if v_status <> 'awaiting_contributor_approval' then
+    raise exception 'can only approve-and-edit a submitted draft (current status: %)', v_status;
+  end if;
+
+  v_new_version_id := public._insert_piece_description_version(
+    p_description_id, v_piece_id, v_contributor_id,
+    p_body, v_contributor_id, true
+  );
+
+  update public.piece_descriptions
+    set status = 'published',
+        current_version_id = v_new_version_id,
+        approved_by = v_contributor_id,
+        approved_by_contributor_at = now()
+    where id = p_description_id;
+
+  perform public._clear_notifications_for('piece_descriptions', p_description_id);
+  return v_new_version_id;
+end;
+$$;
+
+create or replace function public.reject_piece_description(
+  p_description_id uuid,
+  p_reason text default null
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_contributor_id uuid := auth.uid();
+  v_pending_version_id uuid;
+  v_status draft_status;
+begin
+  perform public._require_active_contributor();
+
+  select d.status, v.id
+    into v_status, v_pending_version_id
+    from public.piece_descriptions d
+    join public.piece_description_versions v
+      on v.description_id = d.id and v.approved_at is null
+    where d.id = p_description_id
+      and d.contributor_id = v_contributor_id
+    order by v.version_number desc
+    limit 1;
+
+  if not found then
+    raise exception 'description not found, not owned by caller, or has no pending version';
+  end if;
+  if v_status <> 'awaiting_contributor_approval' then
+    raise exception 'can only reject a submitted draft (current status: %)', v_status;
+  end if;
+
+  update public.piece_description_versions
+    set rejection_note = p_reason
+    where id = v_pending_version_id;
+
+  update public.piece_descriptions
+    set status = 'draft',
+        rejected_by = v_contributor_id
+    where id = p_description_id;
+
+  perform public._clear_notifications_for('piece_descriptions', p_description_id);
+end;
+$$;
+
+-- ============================================
+-- Execute grants (authenticated; functions gate via auth.uid())
+-- ============================================
+
+-- Schools
+grant execute on function public.publish_contributor_interpretive_school(text, text, text, jsonb)        to authenticated;
+grant execute on function public.publish_contributor_interpretive_school_edit(uuid, text)               to authenticated;
+grant execute on function public.update_interpretive_school_metadata(uuid, text, jsonb)                 to authenticated;
+grant execute on function public.remove_interpretive_school(uuid)                                       to authenticated;
+grant execute on function public.create_interpretive_school_draft(text, uuid, text, text, jsonb)        to authenticated;
+grant execute on function public.update_interpretive_school_draft(uuid, text, text, jsonb)              to authenticated;
+grant execute on function public.submit_interpretive_school(uuid)                                       to authenticated;
+grant execute on function public.retract_interpretive_school(uuid)                                      to authenticated;
+grant execute on function public.approve_interpretive_school(uuid)                                      to authenticated;
+grant execute on function public.approve_and_edit_interpretive_school(uuid, text)                       to authenticated;
+grant execute on function public.reject_interpretive_school(uuid, text)                                 to authenticated;
+
+-- Descriptions
+grant execute on function public.publish_contributor_piece_description(text, text)                      to authenticated;
+grant execute on function public.publish_contributor_piece_description_edit(uuid, text)                 to authenticated;
+grant execute on function public.remove_piece_description(uuid)                                         to authenticated;
+grant execute on function public.create_piece_description_draft(text, uuid, text)                       to authenticated;
+grant execute on function public.update_piece_description_draft(uuid, text)                             to authenticated;
+grant execute on function public.submit_piece_description(uuid)                                         to authenticated;
+grant execute on function public.retract_piece_description(uuid)                                        to authenticated;
+grant execute on function public.approve_piece_description(uuid)                                        to authenticated;
+grant execute on function public.approve_and_edit_piece_description(uuid, text)                         to authenticated;
+grant execute on function public.reject_piece_description(uuid, text)                                   to authenticated;
+
+-- Internal helpers — revoked from public.
+revoke execute on function public._insert_notification(uuid, text, uuid, text, text) from public;
+revoke execute on function public._clear_notifications_for(text, uuid) from public;
+revoke execute on function public._insert_interpretive_school_version(uuid, text, uuid, text, uuid, boolean, text) from public;
+revoke execute on function public._insert_piece_description_version(uuid, text, uuid, text, uuid, boolean, text) from public;


### PR DESCRIPTION
## Summary

Second of six rollout steps for [Slice B](./PLAN-contributor-pipeline-slice-b.md). Lands the full RPC surface for the two new signed content types. No UI yet — verifiable via curl and integration tests.

## RPCs added

**Shared helpers (reusable across all subject types):**
- `_insert_notification(recipient, subject_table, subject_id, body, link_path)` — idempotent via `ON CONFLICT DO NOTHING` on `uq_notifications_live_per_subject` (**CM3**). Returns the notification id (existing if live, new otherwise). Dual-writes `performers_note_id` for the **CM1** vestigial window.
- `_clear_notifications_for(subject_table, subject_id)` — generic polymorphic clear; matches both polymorphic and narrow-FK rows to cover the dual-write window seamlessly.
- `_insert_interpretive_school_version`, `_insert_piece_description_version` — per-subject version inserters, retry-once on `unique_violation`, mirrors Slice A's pattern.

**InterpretiveSchool (12 RPCs):** publish_contributor / publish_contributor_edit / **update_metadata (CM4 owner-only, 4A audit)** / remove / create_draft / update_draft / submit / retract / approve / approve_and_edit / reject. Submit body: `"A draft interpretive school ('<name>') on <piece> is ready for your review."`

**PieceDescription (11 RPCs):** same shape minus the metadata RPC (body-only entity). Submit body: `"A draft piece description on <piece> is ready for your review."`

## Key decisions preserved from eng-review + Codex

- **4A** — `metadata_updated_by/at` set on every metadata RPC call for audit trail
- **CM4** — `update_interpretive_school_metadata` is owner-only; staff cannot rename a published school. Preserves PRD invariant: nothing changes under a byline without the contributor's hands on the keyboard.
- **CM3** — `_insert_notification` uses `ON CONFLICT DO NOTHING` on the partial unique index. Double-submit + retries produce exactly one live notification.
- **CM1** — dual-write continues: `_insert_notification` populates both narrow `performers_note_id` and polymorphic `(subject_table, subject_id)` when the subject is a performers_note.

## Tests

**35 new integration tests** (`interpretiveSchools.test.ts` 20 + `pieceDescriptions.test.ts` 15). Total **75 integration + 118 unit = 193 tests pass, 0 fail.**

Coverage:
- Self-authored atomicity (create + publish, edit bumps version)
- Iron-rule regression: 0 notifications on self-author/edit paths for BOTH new types
- Metadata RPC: owner updates name + tempo_cues, audit columns set, version NOT bumped, non-owner blocked, staff blocked (**CM4**), at-least-one-field required
- Staff-drafted round trip with notification lifecycle
- **CM3** idempotency: double-submit → 1 live notification
- `approve_and_edit`: atomic version insert + publish
- Reject + revise loop with `rejection_note` persistence
- Staff retract clears notification
- Plurality: same contributor multiple schools per piece; two contributors with identical school names allowed
- Forbidden transitions

## Follow-ups (later PRs)

- **Step 3:** refactor `NotificationsQueue` + digest to read `subject_table`
- **Step 4:** schools UI (admin + queue card + piece page)
- **Step 5:** description UI + unsigned-metadata-strip treatment (**7A**)
- **Step 6:** seed fixtures
- **Post-Slice-B cleanup:** drop `performers_note_id` + remove dual-write

## Test plan

- [x] `bun run test:integration` — 75 pass, 0 fail
- [x] `bun run test` — 118 pass, 0 fail
- [x] Migration applies cleanly via `supabase migration up`
- [x] Slice A end-to-end unchanged (regression suite intact)
- [ ] `supabase db push` against prod before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)