### PR TITLE
ci: auto-apply supabase migrations on push to main

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,84 @@
+name: Supabase Migrations
+
+# Applies new migrations to the linked Supabase project on every push to main
+# that touches supabase/migrations/. Idempotent — existing migrations are
+# skipped via the schema_migrations table the CLI maintains.
+#
+# Manual trigger available via workflow_dispatch when a one-off push is needed
+# (e.g. replaying after a rollback, or catching up after disabling this
+# workflow).
+#
+# Required repo secrets (two new; project ref derived from existing SUPABASE_URL):
+#   SUPABASE_ACCESS_TOKEN   Personal access token (starts with `sbp_`), create
+#                           at https://supabase.com/dashboard/account/tokens.
+#                           Different from SUPABASE_SERVICE_ROLE_KEY — this
+#                           auths the CLI against the Supabase management API,
+#                           not the project runtime.
+#   SUPABASE_DB_PASSWORD    Postgres password for the linked project. From
+#                           Dashboard → Project Settings → Database.
+# Reused from existing workflows:
+#   SUPABASE_URL            `https://<ref>.supabase.co`. Project ref is
+#                           extracted from the subdomain.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+      - '.github/workflows/supabase-migrations.yml'
+  workflow_dispatch:
+
+concurrency:
+  # Only one migration run at a time; queue the rest.
+  group: supabase-migrations
+  cancel-in-progress: false
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Derive project ref from SUPABASE_URL
+        id: ref
+        run: |
+          URL="${{ secrets.SUPABASE_URL }}"
+          # Expect https://<ref>.supabase.co → strip scheme + domain suffix.
+          REF=$(echo "$URL" | sed -E 's|https?://||; s|\.supabase\.co.*||')
+          if [ -z "$REF" ]; then
+            echo "::error::Could not derive project ref from SUPABASE_URL ($URL)"
+            exit 1
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          # Don't print the full ref in logs — mask it.
+          echo "::add-mask::$REF"
+
+      - name: Link to project
+        run: supabase link --project-ref "${{ steps.ref.outputs.ref }}"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Push migrations
+        # `supabase db push` applies only migrations not already recorded in
+        # the project's schema_migrations table. Idempotent; safe on re-runs.
+        run: supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Migration push summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: \`${GITHUB_SHA::8}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Result: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Closes the "migrations don't auto-deploy" gap. New workflow `.github/workflows/supabase-migrations.yml` runs `supabase db push` on every push to `main` that touches `supabase/migrations/`.

Matches project memory "always run migration and deploy — don't leave DB migrations or deploys as manual steps."

## Secrets required before merging

Your existing `SUPABASE_URL` secret gets reused — the workflow extracts the project ref from its subdomain. Only **two new** secrets to add:

| Name | Value source |
|------|-------------|
| `SUPABASE_ACCESS_TOKEN` | [supabase.com/dashboard/account/tokens](https://supabase.com/dashboard/account/tokens) — "Generate new token". Starts with `sbp_`. **Different** from `SUPABASE_SERVICE_ROLE_KEY` (that's runtime auth; this is management-API auth). |
| `SUPABASE_DB_PASSWORD` | Dashboard → Project Settings → Database → Database password. The Postgres password set when you created the project. |

To add: Repo Settings → Secrets and variables → Actions → New repository secret.

## How it works

- Triggers: push to `main` touching `supabase/migrations/**` OR `workflow_dispatch` (manual).
- Steps: derive project ref from `SUPABASE_URL` subdomain → install CLI → `supabase link` → `supabase db push`.
- Idempotent: `supabase db push` skips migrations already in `schema_migrations`.
- Concurrency-guarded: two pushes queue instead of race.
- Project ref is masked in logs.

## Catch-up after merge

Pending migrations (in PRs [#48](https://github.com/jspkm/irregular-pearl/pull/48) + [#49](https://github.com/jspkm/irregular-pearl/pull/49)) won't auto-apply until those PRs land. Two options after this workflow merges:

**Option A — local one-off:**
```bash
supabase db push
```

**Option B — trigger via Actions UI:** workflow_dispatch button on the Supabase Migrations workflow page.

From then on, merging PRs #48 and #49 triggers the workflow automatically.

## Test plan
- [ ] Add `SUPABASE_ACCESS_TOKEN` + `SUPABASE_DB_PASSWORD` in repo settings
- [ ] Merge this PR
- [ ] Trigger workflow manually once (catches up pending migrations)
- [ ] Verify via Dashboard → Database → Tables that new migrations appear in `schema_migrations`
- [ ] Re-run `bun run supabase/seed.ts` — movements seed succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)