### PR TITLE
feat(slice-c): step 2 — materialize movements as first-class entity

### DIFF
--- a/src/integration/movements.test.ts
+++ b/src/integration/movements.test.ts
@@ -1,0 +1,223 @@
+// Slice C Step 2 integration tests: movements table schema + behavior.
+//
+// Step 2 ships schema only; wiki-edit RPCs (update_movement, revert_movement,
+// fetch_movement_history) land in Step 3. Actual catalog data is populated
+// via `bun run supabase/seed.ts` post-migration — these tests don't depend
+// on seeded data and use synthetic test pieces.
+//
+// Covered:
+//   - Composite FK on current_version_id rejects cross-movement pairs.
+//   - unique(piece_id, ordinal) rejects duplicates.
+//   - name length CHECK.
+//   - authored_by nullable (initial seed) vs non-null (user wiki edit).
+//   - RLS grants anon + authenticated public select on both tables.
+//   - Cascade: delete piece → movements + movement_versions cascade.
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { admin, createTestPiece, deleteTestPiece } from './helpers';
+import { createClient } from '@supabase/supabase-js';
+
+const ANON = createClient(
+  process.env.PUBLIC_SUPABASE_URL ?? 'http://127.0.0.1:54321',
+  process.env.PUBLIC_SUPABASE_ANON_KEY ?? '',
+);
+
+const TEST_PIECE = 'movements-test-piece';
+
+beforeAll(async () => {
+  await createTestPiece(TEST_PIECE, 'Movements Test Piece');
+});
+
+afterAll(async () => {
+  await deleteTestPiece(TEST_PIECE);
+});
+
+afterEach(async () => {
+  // Between tests, clear any movement rows created under the test piece.
+  // Null current_version_id first so FK allows the version delete.
+  await admin.from('movements').update({ current_version_id: null }).eq('piece_id', TEST_PIECE);
+  await admin.from('movement_versions').delete().eq('piece_id', TEST_PIECE);
+  await admin.from('movements').delete().eq('piece_id', TEST_PIECE);
+});
+
+describe('schema shape', () => {
+  test('composite FK rejects cross-movement current_version_id', async () => {
+    const { data: m1, error: e1 } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 10, name: 'Alpha' })
+      .select('id')
+      .single();
+    expect(e1).toBeNull();
+
+    const { data: m2, error: e2 } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 11, name: 'Beta' })
+      .select('id')
+      .single();
+    expect(e2).toBeNull();
+
+    const { data: v1, error: e3 } = await admin
+      .from('movement_versions')
+      .insert({
+        movement_id: m1!.id,
+        piece_id: TEST_PIECE,
+        ordinal: 10,
+        name: 'Alpha',
+        version_number: 1,
+        authored_by: null,
+      })
+      .select('id')
+      .single();
+    expect(e3).toBeNull();
+
+    // Try to point m2.current_version_id at v1 (which belongs to m1).
+    // Composite FK should reject.
+    const { error: badErr } = await admin
+      .from('movements')
+      .update({ current_version_id: v1!.id })
+      .eq('id', m2!.id);
+    expect(badErr).not.toBeNull();
+    expect(badErr!.message).toMatch(/fk_movements_current_version_matches|foreign key/i);
+  });
+
+  test('unique(piece_id, ordinal) rejects duplicates', async () => {
+    const { error: e1 } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 20, name: 'First' });
+    expect(e1).toBeNull();
+
+    const { error: e2 } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 20, name: 'Duplicate' });
+    expect(e2).not.toBeNull();
+    expect(e2!.message).toMatch(/duplicate key|unique/i);
+  });
+
+  test('name length CHECK rejects empty + over-length names', async () => {
+    const { error: tooShort } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 30, name: '' });
+    expect(tooShort).not.toBeNull();
+
+    const { error: tooLong } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 31, name: 'x'.repeat(201) });
+    expect(tooLong).not.toBeNull();
+  });
+
+  test('authored_by is nullable (seed marker)', async () => {
+    const { data: m, error: mErr } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 40, name: 'Seed-authorship test' })
+      .select('id')
+      .single();
+    expect(mErr).toBeNull();
+
+    const { data: v, error: vErr } = await admin
+      .from('movement_versions')
+      .insert({
+        movement_id: m!.id,
+        piece_id: TEST_PIECE,
+        ordinal: 40,
+        name: 'Seed-authorship test',
+        version_number: 1,
+        authored_by: null,
+        edit_summary: 'initial seed from src/data/seed.ts',
+      })
+      .select('authored_by, edit_summary')
+      .single();
+    expect(vErr).toBeNull();
+    expect(v!.authored_by).toBeNull();
+    expect(v!.edit_summary).toBe('initial seed from src/data/seed.ts');
+  });
+});
+
+describe('RLS — public select works for anon + authenticated', () => {
+  test('anon client can read movements', async () => {
+    // Create a movement via admin, then read via anon.
+    const { data: m } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 50, name: 'Anon-readable' })
+      .select('id')
+      .single();
+
+    const { data, error } = await ANON
+      .from('movements')
+      .select('id, name')
+      .eq('id', m!.id)
+      .single();
+    expect(error).toBeNull();
+    expect(data!.name).toBe('Anon-readable');
+  });
+
+  test('anon client can read movement_versions', async () => {
+    const { data: m } = await admin
+      .from('movements')
+      .insert({ piece_id: TEST_PIECE, ordinal: 51, name: 'Anon-version-readable' })
+      .select('id')
+      .single();
+
+    const { data: v } = await admin
+      .from('movement_versions')
+      .insert({
+        movement_id: m!.id,
+        piece_id: TEST_PIECE,
+        ordinal: 51,
+        name: 'Anon-version-readable',
+        version_number: 1,
+        authored_by: null,
+      })
+      .select('id')
+      .single();
+
+    const { data, error } = await ANON
+      .from('movement_versions')
+      .select('id, name, version_number')
+      .eq('id', v!.id)
+      .single();
+    expect(error).toBeNull();
+    expect(data!.name).toBe('Anon-version-readable');
+    expect(data!.version_number).toBe(1);
+  });
+});
+
+describe('cascade behavior', () => {
+  test('deleting a piece cascades to movements and movement_versions', async () => {
+    const cascadePieceId = 'movements-cascade-test';
+    await createTestPiece(cascadePieceId, 'Cascade Test');
+
+    const { data: m, error: mErr } = await admin
+      .from('movements')
+      .insert({ piece_id: cascadePieceId, ordinal: 1, name: 'Only' })
+      .select('id')
+      .single();
+    expect(mErr).toBeNull();
+
+    const { error: vErr } = await admin
+      .from('movement_versions')
+      .insert({
+        movement_id: m!.id,
+        piece_id: cascadePieceId,
+        ordinal: 1,
+        name: 'Only',
+        version_number: 1,
+        authored_by: null,
+      });
+    expect(vErr).toBeNull();
+
+    // Delete the piece. Cascade should drop the movement + version.
+    await admin.from('pieces').delete().eq('id', cascadePieceId);
+
+    const { count: mCount } = await admin
+      .from('movements')
+      .select('id', { count: 'exact', head: true })
+      .eq('piece_id', cascadePieceId);
+    expect(mCount).toBe(0);
+
+    const { count: vCount } = await admin
+      .from('movement_versions')
+      .select('id', { count: 'exact', head: true })
+      .eq('piece_id', cascadePieceId);
+    expect(vCount).toBe(0);
+  });
+});

--- a/src/lib/movements.ts
+++ b/src/lib/movements.ts
@@ -1,0 +1,175 @@
+// Helpers for reading piece movements. Movements are wiki-edit content
+// (any authenticated user can update via the update_movement RPC landing in
+// Step 3). RLS grants public select on both `movements` and
+// `movement_versions`, so this helper works for anon + authenticated alike.
+//
+// The current row in `movements` always reflects the latest version via
+// the composite FK on current_version_id. Reading from the base table is
+// fine for the common "show current state" case; the versions table is
+// only needed for history + revert.
+
+import { supabase, hasSupabase } from './supabase';
+
+export interface Movement {
+  id: string;
+  pieceId: string;
+  ordinal: number;
+  name: string;
+  tempoIndication: string | null;
+  keySignature: string | null;
+  meter: string | null;
+  currentVersionId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MovementVersion {
+  id: string;
+  movementId: string;
+  pieceId: string;
+  ordinal: number;
+  name: string;
+  tempoIndication: string | null;
+  keySignature: string | null;
+  meter: string | null;
+  versionNumber: number;
+  authoredBy: string;
+  createdAt: string;
+  editSummary: string | null;
+  revertedFromVersionId: string | null;
+}
+
+/**
+ * Fetch all movements for a piece, ordered by ordinal ASC.
+ * Returns an empty array if the piece has no movements (synthetic fallback)
+ * or if Supabase isn't configured.
+ */
+export async function fetchMovementsForPiece(pieceId: string): Promise<Movement[]> {
+  if (!hasSupabase) return [];
+
+  const { data, error } = await supabase
+    .from('movements')
+    .select(
+      'id, piece_id, ordinal, name, tempo_indication, key_signature, meter, current_version_id, created_at, updated_at',
+    )
+    .eq('piece_id', pieceId)
+    .order('ordinal', { ascending: true });
+
+  if (error) {
+    console.error('fetchMovementsForPiece', error);
+    return [];
+  }
+
+  return (data ?? []).map(rowToMovement);
+}
+
+/**
+ * Fetch a single movement by id.
+ */
+export async function fetchMovement(movementId: string): Promise<Movement | null> {
+  if (!hasSupabase) return null;
+
+  const { data, error } = await supabase
+    .from('movements')
+    .select(
+      'id, piece_id, ordinal, name, tempo_indication, key_signature, meter, current_version_id, created_at, updated_at',
+    )
+    .eq('id', movementId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('fetchMovement', error);
+    return null;
+  }
+
+  return data ? rowToMovement(data) : null;
+}
+
+/**
+ * Fetch the full version history for a movement, most recent first.
+ * Used by the history modal (landing in Step 3).
+ */
+export async function fetchMovementHistory(movementId: string): Promise<MovementVersion[]> {
+  if (!hasSupabase) return [];
+
+  const { data, error } = await supabase
+    .from('movement_versions')
+    .select(
+      'id, movement_id, piece_id, ordinal, name, tempo_indication, key_signature, meter, version_number, authored_by, created_at, edit_summary, reverted_from_version_id',
+    )
+    .eq('movement_id', movementId)
+    .order('version_number', { ascending: false });
+
+  if (error) {
+    console.error('fetchMovementHistory', error);
+    return [];
+  }
+
+  return (data ?? []).map(rowToMovementVersion);
+}
+
+// ============================================================================
+// Row mappers — DB snake_case → TS camelCase
+// ============================================================================
+
+type MovementRow = {
+  id: string;
+  piece_id: string;
+  ordinal: number;
+  name: string;
+  tempo_indication: string | null;
+  key_signature: string | null;
+  meter: string | null;
+  current_version_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function rowToMovement(row: MovementRow): Movement {
+  return {
+    id: row.id,
+    pieceId: row.piece_id,
+    ordinal: row.ordinal,
+    name: row.name,
+    tempoIndication: row.tempo_indication,
+    keySignature: row.key_signature,
+    meter: row.meter,
+    currentVersionId: row.current_version_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+type MovementVersionRow = {
+  id: string;
+  movement_id: string;
+  piece_id: string;
+  ordinal: number;
+  name: string;
+  tempo_indication: string | null;
+  key_signature: string | null;
+  meter: string | null;
+  version_number: number;
+  authored_by: string;
+  created_at: string;
+  edit_summary: string | null;
+  reverted_from_version_id: string | null;
+};
+
+function rowToMovementVersion(row: MovementVersionRow): MovementVersion {
+  return {
+    id: row.id,
+    movementId: row.movement_id,
+    pieceId: row.piece_id,
+    ordinal: row.ordinal,
+    name: row.name,
+    tempoIndication: row.tempo_indication,
+    keySignature: row.key_signature,
+    meter: row.meter,
+    versionNumber: row.version_number,
+    authoredBy: row.authored_by,
+    createdAt: row.created_at,
+    editSummary: row.edit_summary,
+    revertedFromVersionId: row.reverted_from_version_id,
+  };
+}

--- a/supabase/migrations/20260427000000_movements_table.sql
+++ b/supabase/migrations/20260427000000_movements_table.sql
@@ -1,0 +1,107 @@
+-- Slice C Step 2: materialize movements as first-class Postgres entity.
+--
+-- Until now, each piece carried its movements as an inline array in
+-- src/data/seed.ts — never persisted to the DB. Slice C introduces
+-- landmarks, which need a stable movement_id FK; that forces movements
+-- to exist as rows.
+--
+-- Governance model (per PLAN-contributor-pipeline-slice-c.md §1.4):
+--   Movements are wiki-edit content. Any authenticated user can update a
+--   movement via the update_movement RPC (landing in Step 3). Every edit
+--   writes a new movement_versions row; revert creates another version
+--   pointing back. No approval queue, no byline enforcement. Initial seed
+--   versions have authored_by = NULL (rendered as "Seed data" in the UI).
+--
+-- This migration creates the SCHEMA ONLY. Population happens via
+-- supabase/seed.ts, consistent with how pieces / editions / external_links
+-- already work — seed.ts is the authoritative source for curated catalog
+-- data. Running `bun run supabase/seed.ts` after `supabase db reset` seeds
+-- pieces THEN movements THEN versions in the correct order.
+--
+-- Eng-review open question on "seed from seed.ts vs pieces.movements jsonb":
+-- resolved toward seed.ts as source of truth. Drift detection for any
+-- piece lacking a movement row is an integration test (seed-time check),
+-- not a migration-time check.
+
+begin;
+
+-- ============================================
+-- movements — the editable entity.
+-- ============================================
+--
+-- `meter` extends plan §2.3 (name, tempo_indication, key_signature) because
+-- src/data/seed.ts already carries a meter per movement. Persisting it keeps
+-- editorial data.
+
+create table public.movements (
+  id uuid primary key default gen_random_uuid(),
+  piece_id text not null references public.pieces(id) on delete cascade,
+  ordinal smallint not null,
+  name text not null,
+  tempo_indication text,
+  key_signature text,
+  meter text,
+  current_version_id uuid,  -- composite FK wired after movement_versions exists
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (piece_id, ordinal),
+  check (char_length(name) between 1 and 200)
+);
+
+create index ix_movements_piece_ordinal on public.movements (piece_id, ordinal);
+
+-- ============================================
+-- movement_versions — append-only history.
+-- ============================================
+
+create table public.movement_versions (
+  id uuid primary key default gen_random_uuid(),
+  movement_id uuid not null references public.movements(id) on delete cascade,
+  piece_id text not null,
+  ordinal smallint not null,
+  name text not null,
+  tempo_indication text,
+  key_signature text,
+  meter text,
+  version_number integer not null,
+  authored_by uuid references public.users(id), -- null = initial seed; non-null for user wiki edits
+  created_at timestamptz not null default now(),
+  edit_summary text,
+  reverted_from_version_id uuid references public.movement_versions(id),
+  unique (movement_id, version_number),
+  unique (movement_id, id)  -- composite FK target
+);
+
+create index ix_movement_versions_movement_version
+  on public.movement_versions (movement_id, version_number desc);
+
+-- Composite FK: current_version_id must belong to the same movement.
+alter table public.movements
+  add constraint fk_movements_current_version_matches
+  foreign key (id, current_version_id)
+  references public.movement_versions (movement_id, id)
+  deferrable initially deferred;
+
+-- ============================================
+-- RLS — both tables publicly readable.
+-- ============================================
+
+alter table public.movements enable row level security;
+alter table public.movement_versions enable row level security;
+
+create policy movements_select_public
+  on public.movements
+  for select
+  to anon, authenticated
+  using (true);
+
+create policy movement_versions_select_public
+  on public.movement_versions
+  for select
+  to anon, authenticated
+  using (true);
+
+-- Mutations go through Step 3 RPCs (update_movement, revert_movement),
+-- which use security-definer. No direct client insert/update/delete policies.
+
+commit;

--- a/supabase/seed.ts
+++ b/supabase/seed.ts
@@ -18,6 +18,20 @@ const supabase = createClient(url, serviceKey);
 async function seed() {
   console.log(`Seeding ${seedPieces.length} pieces...`);
 
+  // Detect whether the movements table exists (Slice C Step 2). If it doesn't,
+  // skip movement seeding silently so the rest of the seed still works against
+  // pre-Step-2 databases.
+  const { error: movementsProbeErr } = await supabase
+    .from('movements')
+    .select('id', { count: 'exact', head: true })
+    .limit(1);
+  const hasMovements = !movementsProbeErr;
+  if (!hasMovements) {
+    console.log(
+      '  (movements table not found — skipping movement seeding. Apply migration 20260427000000 to enable.)',
+    );
+  }
+
   for (const piece of seedPieces) {
     // Insert piece
     const { error: pieceError } = await supabase
@@ -73,6 +87,80 @@ async function seed() {
 
       if (error) {
         console.error(`    Failed to insert link "${link.label}":`, error.message);
+      }
+    }
+
+    // Insert movements + their initial versions. Slice C Step 2 materialized
+    // movements as first-class Postgres rows; seed.ts remains the source of
+    // truth. Idempotent via unique(piece_id, ordinal) — re-running the seed
+    // skips existing movements instead of duplicating. Skipped entirely if
+    // the movements table doesn't exist yet (pre-Step-2 DB).
+    if (hasMovements && piece.movements && piece.movements.length > 0) {
+      for (let i = 0; i < piece.movements.length; i++) {
+        const mv = piece.movements[i];
+        const ordinal = i + 1;
+
+        // Check whether this (piece, ordinal) already has a movement row.
+        const { data: existing } = await supabase
+          .from('movements')
+          .select('id')
+          .eq('piece_id', piece.id)
+          .eq('ordinal', ordinal)
+          .maybeSingle();
+
+        if (existing) {
+          continue; // already seeded; don't duplicate or overwrite user edits
+        }
+
+        // Insert movement first (current_version_id null — FK is deferrable).
+        const { data: movement, error: mErr } = await supabase
+          .from('movements')
+          .insert({
+            piece_id: piece.id,
+            ordinal,
+            name: mv.name,
+            key_signature: mv.key ?? null,
+            meter: mv.meter ?? null,
+          })
+          .select('id')
+          .single();
+
+        if (mErr || !movement) {
+          console.error(`    Failed to insert movement "${mv.name}":`, mErr?.message);
+          continue;
+        }
+
+        // Insert initial version (authored_by null = seed data).
+        const { data: version, error: vErr } = await supabase
+          .from('movement_versions')
+          .insert({
+            movement_id: movement.id,
+            piece_id: piece.id,
+            ordinal,
+            name: mv.name,
+            key_signature: mv.key ?? null,
+            meter: mv.meter ?? null,
+            version_number: 1,
+            authored_by: null,
+            edit_summary: 'initial seed from src/data/seed.ts',
+          })
+          .select('id')
+          .single();
+
+        if (vErr || !version) {
+          console.error(`    Failed to insert version for "${mv.name}":`, vErr?.message);
+          continue;
+        }
+
+        // Point movement.current_version_id at the newly created version.
+        const { error: uErr } = await supabase
+          .from('movements')
+          .update({ current_version_id: version.id })
+          .eq('id', movement.id);
+
+        if (uErr) {
+          console.error(`    Failed to link current_version for "${mv.name}":`, uErr.message);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Re-land of [#49](https://github.com/jspkm/irregular-pearl/pull/49) against `main` after the stacked-PR collapse. Original #49 was based on Step 1's branch; when Step 1 squash-merged, #49 was marked merged by GitHub but its changes didn't reach main.

Prod DB already has the migration applied (user pushed manually via `supabase db push` after adding the automation secrets). This PR lands the companion code: the migration file in repo history + app-side helpers + tests.

## What's in

### Migration `20260427000000_movements_table.sql`
- `movements` — piece_id FK cascade, ordinal, name, tempo_indication, key_signature, **meter**, current_version_id, composite FK to movement_versions.
- `movement_versions` — append-only, unique(movement_id, version_number), authored_by nullable (NULL = initial seed), edit_summary, reverted_from_version_id.
- RLS: public select on both. Mutations go through Step 3 RPCs.

### `supabase/seed.ts`
Extended to upsert movements + initial versions. Forgiving: detects "movements table not found" upfront and skips that section silently so the seed script still works on pre-Step-2 DBs.

### `src/lib/movements.ts`
`fetchMovementsForPiece`, `fetchMovement`, `fetchMovementHistory` + types. No consumer yet (Step 6 wires landmarks; Step 3 wires the edit UI).

### `src/integration/movements.test.ts`
7 tests: composite FK, uniqueness, CHECK constraints, nullable authored_by, anon RLS read, cascade delete.

## Test plan

- [x] `supabase db reset` clean through all migrations
- [x] `bun run test:integration` — 85/85 pass
- [x] Prod DB already has the movements table + schema (manually pushed)
- [x] Prod seed succeeded (18 pieces → 69 movement rows + 69 versions)
- [ ] Merge → no-op on prod (migration already applied, idempotent) → app code now consistent with DB

## Notes

After merging, the `supabase-migrations.yml` workflow will fire but the migration is already in `schema_migrations`, so it's a no-op. Safe.

Closes the stacked-PR collapse issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)