### PR TITLE
feat(slice-b): steps 4-6 — schools + descriptions UI, piece-page wiring, fixtures (closes Slice B)

### DIFF
--- a/scripts/seed-local-queue.ts
+++ b/scripts/seed-local-queue.ts
@@ -1,13 +1,20 @@
 #!/usr/bin/env bun
 // Seeds the local Supabase stack with fixtures so the /notifications queue
-// has something to show when you visit the dev server.
+// AND the piece-page signed surfaces have something to show when you visit
+// the dev server.
 //
 // Creates:
 //   - a contributor (haji@local.test / password: hajilocal)
 //   - a staff user   (staff@local.test / password: stafflocal)
-//   - one submitted pending draft on an existing piece
+//   - one submitted pending performer's note (Slice A)
+//   - one submitted pending interpretive school (Slice B)
+//   - one submitted pending piece description (Slice B)
+//   - one published interpretive school on a SECOND piece (Slice B, renders
+//     in the schools grid on that piece page for visual QA without needing
+//     to click approve)
+//   - one published piece description on the same second piece (Slice B)
 //
-// Idempotent — re-running refreshes the draft. Safe to run anytime.
+// Idempotent — re-running refreshes the drafts + republishes the visuals.
 //
 // Usage:
 //   bun --env-file=.env.development.local run scripts/seed-local-queue.ts
@@ -43,15 +50,18 @@ const hajiId = await ensureUser('haji@local.test', 'hajilocal', {
   contributor_agreement_signed_at: new Date().toISOString(),
   contributor_bio_short: 'cellist, NYC',
 });
-const staffId = await ensureUser('staff@local.test', 'stafflocal', {
+await ensureUser('staff@local.test', 'stafflocal', {
   display_name: 'Staff Local',
   role: 'admin',
 });
 
-// Pick an existing piece. Falls back to creating one if the catalog is empty.
-const { data: pieces } = await admin.from('pieces').select('id, title').limit(1);
-let pieceId = pieces?.[0]?.id;
-if (!pieceId) {
+// Pick two existing pieces if available so we can stage pending drafts on
+// one and published signed content on the other. Fall back to a single
+// Bach fixture if the catalog is empty.
+const { data: pieces } = await admin.from('pieces').select('id, title').limit(2);
+const pendingPieceId = pieces?.[0]?.id ?? 'bach-cello-suite-1';
+const publishedPieceId = pieces?.[1]?.id ?? pendingPieceId;
+if (!pieces || pieces.length === 0) {
   const fixtureId = 'bach-cello-suite-1';
   await admin.from('pieces').upsert({
     id: fixtureId,
@@ -64,40 +74,134 @@ if (!pieceId) {
     difficulty: 'advanced',
     description: 'The most-played of the Six, and the one every cellist must eventually confront on their own terms.',
   });
-  pieceId = fixtureId;
 }
 
-// Reset any previous local test draft for this piece + contributor.
-await admin
-  .from('performers_notes')
-  .update({ current_version_id: null, status: 'removed' })
-  .eq('piece_id', pieceId)
-  .eq('contributor_id', hajiId);
+// Reset any previous local test drafts for both pieces + contributor.
+for (const pid of [pendingPieceId, publishedPieceId]) {
+  await admin
+    .from('performers_notes')
+    .update({ current_version_id: null, status: 'removed' })
+    .eq('piece_id', pid)
+    .eq('contributor_id', hajiId);
+  await admin
+    .from('interpretive_schools')
+    .update({ current_version_id: null, status: 'removed' })
+    .eq('piece_id', pid)
+    .eq('contributor_id', hajiId);
+  await admin
+    .from('piece_descriptions')
+    .update({ current_version_id: null, status: 'removed' })
+    .eq('piece_id', pid)
+    .eq('contributor_id', hajiId);
+}
+await admin.from('notifications').delete().eq('recipient_id', hajiId);
 
-// Sign in as staff to call the RPC with a real JWT.
+// Sign in as staff + haji respectively so auth.uid() populates correctly.
 const anonKey = process.env.PUBLIC_SUPABASE_ANON_KEY!;
 const staffClient = createClient(url, anonKey, { auth: { autoRefreshToken: false, persistSession: false } });
-const { error: signInErr } = await staffClient.auth.signInWithPassword({ email: 'staff@local.test', password: 'stafflocal' });
-if (signInErr) throw new Error(`sign-in staff: ${signInErr.message}`);
+const hajiClient = createClient(url, anonKey, { auth: { autoRefreshToken: false, persistSession: false } });
 
-const { data: noteId, error: createErr } = await staffClient.rpc('create_performers_note_draft', {
-  p_piece_id: pieceId,
+{
+  const { error } = await staffClient.auth.signInWithPassword({ email: 'staff@local.test', password: 'stafflocal' });
+  if (error) throw new Error(`sign-in staff: ${error.message}`);
+}
+{
+  const { error } = await hajiClient.auth.signInWithPassword({ email: 'haji@local.test', password: 'hajilocal' });
+  if (error) throw new Error(`sign-in haji: ${error.message}`);
+}
+
+// --- Pending drafts on pendingPieceId (bell/queue fixtures) ---
+
+const { data: noteId, error: noteErr } = await staffClient.rpc('create_performers_note_draft', {
+  p_piece_id: pendingPieceId,
   p_contributor_id: hajiId,
   p_body:
     "Staff-authored draft: the opening arpeggios call for bow speed more than articulation — try broadening the second bar under a single down-bow to hear the architecture Bach wrote, then restore the printed bowing if it serves the room.",
 });
-if (createErr) throw new Error(`create draft: ${createErr.message}`);
+if (noteErr) throw new Error(`create performer's note draft: ${noteErr.message}`);
+{
+  const { error } = await staffClient.rpc('submit_performers_note', { p_note_id: noteId });
+  if (error) throw new Error(`submit performer's note: ${error.message}`);
+}
 
-const { error: submitErr } = await staffClient.rpc('submit_performers_note', { p_note_id: noteId });
-if (submitErr) throw new Error(`submit draft: ${submitErr.message}`);
+const { data: schoolDraftId, error: schoolErr } = await staffClient.rpc('create_interpretive_school_draft', {
+  p_piece_id: pendingPieceId,
+  p_contributor_id: hajiId,
+  p_name: 'Historically informed',
+  p_body:
+    "Staff-drafted school: the HIP reading treats the prelude's sixteenths as inégales rather than metrically even — every second note slightly weighted, the phrase shaped around the long arc of the dominant pedal.",
+  p_tempo_cues: { opening: 'quarter=72' },
+});
+if (schoolErr) throw new Error(`create school draft: ${schoolErr.message}`);
+{
+  const { error } = await staffClient.rpc('submit_interpretive_school', { p_school_id: schoolDraftId });
+  if (error) throw new Error(`submit school: ${error.message}`);
+}
 
-console.log('Local queue seeded.');
-console.log(`  piece:       ${pieceId}`);
-console.log(`  note:        ${noteId}`);
+const { data: descDraftId, error: descErr } = await staffClient.rpc('create_piece_description_draft', {
+  p_piece_id: pendingPieceId,
+  p_contributor_id: hajiId,
+  p_body:
+    'Staff-drafted description: the G major Suite is the entry point to the cycle and the thing every cellist eventually confronts on their own terms — not because it is the easiest of the six, but because its rhetoric is the least forgiving. Every shape has to be found, not imposed.',
+});
+if (descErr) throw new Error(`create description draft: ${descErr.message}`);
+{
+  const { error } = await staffClient.rpc('submit_piece_description', { p_description_id: descDraftId });
+  if (error) throw new Error(`submit description: ${error.message}`);
+}
+
+// --- Published signed content on publishedPieceId (piece-page fixtures) ---
+
+let publishedSchoolIds: string[] = [];
+let publishedDescriptionId: string | null = null;
+
+if (publishedPieceId !== pendingPieceId) {
+  const { data: s1, error: s1Err } = await hajiClient.rpc('publish_contributor_interpretive_school', {
+    p_piece_id: publishedPieceId,
+    p_name: 'Historically informed',
+    p_body:
+      'The HIP reading leans into gut-string response — shorter decay, lighter bow weight, clear articulation of the hemiola at the turn. The goal is not austerity but transparency: the counterpoint has to stand on its own.',
+    p_tempo_cues: { opening: 'quarter=80' },
+  });
+  if (s1Err) throw new Error(`publish school 1: ${s1Err.message}`);
+  publishedSchoolIds.push(s1 as string);
+
+  const { data: s2, error: s2Err } = await hajiClient.rpc('publish_contributor_interpretive_school', {
+    p_piece_id: publishedPieceId,
+    p_name: 'Chamber-symphonic',
+    p_body:
+      'Played on a modern set-up with a symphonic bow, the same measures ask for weight, sustain, and a long horizontal line. The work still reads as Bach, but the architecture is closer to late Beethoven than to a gamba sonata.',
+  });
+  if (s2Err) throw new Error(`publish school 2: ${s2Err.message}`);
+  publishedSchoolIds.push(s2 as string);
+
+  const { data: d1, error: d1Err } = await hajiClient.rpc('publish_contributor_piece_description', {
+    p_piece_id: publishedPieceId,
+    p_body:
+      'This suite is the first page of the working cellist\'s internal library. It rewards attention to key architecture more than to virtuoso display — the D minor Sarabande is where a player finds out whether they can keep a long silence inside a line.',
+  });
+  if (d1Err) throw new Error(`publish description 1: ${d1Err.message}`);
+  publishedDescriptionId = d1 as string;
+}
+
+console.log('Local queue + piece-page fixtures seeded.');
+console.log(`  pending piece:      ${pendingPieceId}`);
+console.log(`    performer's note: ${noteId}   (awaiting approval)`);
+console.log(`    school draft:     ${schoolDraftId}   (awaiting approval)`);
+console.log(`    desc draft:       ${descDraftId}   (awaiting approval)`);
+if (publishedPieceId !== pendingPieceId) {
+  console.log(`  published piece:    ${publishedPieceId}`);
+  console.log(`    schools:          ${publishedSchoolIds.join(', ')}`);
+  console.log(`    description:      ${publishedDescriptionId}`);
+} else {
+  console.log('  (only one piece in catalog — skipped published fixtures)');
+}
 console.log('  contributor: haji@local.test / hajilocal');
 console.log('  staff:       staff@local.test / stafflocal');
 console.log('\nNext:');
-console.log('  1. bun run dev');
-console.log('  2. Visit http://localhost:4321');
-console.log('  3. Sign in as haji@local.test / hajilocal');
-console.log('  4. Visit http://localhost:4321/notifications');
+console.log('  1. bun run dev:local');
+console.log('  2. Sign in as haji@local.test / hajilocal (use scripts/magic-link.ts if needed)');
+console.log(`  3. Bell should show 3; queue at /notifications has three distinct kickers`);
+if (publishedPieceId !== pendingPieceId) {
+  console.log(`  4. Visit /piece/${publishedPieceId} — schools grid (2-col) + signed essay render live`);
+}

--- a/src/components/InterpretiveSchools.tsx
+++ b/src/components/InterpretiveSchools.tsx
@@ -1,0 +1,458 @@
+// Published interpretive schools on a piece page, plus contributor
+// affordances (write a school, edit own, remove own). Mirrors
+// src/components/PerformersNotes.tsx, adapted for the multi-column grid
+// treatment PRD describes for schools: "a multi-column grid of signed
+// positions on wide viewports, collapsing to stacked cards on narrow ones."
+//
+// CM5: self-author entry is ALWAYS visible for eligible contributors
+// (schools are plural by design; one contributor may hold multiple).
+// Label adapts: "Write a school" when none exist, "Add another school"
+// when at least one published school already exists on the piece.
+//
+// Reads SSR'd by PiecePageLayout; this island hydrates with the same data.
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+import type { PublishedInterpretiveSchool } from '../lib/interpretiveSchools';
+
+interface Props {
+  pieceId: string;
+  initialSchools: PublishedInterpretiveSchool[];
+}
+
+interface Viewer {
+  userId: string | null;
+  isContributor: boolean;
+  displayName: string | null;
+  bioShort: string | null;
+}
+
+type Mode = null | 'write' | { action: 'edit'; schoolId: string };
+
+export default function InterpretiveSchools({ pieceId, initialSchools }: Props) {
+  const [schools, setSchools] = useState<PublishedInterpretiveSchool[]>(initialSchools);
+  const [viewer, setViewer] = useState<Viewer | null>(null);
+  const [mode, setMode] = useState<Mode>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadViewer = useCallback(async () => {
+    if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
+
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.user) {
+      setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null });
+      return;
+    }
+
+    const { data } = await supabase
+      .from('users')
+      .select('display_name, is_contributor, contributor_active, contributor_bio_short')
+      .eq('id', session.user.id)
+      .single();
+
+    setViewer({
+      userId: session.user.id,
+      isContributor: Boolean(data?.is_contributor && data?.contributor_active),
+      displayName: data?.display_name ?? null,
+      bioShort: data?.contributor_bio_short ?? null,
+    });
+  }, []);
+
+  useEffect(() => { void loadViewer(); }, [loadViewer]);
+
+  async function refetchSchools() {
+    const { data } = await supabase
+      .from('interpretive_schools')
+      .select('id, contributor_id, current_version_id, name, tempo_cues, approved_by_contributor_at')
+      .eq('piece_id', pieceId)
+      .eq('status', 'published')
+      .order('approved_by_contributor_at', { ascending: true });
+    if (!data || data.length === 0) { setSchools([]); return; }
+
+    const versionIds = data.map((s) => s.current_version_id).filter((x): x is string => Boolean(x));
+    const contribIds = [...new Set(data.map((s) => s.contributor_id))];
+
+    const [versionsRes, contribsRes] = await Promise.all([
+      supabase.from('v_interpretive_school_versions_published').select('id, body, version_number, approved_at').in('id', versionIds),
+      supabase.from('users').select('id, display_name, contributor_bio_short').in('id', contribIds),
+    ]);
+    const vById = new Map((versionsRes.data ?? []).map((v) => [v.id, v]));
+    const cById = new Map((contribsRes.data ?? []).map((c) => [c.id, c]));
+
+    const rows: PublishedInterpretiveSchool[] = [];
+    for (const s of data) {
+      if (!s.current_version_id) continue;
+      const v = vById.get(s.current_version_id);
+      const c = cById.get(s.contributor_id);
+      if (!v || !c) continue;
+      rows.push({
+        schoolId: s.id,
+        versionId: v.id,
+        name: s.name,
+        body: v.body,
+        tempoCues: (s.tempo_cues as Record<string, unknown> | null) ?? null,
+        versionNumber: v.version_number,
+        approvedAt: v.approved_at,
+        contributor: { id: c.id, displayName: c.display_name, bioShort: c.contributor_bio_short ?? null },
+      });
+    }
+    setSchools(rows);
+  }
+
+  async function handleWrite(name: string, body: string) {
+    if (name.trim().length === 0) { setError('Name required.'); return; }
+    if (body.trim().length === 0) { setError('Body required.'); return; }
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('publish_contributor_interpretive_school', {
+      p_piece_id: pieceId,
+      p_name: name.trim(),
+      p_body: body,
+    });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    setMode(null);
+    await refetchSchools();
+  }
+
+  async function handleEdit(schoolId: string, body: string) {
+    if (body.trim().length === 0) { setError('Body required.'); return; }
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('publish_contributor_interpretive_school_edit', {
+      p_school_id: schoolId,
+      p_body: body,
+    });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    setMode(null);
+    await refetchSchools();
+  }
+
+  async function handleRemove(schoolId: string) {
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('remove_interpretive_school', { p_school_id: schoolId });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    await refetchSchools();
+    if (typeof window !== 'undefined') window.dispatchEvent(new Event('notifications:changed'));
+  }
+
+  // CM5: always visible for eligible contributors. Label adapts.
+  const canWrite = Boolean(viewer?.isContributor);
+  const writeLabel = schools.length === 0 ? 'Write a school' : 'Add another school';
+
+  return (
+    <div>
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border-[0.5px] px-3 py-2 text-sm"
+          style={{ background: 'var(--color-error-bg)', color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {schools.length === 0 ? (
+        <p className="empty-state">No interpretive schools recorded yet.</p>
+      ) : (
+        <div className={`schools-grid schools-grid-${Math.min(schools.length, 3)}`}>
+          {schools.map((s) => {
+            const isOwner = viewer?.userId === s.contributor.id;
+            const isEditing = typeof mode === 'object' && mode?.action === 'edit' && mode.schoolId === s.schoolId;
+            return (
+              <div key={s.schoolId} className="school-card">
+                {!isEditing && (
+                  <>
+                    <div className="school-name">{s.name}</div>
+                    {s.tempoCues && Object.keys(s.tempoCues).length > 0 && (
+                      <div className="tempo-cues">
+                        {Object.entries(s.tempoCues).map(([k, v]) => (
+                          <span key={k}>
+                            {k}: {typeof v === 'string' ? v : JSON.stringify(v)}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    <div className="prose">
+                      {s.body.split(/\n\s*\n/).map((para, i) => <p key={i}>{para}</p>)}
+                    </div>
+                    <div className="by">
+                      <span className="name">{s.contributor.displayName}</span>
+                      {s.contributor.bioShort && (
+                        <>
+                          <span className="dot" aria-hidden="true"></span>
+                          <span>{s.contributor.bioShort}</span>
+                        </>
+                      )}
+                    </div>
+                    {isOwner && (
+                      <div className="owner-actions">
+                        <button
+                          type="button"
+                          onClick={() => { setMode({ action: 'edit', schoolId: s.schoolId }); setError(null); }}
+                          className="owner-btn"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRemove(s.schoolId)}
+                          disabled={busy}
+                          className="owner-btn"
+                        >
+                          {busy ? 'Removing…' : 'Remove'}
+                        </button>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {isEditing && viewer && (
+                  <EditForm
+                    initialName={s.name}
+                    initialBody={s.body}
+                    showNameField={false}
+                    contributor={{ name: viewer.displayName ?? s.contributor.displayName, bio: viewer.bioShort }}
+                    submitting={busy}
+                    onCancel={() => { setMode(null); setError(null); }}
+                    onSubmit={(_name, body) => handleEdit(s.schoolId, body)}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {mode !== 'write' && canWrite && (
+        <button
+          type="button"
+          onClick={() => { setMode('write'); setError(null); }}
+          className="write-entry"
+        >
+          {writeLabel} &rarr;
+        </button>
+      )}
+      {mode === 'write' && viewer && (
+        <div className="mt-6 school-card">
+          <EditForm
+            initialName=""
+            initialBody=""
+            showNameField={true}
+            placeholder="What does this framing ask of a performer?"
+            contributor={{ name: viewer.displayName ?? 'You', bio: viewer.bioShort }}
+            submitting={busy}
+            onCancel={() => { setMode(null); setError(null); }}
+            onSubmit={handleWrite}
+            submitLabel="Publish"
+            submittingLabel="Publishing…"
+          />
+        </div>
+      )}
+
+      <style>{`
+        .schools-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+        @media (min-width: 768px) {
+          .schools-grid { grid-template-columns: repeat(2, 1fr); }
+        }
+        @media (min-width: 1024px) {
+          .schools-grid-3 { grid-template-columns: repeat(3, 1fr); }
+        }
+        .school-card {
+          border: 0.5px solid var(--border);
+          border-radius: 12px;
+          padding: 20px 22px;
+          background: var(--surface);
+          display: flex;
+          flex-direction: column;
+        }
+        .school-name {
+          font-family: var(--font-sans);
+          font-size: 11px;
+          font-weight: 500;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: var(--ink);
+          margin-bottom: 10px;
+        }
+        .tempo-cues {
+          font-family: var(--font-mono);
+          font-size: 11px;
+          color: var(--muted);
+          margin-bottom: 12px;
+          display: flex;
+          gap: 16px;
+          flex-wrap: wrap;
+        }
+        .school-card .prose {
+          font-family: var(--font-serif);
+          font-size: 16px;
+          line-height: 1.68;
+          color: var(--ink);
+          margin: 0 0 14px;
+        }
+        .school-card .prose p { margin: 0 0 10px; }
+        .school-card .prose p:last-child { margin-bottom: 0; }
+        .school-card .by {
+          font-family: var(--font-sans);
+          font-size: 13px;
+          color: var(--ink);
+        }
+        .school-card .by .name { font-weight: 500; }
+        .school-card .by .dot {
+          display: inline-block;
+          width: 3px; height: 3px;
+          border-radius: 50%;
+          background: var(--muted);
+          margin: 0 8px;
+          vertical-align: middle;
+        }
+        .school-card .by span:not(.name):not(.dot) {
+          color: var(--muted);
+        }
+        .owner-actions { display: flex; gap: 8px; margin-top: 12px; }
+        .owner-btn {
+          background: transparent;
+          border: 0.5px solid var(--border-strong);
+          color: var(--muted);
+          font-family: var(--font-sans);
+          font-size: 11px;
+          padding: 4px 10px;
+          border-radius: 6px;
+          cursor: pointer;
+          transition: color 0.12s, border-color 0.12s;
+        }
+        .owner-btn:hover { color: var(--ink); border-color: var(--ink); }
+        .owner-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .write-entry {
+          margin-top: 24px;
+          background: transparent;
+          border: 0;
+          color: var(--accent);
+          font-family: var(--font-sans);
+          font-size: 13px;
+          padding: 0;
+          cursor: pointer;
+        }
+        .write-entry:hover { color: var(--ink); }
+      `}</style>
+    </div>
+  );
+}
+
+function EditForm(props: {
+  initialName: string;
+  initialBody: string;
+  showNameField: boolean;
+  placeholder?: string;
+  contributor: { name: string; bio: string | null };
+  submitting: boolean;
+  onCancel: () => void;
+  onSubmit: (name: string, body: string) => void;
+  submitLabel?: string;
+  submittingLabel?: string;
+}) {
+  const [nameValue, setNameValue] = useState(props.initialName);
+  const [bodyValue, setBodyValue] = useState(props.initialBody);
+  const submitLabel = props.submitLabel ?? 'Save';
+  const submittingLabel = props.submittingLabel ?? 'Saving…';
+  const disabled = props.submitting || bodyValue.trim() === '' || (props.showNameField && nameValue.trim() === '');
+
+  return (
+    <div>
+      {props.showNameField && (
+        <input
+          type="text"
+          value={nameValue}
+          onChange={(e) => setNameValue(e.target.value)}
+          placeholder="School name (e.g. Historically informed)"
+          style={{
+            width: '100%',
+            fontFamily: 'var(--font-sans)',
+            fontSize: '13px',
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            color: 'var(--ink)',
+            background: 'transparent',
+            border: '0.5px solid var(--border-strong)',
+            borderRadius: '8px',
+            padding: '8px 12px',
+            marginBottom: '10px',
+          }}
+        />
+      )}
+      <textarea
+        value={bodyValue}
+        onChange={(e) => setBodyValue(e.target.value)}
+        rows={6}
+        placeholder={props.placeholder}
+        style={{
+          width: '100%',
+          fontFamily: 'var(--font-serif)',
+          fontSize: '16px',
+          lineHeight: 1.65,
+          color: 'var(--ink)',
+          background: 'transparent',
+          border: '0.5px solid var(--border-strong)',
+          borderRadius: '8px',
+          padding: '10px 12px',
+          resize: 'vertical',
+        }}
+      />
+      <div style={{ marginTop: '12px', fontFamily: 'var(--font-sans)', fontSize: '13px' }}>
+        <span style={{ fontWeight: 500 }}>{props.contributor.name}</span>
+        {props.contributor.bio && (
+          <>
+            <span style={{ margin: '0 8px', color: 'var(--muted)' }}>·</span>
+            <span style={{ color: 'var(--muted)' }}>{props.contributor.bio}</span>
+          </>
+        )}
+      </div>
+      <div style={{ marginTop: '12px', display: 'flex', gap: '8px' }}>
+        <button
+          type="button"
+          onClick={() => props.onSubmit(nameValue, bodyValue)}
+          disabled={disabled}
+          style={{
+            background: 'var(--ink)',
+            color: '#FFFFFF',
+            border: 0,
+            fontFamily: 'var(--font-sans)',
+            fontSize: '13px',
+            fontWeight: 500,
+            padding: '8px 16px',
+            borderRadius: '8px',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+            opacity: disabled ? 0.5 : 1,
+          }}
+        >
+          {props.submitting ? submittingLabel : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={props.onCancel}
+          disabled={props.submitting}
+          style={{
+            background: 'transparent',
+            color: 'var(--ink)',
+            border: '0.5px solid var(--border-strong)',
+            fontFamily: 'var(--font-sans)',
+            fontSize: '13px',
+            fontWeight: 500,
+            padding: '8px 16px',
+            borderRadius: '8px',
+            cursor: props.submitting ? 'not-allowed' : 'pointer',
+            opacity: props.submitting ? 0.5 : 1,
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PiecePageLayout.astro
+++ b/src/components/PiecePageLayout.astro
@@ -21,14 +21,23 @@ import '../styles/piece-page.css';
 import type { PieceFull } from '../lib/pieces';
 import { difficultyAxes, type DifficultyAxis } from '../data/difficulty-axes';
 import { getPublishedPerformersNotes } from '../lib/performersNotes';
+import { getPublishedInterpretiveSchools } from '../lib/interpretiveSchools';
+import { getPublishedPieceDescriptions } from '../lib/pieceDescriptions';
 import PerformersNotes from './PerformersNotes';
+import InterpretiveSchools from './InterpretiveSchools';
+import SignedPieceDescription from './SignedPieceDescription';
 
 interface Props {
   piece: PieceFull;
 }
 
 const { piece } = Astro.props;
-const performersNotes = await getPublishedPerformersNotes(piece.id);
+const [performersNotes, interpretiveSchools, signedDescriptions] = await Promise.all([
+  getPublishedPerformersNotes(piece.id),
+  getPublishedInterpretiveSchools(piece.id),
+  getPublishedPieceDescriptions(piece.id),
+]);
+const hasSignedDescription = signedDescriptions.length > 0;
 const axes = difficultyAxes[piece.id];
 const axisOrder: Array<{ key: keyof typeof axes; label: string }> = [
   { key: 'technical', label: 'Technical' },
@@ -72,9 +81,17 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <span class="pill">{piece.difficulty}</span>
   </div>
 
+  {/* 7A: unsigned pieces.description renders as italic metadata strip when
+      a signed description coexists; as a fuller intro paragraph when alone. */}
   {piece.description && (
-    <p class="piece-intro">{piece.description}</p>
+    <p class={hasSignedDescription ? 'piece-meta-strip' : 'piece-intro'}>{piece.description}</p>
   )}
+
+  {/* 7A: signed description renders as the editorial essay below the header. */}
+  <section class="block" id="signed-description">
+    <SignedPieceDescription client:load pieceId={piece.id} initialDescriptions={signedDescriptions} />
+  </section>
+
 
   {axes && (
     <div class="diff-panel">
@@ -125,10 +142,10 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     )}
   </section>
 
-  {/* ---------- Interpretive schools (empty state) ---------- */}
-  <section class="block">
+  {/* ---------- Interpretive schools ---------- */}
+  <section class="block" id="interpretive-schools">
     <div class="kicker">Interpretive schools</div>
-    <p class="empty-state">No interpretive schools recorded yet.</p>
+    <InterpretiveSchools client:load pieceId={piece.id} initialSchools={interpretiveSchools} />
   </section>
 
   {/* ---------- Editions ---------- */}
@@ -221,9 +238,8 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     margin: 0;
   }
 
-  /* Piece intro — prose description sitting directly under the metadata pills
-     as part of the piece definition. Transitional content until richer editorial
-     surfaces (performer's notes, schools) replace it. */
+  /* Piece intro — unsigned pieces.description as the primary paragraph when
+     no signed editorial description exists on the piece yet. */
   .piece-intro {
     font-family: var(--font-serif);
     font-size: 16px;
@@ -231,6 +247,19 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     color: var(--ink);
     max-width: 640px;
     margin: 0 0 48px;
+  }
+
+  /* 7A: metadata-strip treatment. When a signed piece description exists,
+     the unsigned reference blurb demotes to this smaller italic strip so
+     the signed essay carries the editorial weight. */
+  .piece-meta-strip {
+    font-family: var(--font-sans);
+    font-style: italic;
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--muted);
+    max-width: 640px;
+    margin: 0 0 32px;
   }
 
   /* External reference list (IMSLP, Wikipedia) */

--- a/src/components/SignedPieceDescription.tsx
+++ b/src/components/SignedPieceDescription.tsx
@@ -1,0 +1,375 @@
+// Published signed piece descriptions. Per 7A the signed description
+// renders as the piece's editorial essay, below the header, in Source Serif
+// 4. The unsigned pieces.description stays elsewhere as an italic metadata
+// strip (handled by PiecePageLayout.astro).
+//
+// Plural markup — typically one per piece, but supports N for plural-voice
+// expansion. Contributor affordances mirror InterpretiveSchools + PerformersNotes.
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+import type { PublishedPieceDescription } from '../lib/pieceDescriptions';
+
+interface Props {
+  pieceId: string;
+  initialDescriptions: PublishedPieceDescription[];
+}
+
+interface Viewer {
+  userId: string | null;
+  isContributor: boolean;
+  displayName: string | null;
+  bioShort: string | null;
+}
+
+type Mode = null | 'write' | { action: 'edit'; descriptionId: string };
+
+export default function SignedPieceDescription({ pieceId, initialDescriptions }: Props) {
+  const [descriptions, setDescriptions] = useState<PublishedPieceDescription[]>(initialDescriptions);
+  const [viewer, setViewer] = useState<Viewer | null>(null);
+  const [mode, setMode] = useState<Mode>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadViewer = useCallback(async () => {
+    if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
+
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.user) {
+      setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null });
+      return;
+    }
+
+    const { data } = await supabase
+      .from('users')
+      .select('display_name, is_contributor, contributor_active, contributor_bio_short')
+      .eq('id', session.user.id)
+      .single();
+
+    setViewer({
+      userId: session.user.id,
+      isContributor: Boolean(data?.is_contributor && data?.contributor_active),
+      displayName: data?.display_name ?? null,
+      bioShort: data?.contributor_bio_short ?? null,
+    });
+  }, []);
+
+  useEffect(() => { void loadViewer(); }, [loadViewer]);
+
+  async function refetch() {
+    const { data } = await supabase
+      .from('piece_descriptions')
+      .select('id, contributor_id, current_version_id, approved_by_contributor_at')
+      .eq('piece_id', pieceId)
+      .eq('status', 'published')
+      .order('approved_by_contributor_at', { ascending: true });
+    if (!data || data.length === 0) { setDescriptions([]); return; }
+
+    const versionIds = data.map((d) => d.current_version_id).filter((x): x is string => Boolean(x));
+    const contribIds = [...new Set(data.map((d) => d.contributor_id))];
+
+    const [versionsRes, contribsRes] = await Promise.all([
+      supabase.from('v_piece_description_versions_published').select('id, body, version_number, approved_at').in('id', versionIds),
+      supabase.from('users').select('id, display_name, contributor_bio_short').in('id', contribIds),
+    ]);
+    const vById = new Map((versionsRes.data ?? []).map((v) => [v.id, v]));
+    const cById = new Map((contribsRes.data ?? []).map((c) => [c.id, c]));
+
+    const rows: PublishedPieceDescription[] = [];
+    for (const d of data) {
+      if (!d.current_version_id) continue;
+      const v = vById.get(d.current_version_id);
+      const c = cById.get(d.contributor_id);
+      if (!v || !c) continue;
+      rows.push({
+        descriptionId: d.id,
+        versionId: v.id,
+        body: v.body,
+        versionNumber: v.version_number,
+        approvedAt: v.approved_at,
+        contributor: { id: c.id, displayName: c.display_name, bioShort: c.contributor_bio_short ?? null },
+      });
+    }
+    setDescriptions(rows);
+  }
+
+  async function handleWrite(body: string) {
+    if (body.trim().length === 0) { setError('Body required.'); return; }
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('publish_contributor_piece_description', {
+      p_piece_id: pieceId,
+      p_body: body,
+    });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    setMode(null);
+    await refetch();
+  }
+
+  async function handleEdit(descriptionId: string, body: string) {
+    if (body.trim().length === 0) { setError('Body required.'); return; }
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('publish_contributor_piece_description_edit', {
+      p_description_id: descriptionId,
+      p_body: body,
+    });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    setMode(null);
+    await refetch();
+  }
+
+  async function handleRemove(descriptionId: string) {
+    setBusy(true); setError(null);
+    const { error: err } = await supabase.rpc('remove_piece_description', { p_description_id: descriptionId });
+    setBusy(false);
+    if (err) { setError(err.message); return; }
+    await refetch();
+    if (typeof window !== 'undefined') window.dispatchEvent(new Event('notifications:changed'));
+  }
+
+  const canWrite = Boolean(viewer?.isContributor);
+  const writeLabel = descriptions.length === 0 ? 'Write a signed description' : 'Add another description';
+
+  return (
+    <div>
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border-[0.5px] px-3 py-2 text-sm"
+          style={{ background: 'var(--color-error-bg)', color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {descriptions.length === 0 ? (
+        <p className="empty-state">No signed description yet.</p>
+      ) : (
+        <div className="descriptions-list">
+          {descriptions.map((d) => {
+            const isOwner = viewer?.userId === d.contributor.id;
+            const isEditing = typeof mode === 'object' && mode?.action === 'edit' && mode.descriptionId === d.descriptionId;
+            return (
+              <article key={d.descriptionId} className="description-essay">
+                {!isEditing && (
+                  <>
+                    <div className="prose">
+                      {d.body.split(/\n\s*\n/).map((para, i) => <p key={i}>{para}</p>)}
+                    </div>
+                    <div className="by">
+                      <span className="name">{d.contributor.displayName}</span>
+                      {d.contributor.bioShort && (
+                        <>
+                          <span className="dot" aria-hidden="true"></span>
+                          <span>{d.contributor.bioShort}</span>
+                        </>
+                      )}
+                    </div>
+                    {isOwner && (
+                      <div className="owner-actions">
+                        <button
+                          type="button"
+                          onClick={() => { setMode({ action: 'edit', descriptionId: d.descriptionId }); setError(null); }}
+                          className="owner-btn"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRemove(d.descriptionId)}
+                          disabled={busy}
+                          className="owner-btn"
+                        >
+                          {busy ? 'Removing…' : 'Remove'}
+                        </button>
+                      </div>
+                    )}
+                  </>
+                )}
+                {isEditing && viewer && (
+                  <EssayEditForm
+                    initial={d.body}
+                    contributor={{ name: viewer.displayName ?? d.contributor.displayName, bio: viewer.bioShort }}
+                    submitting={busy}
+                    onCancel={() => { setMode(null); setError(null); }}
+                    onSubmit={(body) => handleEdit(d.descriptionId, body)}
+                  />
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      {mode !== 'write' && canWrite && (
+        <button
+          type="button"
+          onClick={() => { setMode('write'); setError(null); }}
+          className="write-entry"
+        >
+          {writeLabel} &rarr;
+        </button>
+      )}
+      {mode === 'write' && viewer && (
+        <div className="mt-6 description-essay">
+          <EssayEditForm
+            initial=""
+            placeholder="What is this piece, to you, as a working musician?"
+            contributor={{ name: viewer.displayName ?? 'You', bio: viewer.bioShort }}
+            submitting={busy}
+            onCancel={() => { setMode(null); setError(null); }}
+            onSubmit={handleWrite}
+            submitLabel="Publish"
+            submittingLabel="Publishing…"
+          />
+        </div>
+      )}
+
+      <style>{`
+        .descriptions-list { display: flex; flex-direction: column; gap: 40px; }
+        .description-essay .prose {
+          font-family: var(--font-serif);
+          font-size: 17px;
+          line-height: 1.72;
+          color: var(--ink);
+          max-width: 640px;
+          margin: 0 0 18px;
+        }
+        .description-essay .prose p { margin: 0 0 14px; }
+        .description-essay .prose p:last-child { margin-bottom: 0; }
+        .description-essay .by {
+          font-family: var(--font-sans);
+          font-size: 13px;
+          color: var(--ink);
+          text-align: right;
+          max-width: 640px;
+        }
+        .description-essay .by .name { font-weight: 500; }
+        .description-essay .by .dot {
+          display: inline-block;
+          width: 3px; height: 3px;
+          border-radius: 50%;
+          background: var(--muted);
+          margin: 0 8px;
+          vertical-align: middle;
+        }
+        .description-essay .by span:not(.name):not(.dot) { color: var(--muted); }
+        .owner-actions { display: flex; gap: 8px; margin-top: 14px; }
+        .owner-btn {
+          background: transparent;
+          border: 0.5px solid var(--border-strong);
+          color: var(--muted);
+          font-family: var(--font-sans);
+          font-size: 11px;
+          padding: 4px 10px;
+          border-radius: 6px;
+          cursor: pointer;
+          transition: color 0.12s, border-color 0.12s;
+        }
+        .owner-btn:hover { color: var(--ink); border-color: var(--ink); }
+        .owner-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .write-entry {
+          margin-top: 24px;
+          background: transparent;
+          border: 0;
+          color: var(--accent);
+          font-family: var(--font-sans);
+          font-size: 13px;
+          padding: 0;
+          cursor: pointer;
+        }
+        .write-entry:hover { color: var(--ink); }
+      `}</style>
+    </div>
+  );
+}
+
+function EssayEditForm(props: {
+  initial: string;
+  placeholder?: string;
+  contributor: { name: string; bio: string | null };
+  submitting: boolean;
+  onCancel: () => void;
+  onSubmit: (body: string) => void;
+  submitLabel?: string;
+  submittingLabel?: string;
+}) {
+  const [value, setValue] = useState(props.initial);
+  const submitLabel = props.submitLabel ?? 'Save';
+  const submittingLabel = props.submittingLabel ?? 'Saving…';
+  const disabled = props.submitting || value.trim() === '';
+
+  return (
+    <div>
+      <textarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        rows={8}
+        placeholder={props.placeholder}
+        style={{
+          width: '100%',
+          maxWidth: '640px',
+          fontFamily: 'var(--font-serif)',
+          fontSize: '17px',
+          lineHeight: 1.72,
+          color: 'var(--ink)',
+          background: 'transparent',
+          border: '0.5px solid var(--border-strong)',
+          borderRadius: '8px',
+          padding: '10px 12px',
+          resize: 'vertical',
+        }}
+      />
+      <div style={{ marginTop: '12px', fontFamily: 'var(--font-sans)', fontSize: '13px', textAlign: 'right', maxWidth: '640px' }}>
+        <span style={{ fontWeight: 500 }}>{props.contributor.name}</span>
+        {props.contributor.bio && (
+          <>
+            <span style={{ margin: '0 8px', color: 'var(--muted)' }}>·</span>
+            <span style={{ color: 'var(--muted)' }}>{props.contributor.bio}</span>
+          </>
+        )}
+      </div>
+      <div style={{ marginTop: '12px', display: 'flex', gap: '8px' }}>
+        <button
+          type="button"
+          onClick={() => props.onSubmit(value)}
+          disabled={disabled}
+          style={{
+            background: 'var(--ink)',
+            color: '#FFFFFF',
+            border: 0,
+            fontFamily: 'var(--font-sans)',
+            fontSize: '13px',
+            fontWeight: 500,
+            padding: '8px 16px',
+            borderRadius: '8px',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+            opacity: disabled ? 0.5 : 1,
+          }}
+        >
+          {props.submitting ? submittingLabel : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={props.onCancel}
+          disabled={props.submitting}
+          style={{
+            background: 'transparent',
+            color: 'var(--ink)',
+            border: '0.5px solid var(--border-strong)',
+            fontFamily: 'var(--font-sans)',
+            fontSize: '13px',
+            fontWeight: 500,
+            padding: '8px 16px',
+            borderRadius: '8px',
+            cursor: props.submitting ? 'not-allowed' : 'pointer',
+            opacity: props.submitting ? 0.5 : 1,
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AdminPage.tsx
+++ b/src/components/admin/AdminPage.tsx
@@ -3,9 +3,9 @@ import { supabase, hasSupabase } from '../../lib/supabase';
 import AdminDashboard from './AdminDashboard';
 import AdminUserList from './AdminUserList';
 import AdminPlaylist from './AdminPlaylist';
-import PerformersNotesAdmin from './PerformersNotesAdmin';
+import ContributorContentAdmin from './ContributorContentAdmin';
 
-type Tab = 'dashboard' | 'users' | 'playlist' | 'performers-notes';
+type Tab = 'dashboard' | 'users' | 'playlist' | 'performers-notes' | 'interpretive-schools' | 'piece-descriptions';
 
 interface StaffProfile {
   id: string;
@@ -66,6 +66,8 @@ export default function AdminPage({ initialTab }: Props) {
     { id: 'dashboard' as Tab, label: 'Dashboard', show: isAdmin },
     { id: 'users' as Tab, label: 'Users', show: isAdmin },
     { id: 'performers-notes' as Tab, label: "Performer's notes", show: isAdmin },
+    { id: 'interpretive-schools' as Tab, label: 'Schools', show: isAdmin },
+    { id: 'piece-descriptions' as Tab, label: 'Descriptions', show: isAdmin },
     { id: 'playlist' as Tab, label: 'Playlist', show: isMaestro },
   ].filter(t => t.show);
 
@@ -77,6 +79,8 @@ export default function AdminPage({ initialTab }: Props) {
     dashboard: 'Dashboard',
     users: 'User Management',
     'performers-notes': "Performer's notes",
+    'interpretive-schools': 'Interpretive schools',
+    'piece-descriptions': 'Piece descriptions',
     playlist: 'Maestro Playlist',
   };
 
@@ -117,7 +121,9 @@ export default function AdminPage({ initialTab }: Props) {
 
         {activeTab === 'dashboard' && isAdmin && <AdminDashboard isAdmin={true} />}
         {activeTab === 'users' && isAdmin && <AdminUserList />}
-        {activeTab === 'performers-notes' && isAdmin && <PerformersNotesAdmin />}
+        {activeTab === 'performers-notes' && isAdmin && <ContributorContentAdmin subjectTable="performers_notes" />}
+        {activeTab === 'interpretive-schools' && isAdmin && <ContributorContentAdmin subjectTable="interpretive_schools" />}
+        {activeTab === 'piece-descriptions' && isAdmin && <ContributorContentAdmin subjectTable="piece_descriptions" />}
         {activeTab === 'playlist' && isMaestro && <AdminPlaylist />}
       </div>
     </div>

--- a/src/components/admin/ContributorContentAdmin.tsx
+++ b/src/components/admin/ContributorContentAdmin.tsx
@@ -1,13 +1,25 @@
-// Staff authoring surface for performer's notes. Deliberately unpolished —
-// PRD treats Tier 1 as data-model + admin view, not styled product. The goal
-// is a reliable scaffold: create a draft on behalf of a contributor, revise
-// after a rejection, submit, retract, see status at a glance.
+// Generic staff authoring surface for all three signed content types that
+// flow through the contributor approval pipeline:
+//   - performer's notes (body only)
+//   - interpretive schools (name + optional tempo_cues + body)
+//   - piece descriptions (body only)
 //
-// The contributor-facing UX lives at /notifications. This page is for
-// Editorial Director and staff.
+// One component, parameterized by `subjectTable`; per-subject config comes
+// from SUBJECT_CONFIG in src/lib/contributorSubjects.ts. Adding a fourth
+// subject type in a future slice is: (a) migration for the new tables,
+// (b) one row in SUBJECT_CONFIG, (c) mount this component with the new
+// subject table — no component duplication.
+//
+// Deliberately unpolished per the PRD: Tier 1 staff admin is data-model +
+// admin view, not styled product.
 
 import { useCallback, useEffect, useState } from 'react';
 import { supabase } from '../../lib/supabase';
+import {
+  SUBJECT_CONFIG,
+  rpcSubjectIdParam,
+  type SubjectTable,
+} from '../../lib/contributorSubjects';
 
 type DraftStatus = 'draft' | 'awaiting_contributor_approval' | 'published' | 'removed';
 
@@ -23,7 +35,7 @@ interface Contributor {
   display_name: string;
 }
 
-interface NoteVersion {
+interface VersionRow {
   id: string;
   version_number: number;
   body: string;
@@ -32,22 +44,47 @@ interface NoteVersion {
   created_at: string;
 }
 
-interface NoteRow {
+interface SubjectRow {
   id: string;
   piece: Piece;
   contributor: Contributor;
   status: DraftStatus;
   current_version_id: string | null;
   drafted_by_name: string | null;
-  versions: NoteVersion[];
+  versions: VersionRow[];
   created_at: string;
   updated_at: string;
+  /** Schools only. */
+  name: string | null;
+  /** Schools only. */
+  tempo_cues: Record<string, unknown> | null;
 }
 
-export default function PerformersNotesAdmin() {
+interface Props {
+  subjectTable: SubjectTable;
+}
+
+function parseTempoCues(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('tempo_cues must be a JSON object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch (e) {
+    throw new Error(`tempo_cues: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export default function ContributorContentAdmin({ subjectTable }: Props) {
+  const cfg = SUBJECT_CONFIG[subjectTable];
+  const idParam = rpcSubjectIdParam(subjectTable);
+
   const [pieces, setPieces] = useState<Piece[]>([]);
   const [contributors, setContributors] = useState<Contributor[]>([]);
-  const [notes, setNotes] = useState<NoteRow[]>([]);
+  const [rows, setRows] = useState<SubjectRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -55,6 +92,8 @@ export default function PerformersNotesAdmin() {
   const [pieceId, setPieceId] = useState<string>('');
   const [contributorId, setContributorId] = useState<string>('');
   const [body, setBody] = useState<string>('');
+  const [name, setName] = useState<string>('');
+  const [tempoCuesRaw, setTempoCuesRaw] = useState<string>('');
   const [creating, setCreating] = useState<boolean>(false);
 
   // Per-row state
@@ -66,7 +105,20 @@ export default function PerformersNotesAdmin() {
   const reload = useCallback(async () => {
     setError(null);
 
-    const [piecesRes, contribRes, notesRes] = await Promise.all([
+    const selectFields = [
+      'id',
+      'piece_id',
+      'contributor_id',
+      'status',
+      'current_version_id',
+      'drafted_by',
+      'created_at',
+      'updated_at',
+      cfg.hasName ? 'name' : null,
+      cfg.hasTempoCues ? 'tempo_cues' : null,
+    ].filter(Boolean).join(', ');
+
+    const [piecesRes, contribRes, rowsRes] = await Promise.all([
       supabase.from('pieces').select('id, title, composer_name, catalog_number').order('title'),
       supabase
         .from('users')
@@ -75,38 +127,49 @@ export default function PerformersNotesAdmin() {
         .eq('contributor_active', true)
         .order('display_name'),
       supabase
-        .from('performers_notes')
-        .select('id, piece_id, contributor_id, status, current_version_id, drafted_by, created_at, updated_at')
+        .from(cfg.table)
+        .select(selectFields)
         .order('updated_at', { ascending: false }),
     ]);
     if (piecesRes.error) { setError(piecesRes.error.message); return; }
     if (contribRes.error) { setError(contribRes.error.message); return; }
-    if (notesRes.error) { setError(notesRes.error.message); return; }
+    if (rowsRes.error) { setError(rowsRes.error.message); return; }
 
     setPieces(piecesRes.data ?? []);
     setContributors(contribRes.data ?? []);
 
-    // Pre-select default contributor if exactly one exists.
     if ((contribRes.data?.length ?? 0) === 1) {
       setContributorId(contribRes.data![0].id);
     }
 
-    const rawNotes = notesRes.data ?? [];
-    if (rawNotes.length === 0) {
-      setNotes([]);
+    type RawRow = {
+      id: string;
+      piece_id: string;
+      contributor_id: string;
+      status: DraftStatus;
+      current_version_id: string | null;
+      drafted_by: string | null;
+      created_at: string;
+      updated_at: string;
+      name?: string | null;
+      tempo_cues?: Record<string, unknown> | null;
+    };
+    const rawRows = (rowsRes.data ?? []) as RawRow[];
+    if (rawRows.length === 0) {
+      setRows([]);
       setLoading(false);
       return;
     }
 
-    const noteIds = rawNotes.map((n) => n.id);
-    const drafterIds = [...new Set(rawNotes.map((n) => n.drafted_by).filter((x): x is string => Boolean(x)))];
-    const contribIds = [...new Set(rawNotes.map((n) => n.contributor_id))];
+    const subjectIds = rawRows.map((r) => r.id);
+    const drafterIds = [...new Set(rawRows.map((r) => r.drafted_by).filter((x): x is string => Boolean(x)))];
+    const contribIds = [...new Set(rawRows.map((r) => r.contributor_id))];
 
     const [versionsRes, draftersRes, contribLookupRes] = await Promise.all([
       supabase
-        .from('performers_note_versions')
-        .select('id, note_id, version_number, body, approved_at, rejection_note, created_at')
-        .in('note_id', noteIds)
+        .from(cfg.versionsTable)
+        .select(`id, ${cfg.versionForeignKey}, version_number, body, approved_at, rejection_note, created_at`)
+        .in(cfg.versionForeignKey, subjectIds)
         .order('version_number', { ascending: false }),
       drafterIds.length
         ? supabase.from('users').select('id, display_name').in('id', drafterIds)
@@ -121,9 +184,11 @@ export default function PerformersNotesAdmin() {
     const drafterById = new Map((draftersRes.data ?? []).map((u) => [u.id, u.display_name]));
     const contributorById = new Map((contribLookupRes.data ?? []).map((u) => [u.id, u.display_name]));
 
-    const versionsByNote = new Map<string, NoteVersion[]>();
-    for (const v of versionsRes.data ?? []) {
-      const arr = versionsByNote.get(v.note_id) ?? [];
+    type RawVersion = VersionRow & Record<string, string>;
+    const versionsBySubject = new Map<string, VersionRow[]>();
+    for (const v of (versionsRes.data ?? []) as RawVersion[]) {
+      const subjectId = v[cfg.versionForeignKey];
+      const arr = versionsBySubject.get(subjectId) ?? [];
       arr.push({
         id: v.id,
         version_number: v.version_number,
@@ -132,98 +197,124 @@ export default function PerformersNotesAdmin() {
         rejection_note: v.rejection_note,
         created_at: v.created_at,
       });
-      versionsByNote.set(v.note_id, arr);
+      versionsBySubject.set(subjectId, arr);
     }
 
-    const hydrated: NoteRow[] = [];
-    for (const n of rawNotes) {
-      const piece = pieceById.get(n.piece_id);
+    const hydrated: SubjectRow[] = [];
+    for (const r of rawRows) {
+      const piece = pieceById.get(r.piece_id);
       if (!piece) continue;
       hydrated.push({
-        id: n.id,
+        id: r.id,
         piece,
-        contributor: { id: n.contributor_id, display_name: contributorById.get(n.contributor_id) ?? 'Unknown' },
-        status: n.status as DraftStatus,
-        current_version_id: n.current_version_id,
-        drafted_by_name: n.drafted_by ? drafterById.get(n.drafted_by) ?? null : null,
-        versions: versionsByNote.get(n.id) ?? [],
-        created_at: n.created_at,
-        updated_at: n.updated_at,
+        contributor: { id: r.contributor_id, display_name: contributorById.get(r.contributor_id) ?? 'Unknown' },
+        status: r.status,
+        current_version_id: r.current_version_id,
+        drafted_by_name: r.drafted_by ? drafterById.get(r.drafted_by) ?? null : null,
+        versions: versionsBySubject.get(r.id) ?? [],
+        created_at: r.created_at,
+        updated_at: r.updated_at,
+        name: cfg.hasName ? r.name ?? null : null,
+        tempo_cues: cfg.hasTempoCues ? r.tempo_cues ?? null : null,
       });
     }
-    setNotes(hydrated);
+    setRows(hydrated);
     setLoading(false);
-  }, []);
+  }, [cfg]);
 
   useEffect(() => { void reload(); }, [reload]);
-
-  async function handleCreate(options: { submitAfter: boolean }) {
-    if (!pieceId) { setError('Pick a piece.'); return; }
-    if (!contributorId) { setError('Pick a contributor.'); return; }
-    if (body.trim().length === 0) { setError('Body required.'); return; }
-
-    setCreating(true);
-    setError(null);
-    const { data: noteId, error: createErr } = await supabase.rpc('create_performers_note_draft', {
-      p_piece_id: pieceId,
-      p_contributor_id: contributorId,
-      p_body: body,
-    });
-    if (createErr) { setError(createErr.message); setCreating(false); return; }
-
-    if (options.submitAfter) {
-      const { error: submitErr } = await supabase.rpc('submit_performers_note', { p_note_id: noteId });
-      if (submitErr) { setError(submitErr.message); setCreating(false); return; }
-    }
-
-    setBody('');
-    setCreating(false);
-    await reload();
-    notifyChanged();
-  }
 
   function notifyChanged() {
     if (typeof window !== 'undefined') window.dispatchEvent(new Event('notifications:changed'));
   }
 
-  async function handleSubmit(noteId: string) {
-    setRowBusy((b) => ({ ...b, [noteId]: true })); setError(null);
-    const { error: err } = await supabase.rpc('submit_performers_note', { p_note_id: noteId });
-    setRowBusy((b) => ({ ...b, [noteId]: false }));
+  async function handleCreate(options: { submitAfter: boolean }) {
+    if (!pieceId) { setError('Pick a piece.'); return; }
+    if (!contributorId) { setError('Pick a contributor.'); return; }
+    if (body.trim().length === 0) { setError('Body required.'); return; }
+    if (cfg.hasName && name.trim().length === 0) {
+      setError('Name required for this subject type.');
+      return;
+    }
+
+    let tempoCues: Record<string, unknown> | null = null;
+    if (cfg.hasTempoCues) {
+      try {
+        tempoCues = parseTempoCues(tempoCuesRaw);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        return;
+      }
+    }
+
+    setCreating(true);
+    setError(null);
+
+    const createArgs: Record<string, unknown> = {
+      p_piece_id: pieceId,
+      p_contributor_id: contributorId,
+      p_body: body,
+    };
+    if (cfg.hasName) createArgs.p_name = name.trim();
+    if (cfg.hasTempoCues && tempoCues !== null) createArgs.p_tempo_cues = tempoCues;
+
+    const { data: subjectId, error: createErr } = await supabase.rpc(cfg.rpcs.createDraft, createArgs);
+    if (createErr) { setError(createErr.message); setCreating(false); return; }
+
+    if (options.submitAfter) {
+      const { error: submitErr } = await supabase.rpc(cfg.rpcs.submit, {
+        [idParam]: subjectId,
+      });
+      if (submitErr) { setError(submitErr.message); setCreating(false); return; }
+    }
+
+    setBody('');
+    setName('');
+    setTempoCuesRaw('');
+    setCreating(false);
+    await reload();
+    notifyChanged();
+  }
+
+  async function handleSubmit(rowId: string) {
+    setRowBusy((b) => ({ ...b, [rowId]: true })); setError(null);
+    const { error: err } = await supabase.rpc(cfg.rpcs.submit, { [idParam]: rowId });
+    setRowBusy((b) => ({ ...b, [rowId]: false }));
     if (err) { setError(err.message); return; }
     await reload();
     notifyChanged();
   }
 
-  async function handleRetract(noteId: string) {
-    setRowBusy((b) => ({ ...b, [noteId]: true })); setError(null);
-    const { error: err } = await supabase.rpc('retract_performers_note', { p_note_id: noteId });
-    setRowBusy((b) => ({ ...b, [noteId]: false }));
+  async function handleRetract(rowId: string) {
+    setRowBusy((b) => ({ ...b, [rowId]: true })); setError(null);
+    const { error: err } = await supabase.rpc(cfg.rpcs.retract, { [idParam]: rowId });
+    setRowBusy((b) => ({ ...b, [rowId]: false }));
     if (err) { setError(err.message); return; }
     await reload();
     notifyChanged();
   }
 
-  async function handleRevise(noteId: string) {
-    const newBody = reviseBody[noteId] ?? '';
+  async function handleRevise(rowId: string) {
+    const newBody = reviseBody[rowId] ?? '';
     if (newBody.trim().length === 0) { setError('Revision body required.'); return; }
-    setRowBusy((b) => ({ ...b, [noteId]: true })); setError(null);
-    const { error: err } = await supabase.rpc('update_performers_note_draft', {
-      p_note_id: noteId,
+    setRowBusy((b) => ({ ...b, [rowId]: true })); setError(null);
+    const { error: err } = await supabase.rpc(cfg.rpcs.updateDraft, {
+      [idParam]: rowId,
       p_body: newBody,
     });
-    setRowBusy((b) => ({ ...b, [noteId]: false }));
+    setRowBusy((b) => ({ ...b, [rowId]: false }));
     if (err) { setError(err.message); return; }
-    setReviseOpen((o) => ({ ...o, [noteId]: false }));
-    setReviseBody((b) => ({ ...b, [noteId]: '' }));
+    setReviseOpen((o) => ({ ...o, [rowId]: false }));
+    setReviseBody((b) => ({ ...b, [rowId]: '' }));
     await reload();
   }
 
   if (loading) return <div className="text-sm text-[#6F6F6F]">Loading…</div>;
 
-  const filtered = filter === 'all' ? notes : notes.filter((n) => n.status === filter);
-
-  const canSend = Boolean(pieceId && contributorId && body.trim().length > 0 && !creating);
+  const filtered = filter === 'all' ? rows : rows.filter((r) => r.status === filter);
+  const baseReady = Boolean(pieceId && contributorId && body.trim().length > 0);
+  const nameReady = !cfg.hasName || name.trim().length > 0;
+  const canSend = baseReady && nameReady && !creating;
   const noContributor = contributors.length === 0;
 
   return (
@@ -234,7 +325,6 @@ export default function PerformersNotesAdmin() {
         </div>
       )}
 
-      {/* Create a new draft */}
       <section className="border-[0.5px] border-[#E5E3DE] rounded-xl bg-white p-5">
         <h2 className="font-display text-[20px] mb-1 text-[#1A1A1A]">New draft</h2>
         <p className="text-xs text-[#6F6F6F] mb-4">
@@ -285,13 +375,39 @@ export default function PerformersNotesAdmin() {
           </label>
         </div>
 
+        {cfg.hasName && (
+          <label className="block text-xs text-[#6F6F6F] mb-3">
+            Name
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Historically informed"
+              className="mt-1 w-full px-3 py-2 text-sm text-[#1A1A1A] border-[0.5px] border-[#CCC9C2] rounded-lg bg-white"
+            />
+          </label>
+        )}
+
+        {cfg.hasTempoCues && (
+          <label className="block text-xs text-[#6F6F6F] mb-3">
+            Tempo cues (optional JSON object)
+            <textarea
+              value={tempoCuesRaw}
+              onChange={(e) => setTempoCuesRaw(e.target.value)}
+              rows={2}
+              placeholder='{"opening": "quarter=72"}'
+              className="mt-1 w-full px-3 py-2 text-xs font-mono leading-relaxed text-[#1A1A1A] border-[0.5px] border-[#CCC9C2] rounded-lg resize-y bg-white"
+            />
+          </label>
+        )}
+
         <label className="block text-xs text-[#6F6F6F] mb-3">
           Body
           <textarea
             value={body}
             onChange={(e) => setBody(e.target.value)}
             rows={6}
-            placeholder="Proposed performer's note…"
+            placeholder={`Proposed ${cfg.label.toLowerCase()}…`}
             className="mt-1 w-full px-3 py-2 text-[15px] font-display leading-[1.68] text-[#1A1A1A] border-[0.5px] border-[#CCC9C2] rounded-lg resize-y bg-white"
           />
         </label>
@@ -316,10 +432,9 @@ export default function PerformersNotesAdmin() {
         </div>
       </section>
 
-      {/* Existing notes */}
       <section>
         <div className="flex items-center justify-between mb-3 gap-4">
-          <h2 className="font-display text-[20px] text-[#1A1A1A]">Notes</h2>
+          <h2 className="font-display text-[20px] text-[#1A1A1A]">{cfg.label}s</h2>
           <div className="flex gap-2 flex-wrap">
             {(['awaiting_contributor_approval', 'draft', 'published', 'removed', 'all'] as const).map((f) => {
               const active = filter === f;
@@ -347,37 +462,51 @@ export default function PerformersNotesAdmin() {
           </div>
         ) : (
           <ul className="space-y-3">
-            {filtered.map((n) => {
-              const busy = rowBusy[n.id] ?? false;
-              const pending = n.versions.find((v) => v.approved_at === null);
-              const currentVersion = n.versions.find((v) => v.id === n.current_version_id);
-              const rejected = n.versions.filter((v) => v.rejection_note);
+            {filtered.map((r) => {
+              const busy = rowBusy[r.id] ?? false;
+              const pending = r.versions.find((v) => v.approved_at === null);
+              const currentVersion = r.versions.find((v) => v.id === r.current_version_id);
+              const rejected = r.versions.filter((v) => v.rejection_note);
               return (
-                <li key={n.id} className="rounded-xl border-[0.5px] border-[#E5E3DE] bg-white p-4">
+                <li key={r.id} className="rounded-xl border-[0.5px] border-[#E5E3DE] bg-white p-4">
                   <div className="flex items-baseline justify-between gap-2 mb-1">
                     <div className="font-display text-[18px] text-[#1A1A1A] leading-tight">
-                      {n.piece.title}{n.piece.catalog_number && (
-                        <span className="ml-2 text-[11px] font-mono text-[#9A9A9A] tracking-wide">{n.piece.catalog_number}</span>
+                      {r.piece.title}{r.piece.catalog_number && (
+                        <span className="ml-2 text-[11px] font-mono text-[#9A9A9A] tracking-wide">{r.piece.catalog_number}</span>
                       )}
                     </div>
-                    <StatusPill status={n.status} />
+                    <StatusPill status={r.status} />
                   </div>
                   <div className="text-xs text-[#6F6F6F] mb-3">
-                    for {n.contributor.display_name} &middot; {n.drafted_by_name ? `drafted by ${n.drafted_by_name}` : 'self-authored'} &middot; {n.versions.length} version{n.versions.length === 1 ? '' : 's'}
+                    for {r.contributor.display_name} &middot; {r.drafted_by_name ? `drafted by ${r.drafted_by_name}` : 'self-authored'} &middot; {r.versions.length} version{r.versions.length === 1 ? '' : 's'}
                   </div>
 
-                  {/* Rejection notes — visible inline so staff learn from them */}
+                  {cfg.hasName && r.name && (
+                    <div className="mb-2 text-[11px] font-medium tracking-[0.08em] uppercase text-[#1A1A1A]">
+                      {r.name}
+                    </div>
+                  )}
+
+                  {cfg.hasTempoCues && r.tempo_cues && Object.keys(r.tempo_cues).length > 0 && (
+                    <div className="mb-2 text-[11px] font-mono text-[#6F6F6F]">
+                      {Object.entries(r.tempo_cues).map(([k, v]) => (
+                        <span key={k} className="mr-3">
+                          {k}: {typeof v === 'string' ? v : JSON.stringify(v)}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
                   {rejected.length > 0 && (
                     <div className="mb-3 rounded-lg bg-[#FAF2DB] border-[0.5px] border-[#8B6914] text-[#8B6914] text-xs px-3 py-2 space-y-1">
-                      {rejected.map((r) => (
-                        <div key={r.id}>
-                          <span className="font-medium">rejected v{r.version_number}:</span> {r.rejection_note}
+                      {rejected.map((x) => (
+                        <div key={x.id}>
+                          <span className="font-medium">rejected v{x.version_number}:</span> {x.rejection_note}
                         </div>
                       ))}
                     </div>
                   )}
 
-                  {/* Current body preview (pending or published) */}
                   {(pending || currentVersion) && (
                     <pre
                       className="px-3 py-2 mb-3 bg-[#F8F7F4] border-[0.5px] border-[#E5E3DE] rounded-lg font-display text-[14px] leading-[1.55] text-[#1A1A1A] whitespace-pre-wrap"
@@ -386,13 +515,12 @@ export default function PerformersNotesAdmin() {
                     </pre>
                   )}
 
-                  {/* Actions */}
                   <div className="flex flex-wrap gap-2">
-                    {n.status === 'draft' && (
+                    {r.status === 'draft' && (
                       <>
                         <button
                           type="button"
-                          onClick={() => handleSubmit(n.id)}
+                          onClick={() => handleSubmit(r.id)}
                           disabled={busy}
                           className="px-3 py-1.5 bg-[#1A1A1A] text-white text-xs font-medium rounded-lg hover:bg-[#292524] disabled:opacity-50"
                         >
@@ -401,20 +529,20 @@ export default function PerformersNotesAdmin() {
                         <button
                           type="button"
                           onClick={() => {
-                            setReviseOpen((o) => ({ ...o, [n.id]: !(o[n.id] ?? false) }));
-                            setReviseBody((b) => ({ ...b, [n.id]: (pending ?? currentVersion)?.body ?? '' }));
+                            setReviseOpen((o) => ({ ...o, [r.id]: !(o[r.id] ?? false) }));
+                            setReviseBody((b) => ({ ...b, [r.id]: (pending ?? currentVersion)?.body ?? '' }));
                           }}
                           disabled={busy}
                           className="px-3 py-1.5 bg-transparent text-[#1A1A1A] text-xs font-medium border-[0.5px] border-[#CCC9C2] rounded-lg hover:bg-[#F8F7F4] disabled:opacity-50"
                         >
-                          {reviseOpen[n.id] ? 'Close' : 'Revise'}
+                          {reviseOpen[r.id] ? 'Close' : 'Revise'}
                         </button>
                       </>
                     )}
-                    {n.status === 'awaiting_contributor_approval' && (
+                    {r.status === 'awaiting_contributor_approval' && (
                       <button
                         type="button"
-                        onClick={() => handleRetract(n.id)}
+                        onClick={() => handleRetract(r.id)}
                         disabled={busy}
                         className="px-3 py-1.5 bg-transparent text-[#1A1A1A] text-xs font-medium border-[0.5px] border-[#CCC9C2] rounded-lg hover:bg-[#F8F7F4] disabled:opacity-50"
                       >
@@ -423,19 +551,18 @@ export default function PerformersNotesAdmin() {
                     )}
                   </div>
 
-                  {/* Revise form */}
-                  {n.status === 'draft' && reviseOpen[n.id] && (
+                  {r.status === 'draft' && reviseOpen[r.id] && (
                     <div className="mt-3">
                       <textarea
-                        value={reviseBody[n.id] ?? ''}
-                        onChange={(e) => setReviseBody((b) => ({ ...b, [n.id]: e.target.value }))}
+                        value={reviseBody[r.id] ?? ''}
+                        onChange={(e) => setReviseBody((b) => ({ ...b, [r.id]: e.target.value }))}
                         rows={5}
                         className="w-full px-3 py-2 text-[15px] font-display leading-[1.68] text-[#1A1A1A] border-[0.5px] border-[#CCC9C2] rounded-lg resize-y bg-white"
                       />
                       <div className="flex gap-2 mt-2">
                         <button
                           type="button"
-                          onClick={() => handleRevise(n.id)}
+                          onClick={() => handleRevise(r.id)}
                           disabled={busy}
                           className="px-3 py-1.5 bg-[#1A1A1A] text-white text-xs font-medium rounded-lg hover:bg-[#292524] disabled:opacity-50"
                         >
@@ -443,7 +570,7 @@ export default function PerformersNotesAdmin() {
                         </button>
                         <button
                           type="button"
-                          onClick={() => setReviseOpen((o) => ({ ...o, [n.id]: false }))}
+                          onClick={() => setReviseOpen((o) => ({ ...o, [r.id]: false }))}
                           disabled={busy}
                           className="px-3 py-1.5 bg-transparent text-[#1A1A1A] text-xs font-medium border-[0.5px] border-[#CCC9C2] rounded-lg hover:bg-[#F8F7F4] disabled:opacity-50"
                         >

--- a/src/lib/contributorSubjects.ts
+++ b/src/lib/contributorSubjects.ts
@@ -32,11 +32,21 @@ export interface SubjectConfig {
   anchor: string;
   /** True if the subject has a `name` column (schools). */
   hasName: boolean;
+  /** True if the subject has a `tempo_cues` jsonb column (schools). */
+  hasTempoCues: boolean;
   /** RPC names the queue dispatches to for each contributor action. */
   rpcs: {
     approve: string;
     approveAndEdit: string;
     reject: string;
+    /** Staff: create a draft on behalf of a contributor. */
+    createDraft: string;
+    /** Staff: insert a new version body on an existing draft. */
+    updateDraft: string;
+    /** Staff: send a draft to the contributor's queue. */
+    submit: string;
+    /** Staff: pull a submitted draft back before the contributor acts. */
+    retract: string;
   };
 }
 
@@ -49,10 +59,15 @@ export const SUBJECT_CONFIG: Record<SubjectTable, SubjectConfig> = {
     pageContext: 'on the piece page',
     anchor: '#performers-notes',
     hasName: false,
+    hasTempoCues: false,
     rpcs: {
       approve: 'approve_performers_note',
       approveAndEdit: 'approve_and_edit_performers_note',
       reject: 'reject_performers_note',
+      createDraft: 'create_performers_note_draft',
+      updateDraft: 'update_performers_note_draft',
+      submit: 'submit_performers_note',
+      retract: 'retract_performers_note',
     },
   },
   interpretive_schools: {
@@ -63,10 +78,15 @@ export const SUBJECT_CONFIG: Record<SubjectTable, SubjectConfig> = {
     pageContext: 'on the piece page',
     anchor: '#interpretive-schools',
     hasName: true,
+    hasTempoCues: true,
     rpcs: {
       approve: 'approve_interpretive_school',
       approveAndEdit: 'approve_and_edit_interpretive_school',
       reject: 'reject_interpretive_school',
+      createDraft: 'create_interpretive_school_draft',
+      updateDraft: 'update_interpretive_school_draft',
+      submit: 'submit_interpretive_school',
+      retract: 'retract_interpretive_school',
     },
   },
   piece_descriptions: {
@@ -77,10 +97,15 @@ export const SUBJECT_CONFIG: Record<SubjectTable, SubjectConfig> = {
     pageContext: 'on the piece page',
     anchor: '#signed-description',
     hasName: false,
+    hasTempoCues: false,
     rpcs: {
       approve: 'approve_piece_description',
       approveAndEdit: 'approve_and_edit_piece_description',
       reject: 'reject_piece_description',
+      createDraft: 'create_piece_description_draft',
+      updateDraft: 'update_piece_description_draft',
+      submit: 'submit_piece_description',
+      retract: 'retract_piece_description',
     },
   },
 };

--- a/src/lib/interpretiveSchools.ts
+++ b/src/lib/interpretiveSchools.ts
@@ -1,0 +1,83 @@
+// Helpers for fetching published interpretive schools on a piece. Mirrors
+// src/lib/performersNotes.ts. The published-versions view (granted to anon
+// + authenticated) exposes only version rows whose parent school is
+// `status = 'published'`; the base table RLS blocks direct anon reads.
+
+import { supabase, hasSupabase } from './supabase';
+
+export interface PublishedInterpretiveSchool {
+  schoolId: string;
+  versionId: string;
+  name: string;
+  body: string;
+  tempoCues: Record<string, unknown> | null;
+  versionNumber: number;
+  approvedAt: string | null;
+  contributor: {
+    id: string;
+    displayName: string;
+    bioShort: string | null;
+  };
+}
+
+/**
+ * Fetch all published interpretive schools for a piece. Ordered by
+ * approved_at ASC (CM6: chronological publication order, non-ranking).
+ */
+export async function getPublishedInterpretiveSchools(
+  pieceId: string,
+): Promise<PublishedInterpretiveSchool[]> {
+  if (!hasSupabase) return [];
+
+  const schoolsRes = await supabase
+    .from('interpretive_schools')
+    .select('id, contributor_id, current_version_id, name, tempo_cues, approved_by_contributor_at')
+    .eq('piece_id', pieceId)
+    .eq('status', 'published')
+    .order('approved_by_contributor_at', { ascending: true });
+  if (schoolsRes.error || !schoolsRes.data || schoolsRes.data.length === 0) return [];
+
+  const versionIds = schoolsRes.data
+    .map((s) => s.current_version_id)
+    .filter((x): x is string => Boolean(x));
+  const contributorIds = [...new Set(schoolsRes.data.map((s) => s.contributor_id))];
+
+  const [versionsRes, contribsRes] = await Promise.all([
+    supabase
+      .from('v_interpretive_school_versions_published')
+      .select('id, body, version_number, approved_at')
+      .in('id', versionIds),
+    supabase
+      .from('users')
+      .select('id, display_name, contributor_bio_short')
+      .in('id', contributorIds),
+  ]);
+  if (versionsRes.error || !versionsRes.data) return [];
+  if (contribsRes.error || !contribsRes.data) return [];
+
+  const versionById = new Map(versionsRes.data.map((v) => [v.id, v]));
+  const contribById = new Map(contribsRes.data.map((c) => [c.id, c]));
+
+  const rows: PublishedInterpretiveSchool[] = [];
+  for (const s of schoolsRes.data) {
+    if (!s.current_version_id) continue;
+    const version = versionById.get(s.current_version_id);
+    const contributor = contribById.get(s.contributor_id);
+    if (!version || !contributor) continue;
+    rows.push({
+      schoolId: s.id,
+      versionId: version.id,
+      name: s.name,
+      body: version.body,
+      tempoCues: (s.tempo_cues as Record<string, unknown> | null) ?? null,
+      versionNumber: version.version_number,
+      approvedAt: version.approved_at,
+      contributor: {
+        id: contributor.id,
+        displayName: contributor.display_name,
+        bioShort: contributor.contributor_bio_short ?? null,
+      },
+    });
+  }
+  return rows;
+}

--- a/src/lib/pieceDescriptions.ts
+++ b/src/lib/pieceDescriptions.ts
@@ -1,0 +1,75 @@
+// Helpers for fetching published signed piece descriptions. Mirrors
+// src/lib/performersNotes.ts. Separate from the unsigned pieces.description
+// column, which stays as short house-style reference copy per PRD §54.
+
+import { supabase, hasSupabase } from './supabase';
+
+export interface PublishedPieceDescription {
+  descriptionId: string;
+  versionId: string;
+  body: string;
+  versionNumber: number;
+  approvedAt: string | null;
+  contributor: {
+    id: string;
+    displayName: string;
+    bioShort: string | null;
+  };
+}
+
+/** Fetch all published piece descriptions. Ordered by approved_at ASC (CM6). */
+export async function getPublishedPieceDescriptions(
+  pieceId: string,
+): Promise<PublishedPieceDescription[]> {
+  if (!hasSupabase) return [];
+
+  const descRes = await supabase
+    .from('piece_descriptions')
+    .select('id, contributor_id, current_version_id, approved_by_contributor_at')
+    .eq('piece_id', pieceId)
+    .eq('status', 'published')
+    .order('approved_by_contributor_at', { ascending: true });
+  if (descRes.error || !descRes.data || descRes.data.length === 0) return [];
+
+  const versionIds = descRes.data
+    .map((d) => d.current_version_id)
+    .filter((x): x is string => Boolean(x));
+  const contributorIds = [...new Set(descRes.data.map((d) => d.contributor_id))];
+
+  const [versionsRes, contribsRes] = await Promise.all([
+    supabase
+      .from('v_piece_description_versions_published')
+      .select('id, body, version_number, approved_at')
+      .in('id', versionIds),
+    supabase
+      .from('users')
+      .select('id, display_name, contributor_bio_short')
+      .in('id', contributorIds),
+  ]);
+  if (versionsRes.error || !versionsRes.data) return [];
+  if (contribsRes.error || !contribsRes.data) return [];
+
+  const versionById = new Map(versionsRes.data.map((v) => [v.id, v]));
+  const contribById = new Map(contribsRes.data.map((c) => [c.id, c]));
+
+  const rows: PublishedPieceDescription[] = [];
+  for (const d of descRes.data) {
+    if (!d.current_version_id) continue;
+    const version = versionById.get(d.current_version_id);
+    const contributor = contribById.get(d.contributor_id);
+    if (!version || !contributor) continue;
+    rows.push({
+      descriptionId: d.id,
+      versionId: version.id,
+      body: version.body,
+      versionNumber: version.version_number,
+      approvedAt: version.approved_at,
+      contributor: {
+        id: contributor.id,
+        displayName: contributor.display_name,
+        bioShort: contributor.contributor_bio_short ?? null,
+      },
+    });
+  }
+  return rows;
+}

--- a/src/pages/admin/interpretive-schools.astro
+++ b/src/pages/admin/interpretive-schools.astro
@@ -1,0 +1,19 @@
+---
+import AdminPage from '../../components/admin/AdminPage';
+---
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Interpretive schools | Admin | Irregular Pearl</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="robots" content="noindex" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;1,8..60,400;1,8..60,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+</head>
+<style>
+  @import '../../styles/global.css';
+</style>
+<body>
+  <AdminPage initialTab="interpretive-schools" client:load />
+</body>
+</html>

--- a/src/pages/admin/piece-descriptions.astro
+++ b/src/pages/admin/piece-descriptions.astro
@@ -1,0 +1,19 @@
+---
+import AdminPage from '../../components/admin/AdminPage';
+---
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Piece descriptions | Admin | Irregular Pearl</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="robots" content="noindex" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;1,8..60,400;1,8..60,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+</head>
+<style>
+  @import '../../styles/global.css';
+</style>
+<body>
+  <AdminPage initialTab="piece-descriptions" client:load />
+</body>
+</html>


### PR DESCRIPTION
## Summary

Final three steps of [Slice B](./PLAN-contributor-pipeline-slice-b.md) combined into one landing. No new migrations — pure UI on top of the RPC surface from Step 2 and the polymorphic consumer flip from Step 3.

### 5A — generic admin extraction

- **`ContributorContentAdmin.tsx`** — one generic React component parameterized by `subjectTable`. Handles piece + contributor dropdowns, optional name + tempo_cues inputs when the config calls for them, body textarea, send/save buttons, list with status filter, per-row revise / submit / retract, rejection notes inline. Adding a fourth subject type in Slice C is: one SUBJECT_CONFIG row, one astro wrapper, mount in AdminPage — no component duplication.
- **`PerformersNotesAdmin.tsx` deleted;** performers-notes tab now mounts `<ContributorContentAdmin subjectTable="performers_notes" />`.
- SUBJECT_CONFIG extended with admin RPC names + `hasTempoCues` flag.

### New admin surfaces

- **`/admin/interpretive-schools`** + **`/admin/piece-descriptions`** — thin astro wrappers onto `AdminPage` with the right initialTab.
- AdminPage header gains two new tabs: `Schools` and `Descriptions`.

### Piece-page components

- **`src/lib/interpretiveSchools.ts`** + **`src/lib/pieceDescriptions.ts`** — SSR helpers, read via published-versions views, ordered by `approved_at ASC` (**CM6**).
- **`InterpretiveSchools.tsx`** — React island, multi-column grid (2-col ≥768px, 3-col ≥1024px when 3+ schools), single column below. Museum-catalog register: Inter uppercase name mini-header, optional tempo-cues strip in mono, Source Serif 4 body, byline. **CM5**: self-author entry always visible for eligible contributors ("Write a school" / "Add another school"). Edit + Remove on own cards.
- **`SignedPieceDescription.tsx`** — React island, Source Serif 4 essay at 1.72 line-height, byline anchored right. N entries supported though typically one.

### 7A — piece-page wiring

`PiecePageLayout.astro`:
- SSR fetches performers_notes + schools + descriptions in parallel.
- **When a signed piece description exists**, the unsigned `pieces.description` demotes to a `.piece-meta-strip` (Inter italic, 14px, muted) so the signed essay carries the editorial weight.
- **When none exists**, the unsigned copy renders in its original `.piece-intro` paragraph style.
- New sections mounted with anchor ids `#signed-description` and `#interpretive-schools` matching the notification link paths.

### Step 6 — fixtures

`scripts/seed-local-queue.ts` extended to seed:
- All three subject types as **pending drafts** on one piece (bell + queue rendering)
- **Two published schools** + **one published signed description** on a second piece when the catalog has one (piece-page visual QA for the grid + essay treatment, no click-through needed)

### Tests

No new tests — the generic admin's state-machine paths are already covered by the schools/descriptions integration suites from Step 2 (75 tests). Piece-page islands delegate to already-tested RPCs; a component-test layer adds little over e2e verification.

**118 unit + 78 integration = 196 tests pass, 0 fail. Production build clean.**

### Follow-ups (outside this slice)

- **Post-Slice-B cleanup migration:** drop `notifications.performers_note_id` + remove the **CM1** dual-write logic from `_insert_notification` once the pivot has been live in prod for ~1 week.

**This PR closes Slice B.**

## Test plan

- [x] `bun run test` — 118 pass
- [x] `bun run test:integration` — 78 pass
- [x] `bun run build` — clean
- [x] Generic admin handles performers_notes, interpretive_schools, piece_descriptions
- [ ] Manual browser smoke: `/admin/interpretive-schools` creates draft, `/admin/piece-descriptions` creates draft, `/piece/<id>` renders schools grid + signed essay after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)