### PR TITLE
feat(slice-c): step 1 — drop vestigial notifications.performers_note_id

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "astro build && printf '_worker.js\n_routes.json\n' > dist/.assetsignore",
     "preview": "astro preview",
     "check": "astro check",
+    "check:vestigial": "bash scripts/check-no-vestigial-refs.sh",
     "test": "bun test src/lib src/data src/components src/tests",
     "test:integration": "bun --env-file=.env.test test src/integration",
     "test:e2e": "bun test src/e2e",

--- a/scripts/check-no-vestigial-refs.sh
+++ b/scripts/check-no-vestigial-refs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Grep-gate preventing reintroduction of vestigial identifiers that have been
+# fully removed. Run via `bun run check:vestigial`. Exits non-zero with
+# specific locations if any dead identifier reappears in src/ or supabase/
+# (excluding migration files, which preserve history).
+#
+# Vestigial identifiers tracked here:
+#   - performers_note_id  — dropped from notifications in migration
+#                           20260426000000_drop_vestigial_performers_note_id.sql.
+#                           Callers must use (subject_table, subject_id).
+
+set -euo pipefail
+
+# Identifiers to ban. One per line.
+IDENTIFIERS=(
+  'performers_note_id'
+)
+
+EXIT=0
+
+for id in "${IDENTIFIERS[@]}"; do
+  # Search src/ and supabase/functions/ — not supabase/migrations/ (history).
+  HITS=$(grep -rn --include='*.ts' --include='*.tsx' --include='*.astro' \
+    -e "$id" src/ supabase/functions/ 2>/dev/null || true)
+
+  if [ -n "$HITS" ]; then
+    echo "ERROR: vestigial identifier '$id' still referenced in source:" >&2
+    echo "$HITS" >&2
+    echo "" >&2
+    EXIT=1
+  fi
+done
+
+if [ $EXIT -eq 0 ]; then
+  echo "OK: no vestigial identifiers found in src/ or supabase/functions/"
+fi
+
+exit $EXIT

--- a/src/integration/contributorPipeline.rls.test.ts
+++ b/src/integration/contributorPipeline.rls.test.ts
@@ -155,14 +155,16 @@ describe('RLS — notifications', () => {
     const { data: contribView } = await contributor.client
       .from('notifications')
       .select('id, recipient_id')
-      .eq('performers_note_id', draftId!);
+      .eq('subject_table', 'performers_notes')
+      .eq('subject_id', draftId!);
     expect(contribView!.length).toBe(1);
     expect(contribView![0].recipient_id).toBe(contributor.id);
 
     const { data: otherView } = await otherContributor.client
       .from('notifications')
       .select('id')
-      .eq('performers_note_id', draftId!);
+      .eq('subject_table', 'performers_notes')
+      .eq('subject_id', draftId!);
     expect(otherView).toEqual([]);
   });
 });

--- a/src/integration/contributorPipeline.test.ts
+++ b/src/integration/contributorPipeline.test.ts
@@ -39,7 +39,6 @@ afterAll(async () => {
 afterEach(async () => {
   // Each test creates notes against the same piece; clean between tests.
   await admin.from('performers_notes').update({ current_version_id: null }).eq('piece_id', PIECE);
-  await admin.from('notifications').delete().eq('performers_note_id', 'any'); // no-op unless needed
   await admin.from('performers_note_versions').delete().eq('piece_id', PIECE);
   await admin.from('performers_notes').delete().eq('piece_id', PIECE);
 });

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -110,12 +110,16 @@ export async function deleteTestPiece(id: string): Promise<void> {
   await admin.from('pieces').delete().eq('id', id);
 }
 
-// Convenience: count notifications scoped to a note.
+// Convenience: count notifications scoped to a performer's note (polymorphic).
 export async function countNotifications(
   noteId: string,
   opts: { onlyUncleared?: boolean } = {},
 ): Promise<number> {
-  let q = admin.from('notifications').select('id', { count: 'exact', head: true }).eq('performers_note_id', noteId);
+  let q = admin
+    .from('notifications')
+    .select('id', { count: 'exact', head: true })
+    .eq('subject_table', 'performers_notes')
+    .eq('subject_id', noteId);
   if (opts.onlyUncleared) q = q.is('cleared_at', null);
   const { count, error } = await q;
   if (error) throw new Error(`count notifications: ${error.message}`);

--- a/src/integration/sliceBCleanup.test.ts
+++ b/src/integration/sliceBCleanup.test.ts
@@ -1,11 +1,17 @@
-// Slice B Step 1 integration tests.
+// Post-Slice-B cleanup integration tests.
 //
-// Verifies the additive polymorphic pivot, the Slice A dual-write, idempotency
-// on notification inserts, and the per-subject trigger behavior (soft-remove
-// AFTER UPDATE + hard-delete BEFORE DELETE).
+// Verifies Slice B notification polymorphism works after the vestigial narrow
+// FK column is dropped by migration 20260426000000. Covered:
+//   - submit_performers_note routes through _insert_notification helper.
+//   - _clear_notifications_for_note delegates to polymorphic clear.
+//   - Per-subject soft-remove trigger still fires (no cross-subject bleed).
+//   - Hard-delete trigger still removes orphan notifications.
+//   - Idempotency on double-submit is preserved.
+//   - Schema shape: subject_table CHECK + polymorphic columns intact.
 //
-// These are the iron-rule regression tests for Step 1: Slice A must keep
-// working unchanged after the pivot.
+// Previously this file tested the Slice B dual-write window; after the column
+// drop those tests are moot. File now tests that the Slice A→B→C migration
+// path still resolves Slice A flows correctly.
 
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import {
@@ -16,15 +22,15 @@ import {
   deleteTestPiece,
 } from './helpers';
 
-const PIECE = 'slice-b-step1-test';
+const PIECE = 'slice-b-cleanup-test';
 
 let contributor: Awaited<ReturnType<typeof createAuthUser>>;
 let staff: Awaited<ReturnType<typeof createAuthUser>>;
 
 beforeAll(async () => {
-  await createTestPiece(PIECE, 'Slice B Step 1 Test Piece');
-  contributor = await createAuthUser({ isContributor: true, displayName: 'Slice B Contributor' });
-  staff = await createAuthUser({ isStaff: true, displayName: 'Slice B Staff' });
+  await createTestPiece(PIECE, 'Slice B Cleanup Test Piece');
+  contributor = await createAuthUser({ isContributor: true, displayName: 'Cleanup Contributor' });
+  staff = await createAuthUser({ isStaff: true, displayName: 'Cleanup Staff' });
 });
 
 afterAll(async () => {
@@ -53,37 +59,25 @@ async function draftAndSubmit(body: string): Promise<string> {
   return noteId!;
 }
 
-describe('CM1 — Slice A dual-write during vestigial window', () => {
-  test('submit_performers_note populates BOTH performers_note_id AND (subject_table, subject_id)', async () => {
-    const noteId = await draftAndSubmit('Dual-write body.');
+describe('post-drop Slice A flow still works', () => {
+  test('submit_performers_note creates exactly one polymorphic notification', async () => {
+    const noteId = await draftAndSubmit('Post-drop submit body.');
 
     const { data: notif, error } = await admin
       .from('notifications')
-      .select('performers_note_id, subject_table, subject_id, body')
+      .select('subject_table, subject_id, body, type, cleared_at')
       .eq('subject_id', noteId)
       .single();
     expect(error).toBeNull();
-    expect(notif!.performers_note_id).toBe(noteId);
     expect(notif!.subject_table).toBe('performers_notes');
     expect(notif!.subject_id).toBe(noteId);
+    expect(notif!.type).toBe('draft_awaiting_approval');
+    expect(notif!.cleared_at).toBeNull();
     expect(notif!.body).toContain("A draft performer's note on");
   });
 
-  test('Slice A queue query (by performers_note_id) still finds the notification', async () => {
-    const noteId = await draftAndSubmit('Slice A consumer regression.');
-
-    // Simulates the pre-refactor Slice A consumer that reads performers_note_id.
-    const { count, error } = await admin
-      .from('notifications')
-      .select('id', { count: 'exact', head: true })
-      .eq('performers_note_id', noteId)
-      .is('cleared_at', null);
-    expect(error).toBeNull();
-    expect(count).toBe(1);
-  });
-
-  test('New-style queue query (by subject_table + subject_id) finds the same notification', async () => {
-    const noteId = await draftAndSubmit('New-style consumer.');
+  test('polymorphic query finds the submitted notification', async () => {
+    const noteId = await draftAndSubmit('Polymorphic consumer read.');
 
     const { count, error } = await admin
       .from('notifications')
@@ -94,18 +88,29 @@ describe('CM1 — Slice A dual-write during vestigial window', () => {
     expect(error).toBeNull();
     expect(count).toBe(1);
   });
+
+  test('retract clears the notification via delegating helper', async () => {
+    const noteId = await draftAndSubmit('Retract delegation test.');
+
+    await staff.client.rpc('retract_performers_note', { p_note_id: noteId });
+
+    const { count } = await admin
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_id', noteId)
+      .is('cleared_at', null);
+    expect(count).toBe(0);
+  });
 });
 
-describe('CM3 — notification insert idempotency', () => {
+describe('CM3 — notification insert idempotency preserved', () => {
   test('calling submit_performers_note twice produces exactly one live notification', async () => {
     const noteId = await draftAndSubmit('Idempotency test body.');
 
-    // Manually flip status back to draft so we can call submit again (the
-    // state machine rejects double-submit on its own, so we're testing the
-    // ON CONFLICT DO NOTHING path directly by forcing the state).
+    // Flip status back to draft so we can exercise the ON CONFLICT DO NOTHING
+    // path directly (state machine rejects real double-submit).
     await admin.from('performers_notes').update({ status: 'draft' }).eq('id', noteId);
 
-    // Call submit a second time; should not create a duplicate notification.
     const { error } = await staff.client.rpc('submit_performers_note', { p_note_id: noteId });
     expect(error).toBeNull();
 
@@ -120,15 +125,12 @@ describe('CM3 — notification insert idempotency', () => {
   test('after clearing, a re-submit produces a new live notification', async () => {
     const noteId = await draftAndSubmit('Re-submit after clear.');
 
-    // Clear the notification.
     await admin.from('notifications').update({ cleared_at: new Date().toISOString() }).eq('subject_id', noteId);
-
-    // Flip status back to draft and re-submit.
     await admin.from('performers_notes').update({ status: 'draft' }).eq('id', noteId);
+
     const { error } = await staff.client.rpc('submit_performers_note', { p_note_id: noteId });
     expect(error).toBeNull();
 
-    // Now two notifications exist: the cleared one + the new live one.
     const { count: total } = await admin
       .from('notifications')
       .select('id', { count: 'exact', head: true })
@@ -154,15 +156,13 @@ describe('2A — parameterized soft-remove trigger', () => {
       recipient_id: contributor.id,
       type: 'draft_awaiting_approval',
       subject_table: 'interpretive_schools',
-      subject_id: noteId, // intentionally same id to prove the filter discriminates
+      subject_id: noteId,
       body: 'Fake school notification — should NOT be cleared when the note is removed.',
       link_path: '/notifications',
     });
 
-    // Remove the note (status='removed' triggers the soft-remove).
     await admin.from('performers_notes').update({ current_version_id: null, status: 'removed' }).eq('id', noteId);
 
-    // The performers_notes notification should be cleared.
     const { data: pnNotif } = await admin
       .from('notifications')
       .select('cleared_at')
@@ -171,7 +171,6 @@ describe('2A — parameterized soft-remove trigger', () => {
       .single();
     expect(pnNotif!.cleared_at).not.toBeNull();
 
-    // The interpretive_schools notification MUST still be live.
     const { data: schoolNotif } = await admin
       .from('notifications')
       .select('cleared_at')
@@ -180,7 +179,6 @@ describe('2A — parameterized soft-remove trigger', () => {
       .single();
     expect(schoolNotif!.cleared_at).toBeNull();
 
-    // Cleanup.
     await admin.from('notifications').delete().eq('subject_table', 'interpretive_schools').eq('subject_id', noteId);
   });
 });
@@ -189,21 +187,16 @@ describe('CM2 — hard-delete cleanup trigger', () => {
   test('BEFORE DELETE on performers_notes removes orphan notifications', async () => {
     const noteId = await draftAndSubmit('Hard-delete orphan cleanup.');
 
-    // Verify the live notification exists before delete.
     const { count: before } = await admin
       .from('notifications')
       .select('id', { count: 'exact', head: true })
       .eq('subject_id', noteId);
     expect(before).toBe(1);
 
-    // Hard-delete the note (simulates cascade from a piece hard-delete or
-    // test cleanup code). Null the current_version_id first so the composite
-    // FK allows delete, then drop the version rows.
     await admin.from('performers_notes').update({ current_version_id: null, status: 'removed' }).eq('id', noteId);
     await admin.from('performers_note_versions').delete().eq('note_id', noteId);
     await admin.from('performers_notes').delete().eq('id', noteId);
 
-    // The notification should have been removed by the BEFORE DELETE trigger.
     const { count: after } = await admin
       .from('notifications')
       .select('id', { count: 'exact', head: true })
@@ -212,22 +205,18 @@ describe('CM2 — hard-delete cleanup trigger', () => {
   });
 });
 
-describe('schema shape', () => {
-  test('notifications.performers_note_id is now nullable', async () => {
-    // Try to insert a notification with NULL performers_note_id and populated
-    // polymorphic columns (what the new subject-type RPCs will do in Step 2).
+describe('schema shape — post-drop', () => {
+  test('polymorphic notification insert without the dropped narrow FK succeeds', async () => {
     const { error } = await admin.from('notifications').insert({
       recipient_id: contributor.id,
       type: 'draft_awaiting_approval',
-      performers_note_id: null,
       subject_table: 'interpretive_schools',
       subject_id: '00000000-0000-0000-0000-000000000001',
-      body: 'Nullable-perf-note-id test.',
+      body: 'Post-drop polymorphic insert test.',
       link_path: '/notifications',
     });
     expect(error).toBeNull();
 
-    // Cleanup.
     await admin
       .from('notifications')
       .delete()
@@ -238,7 +227,6 @@ describe('schema shape', () => {
     const { error } = await admin.from('notifications').insert({
       recipient_id: contributor.id,
       type: 'draft_awaiting_approval',
-      performers_note_id: null,
       subject_table: 'bogus_table',
       subject_id: '00000000-0000-0000-0000-000000000002',
       body: 'Bogus subject_table test.',
@@ -249,7 +237,6 @@ describe('schema shape', () => {
   });
 
   test('interpretive_schools metadata_updated_by/at columns exist', async () => {
-    // Smoke test: schema introspection via direct insert with metadata fields.
     const { data: school, error } = await admin
       .from('interpretive_schools')
       .insert({
@@ -264,7 +251,6 @@ describe('schema shape', () => {
     expect(school!.metadata_updated_by).toBeNull();
     expect(school!.metadata_updated_at).toBeNull();
 
-    // Cleanup.
     await admin.from('interpretive_schools').delete().eq('id', school!.id);
   });
 

--- a/supabase/migrations/20260426000000_drop_vestigial_performers_note_id.sql
+++ b/supabase/migrations/20260426000000_drop_vestigial_performers_note_id.sql
@@ -1,0 +1,200 @@
+-- Post-Slice-B cleanup: drop vestigial notifications.performers_note_id.
+--
+-- Slice B's polymorphic notifications pivot (20260421000000) added
+-- (subject_table, subject_id) alongside the narrow FK and kept
+-- performers_note_id vestigial with dual-write from Slice A's submit RPC.
+-- Consumers flipped to the polymorphic pair in Slice B Step 3
+-- (20260422000000). The narrow FK has been load-bearing only on backfilled
+-- pre-pivot rows that already have (subject_table, subject_id) populated.
+--
+-- This migration finishes the pivot:
+--   1. Rewrite _insert_notification to drop the dual-write branch.
+--   2. Rewrite _clear_notifications_for to drop the narrow-FK OR predicate.
+--   3. Rewrite _clear_notifications_for_note as a thin delegate to the
+--      polymorphic _clear_notifications_for so Slice A callers need no
+--      changes (retract/reject/approve/remove still call it).
+--   4. Rewrite submit_performers_note to route through _insert_notification
+--      instead of its pre-pivot direct INSERT with performers_note_id.
+--   5. Verify no function body still references performers_note_id.
+--   6. Drop the column.
+--
+-- Runs in a single transaction. The guard in step 5 raises and rolls back
+-- if any function was missed.
+--
+-- See PLAN-contributor-pipeline-slice-c.md §2.1 for the ordering rationale.
+
+begin;
+
+-- ============================================
+-- Step 1: Rewrite _insert_notification — drop dual-write.
+-- ============================================
+
+create or replace function public._insert_notification(
+  p_recipient_id uuid,
+  p_subject_table text,
+  p_subject_id uuid,
+  p_body text,
+  p_link_path text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_id uuid;
+begin
+  insert into public.notifications (
+    recipient_id, type, subject_table, subject_id, body, link_path
+  )
+  values (
+    p_recipient_id, 'draft_awaiting_approval',
+    p_subject_table, p_subject_id, p_body, p_link_path
+  )
+  on conflict (subject_table, subject_id, type) where cleared_at is null
+  do nothing
+  returning id into v_id;
+
+  if v_id is null then
+    select id into v_id
+      from public.notifications
+      where subject_table = p_subject_table
+        and subject_id = p_subject_id
+        and type = 'draft_awaiting_approval'
+        and cleared_at is null
+      limit 1;
+  end if;
+
+  return v_id;
+end;
+$$;
+
+-- ============================================
+-- Step 2: Rewrite _clear_notifications_for — drop narrow-FK predicate.
+-- ============================================
+
+create or replace function public._clear_notifications_for(
+  p_subject_table text,
+  p_subject_id uuid
+)
+  returns void
+  language sql
+  security definer
+  set search_path = public
+as $$
+  update public.notifications
+    set cleared_at = now()
+    where subject_table = p_subject_table
+      and subject_id = p_subject_id
+      and cleared_at is null;
+$$;
+
+-- ============================================
+-- Step 3: Rewrite _clear_notifications_for_note — delegate to polymorphic.
+-- ============================================
+--
+-- Keeps Slice A callers (retract_performers_note, reject_performers_note,
+-- approve_performers_note, remove_performers_note) working unchanged while
+-- removing the narrow-FK read path.
+
+create or replace function public._clear_notifications_for_note(p_note_id uuid)
+  returns void
+  language sql
+  security definer
+  set search_path = public
+as $$
+  update public.notifications
+    set cleared_at = now()
+    where subject_table = 'performers_notes'
+      and subject_id = p_note_id
+      and cleared_at is null;
+$$;
+
+-- ============================================
+-- Step 4: Rewrite submit_performers_note — route through _insert_notification.
+-- ============================================
+--
+-- Slice A's original direct INSERT with performers_note_id is replaced by
+-- a call to the polymorphic helper, matching the pattern Slice B submit RPCs
+-- already use. Preserves the state-machine guards and body-line format.
+
+create or replace function public.submit_performers_note(
+  p_note_id uuid
+)
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_staff_id uuid := auth.uid();
+  v_piece_id text;
+  v_piece_title text;
+  v_contributor_id uuid;
+  v_status draft_status;
+begin
+  perform public._require_staff();
+
+  select n.piece_id, n.contributor_id, n.status, p.title
+    into v_piece_id, v_contributor_id, v_status, v_piece_title
+    from public.performers_notes n
+    join public.pieces p on p.id = n.piece_id
+    where n.id = p_note_id;
+
+  if not found then
+    raise exception 'note not found';
+  end if;
+  if v_status <> 'draft' then
+    raise exception 'can only submit a draft (current status: %)', v_status;
+  end if;
+
+  update public.performers_notes
+    set status = 'awaiting_contributor_approval',
+        submitted_by = v_staff_id
+    where id = p_note_id;
+
+  perform public._insert_notification(
+    v_contributor_id,
+    'performers_notes',
+    p_note_id,
+    format('A draft performer''s note on %s is ready for your review.', v_piece_title),
+    '/notifications'
+  );
+end;
+$$;
+
+-- ============================================
+-- Step 5: Verify no function body still references performers_note_id.
+-- ============================================
+--
+-- Runs before the column drop so we roll back cleanly if any function was
+-- missed. If this raises, examine pg_proc WHERE prosrc LIKE '%performers_note_id%'
+-- to find the stragglers.
+
+do $$
+declare
+  _count integer;
+  _culprits text;
+begin
+  select count(*), string_agg(proname, ', ')
+    into _count, _culprits
+    from pg_proc
+    where pronamespace = (select oid from pg_namespace where nspname = 'public')
+      and prosrc like '%performers_note_id%';
+
+  if _count > 0 then
+    raise exception
+      'Refusing to drop notifications.performers_note_id: % function(s) still reference it (%)',
+      _count, _culprits;
+  end if;
+end
+$$;
+
+-- ============================================
+-- Step 6: Drop the column.
+-- ============================================
+
+alter table public.notifications
+  drop column performers_note_id;
+
+commit;


### PR DESCRIPTION
## Summary

First step of [Slice C rollout](https://github.com/jspkm/irregular-pearl/pull/47) — finishes the Slice B polymorphic pivot by dropping the narrow FK that was kept load-bearing during the dual-write window.

**Prerequisite per plan §10:** Slice B in production ≥1 week live traffic. Override accepted; the dual-write has populated both columns since Slice B shipped, so the drop is safe at any point post-merge.

## What changed

### Migration 20260426000000 — atomic ordered cleanup

Single transaction, order matters (dropping the column first would break RPCs still reading it):

1. **Rewrite `_insert_notification`** — drop dual-write branch. Inserts use polymorphic `(subject_table, subject_id)` only.
2. **Rewrite `_clear_notifications_for`** — drop narrow-FK OR predicate.
3. **Rewrite `_clear_notifications_for_note`** as a thin delegate to the polymorphic clear. Keeps Slice A callers (retract/reject/approve/remove) working unchanged.
4. **Rewrite `submit_performers_note`** — replace direct INSERT with narrow-FK param with a call through `_insert_notification`, matching the Slice B pattern.
5. **Guard block** — scans `pg_proc` for any function body still referencing the column; raises + rolls back if a straggler is found.
6. **Drop the column.**

### App-layer cleanup

- `src/integration/helpers.ts` `countNotifications` — polymorphic query.
- `src/integration/contributorPipeline.rls.test.ts` — queries updated.
- `src/integration/contributorPipeline.test.ts` — stale cleanup line removed.
- `src/integration/sliceBStep1.test.ts` → renamed to `sliceBCleanup.test.ts`. Dual-write tests removed, post-drop regression coverage retained + expanded (submit routing, retract delegation, idempotency, soft-remove, hard-delete, schema CHECK).

### CI grep gate

New `scripts/check-no-vestigial-refs.sh` + `bun run check:vestigial`. Catches reintroduction of dead identifiers in `src/` and `supabase/functions/`. Migration files are exempt (they preserve history).

## Test plan

- [x] `supabase db reset` — all migrations apply clean including `20260426000000`
- [x] `bun run test:integration` — 78/78 pass (includes new `sliceBCleanup.test.ts` suite)
- [x] `bun run test` — 118/118 unit pass
- [x] `bun run check:vestigial` — no hits in source
- [ ] Verify in production: migration applies clean against live DB with existing Slice B data
- [ ] Smoke test in production: submit → approve flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)