### PR TITLE
feat(slice-c): step 4 votes + early step 5 stacking + content CRUD

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -22,6 +22,32 @@ Tracked work for Irregular Pearl, organized by component and sorted by priority.
 
 ## Piece page (PRD Tier 1)
 
+### Recordings CRUD UI (wiki-edit)
+
+**What:** Extend `RecordingsList.tsx` with the end-of-row pencil/×/↑/↓ controls and an "+ Add recording" modal. Backing RPCs (`create_external_link`, `update_external_link`, `delete_external_link`, `swap_external_link_ordinals`) already shipped in `20260508000000_external_links_wiki_crud.sql`. Filter rows to the recording subset of link types (`youtube | vimeo | spotify | internet_archive | soundcloud | bandcamp`).
+
+**Why:** Deferred from the Slice-C-Step-4 / wiki-edit push (the parallel PR brought CRUD to Editions + External references). Recordings is next in the same pattern and shares the underlying `external_links` schema + RPCs.
+
+**Context:** `RecordingsList.tsx` currently collapses each recording row and mounts an iframe on expand. Layering CRUD in-place needs care: edit/delete controls should live on the header row (visible when collapsed) and not reach inside the iframe panel. Follow `ExternalRefsList.tsx` for the pattern; reuse the same shared `SignInPrompt` and `ed-ctrls` CSS.
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** None (schema + RPCs shipped)
+
+### Pedagogical arc CRUD UI + piece picker
+
+**What:** Build `PedagogicalArcList.tsx` (two subsections: "Prepare with" and "Natural next") with CRUD affordances per row. Needs a piece-picker autocomplete over `public.pieces` so contributors can select the related piece. Backing schema (`pedagogical_connections` table) and RPCs (`create_pedagogical_connection`, `update_pedagogical_connection`, `delete_pedagogical_connection`, `swap_pedagogical_ordinals`) already shipped in `20260509000000_pedagogical_arc.sql`.
+
+**Why:** Piece page Tier 1 calls for the pedagogical arc. Schema + RPCs landed in the Slice-C-Step-4 / wiki-edit push; UI was deferred because the picker UX deserves its own design pass.
+
+**Context:** Autocomplete matches existing `Autocomplete.tsx` pattern (if it covers pieces) or a new piece-scoped search. Per-row layout: `→ {related_piece.title}` with optional short note line below; reorder within section only (not across prepare/natural-next).
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** None (schema + RPCs shipped)
+
+
+
 ### Redesign piece page per PRD revision 2
 
 **What:** Restructure the piece page into the sections PRD describes: header + difficulty panel, signed performer's notes, structural landmarks with flags and practice notes, interpretive schools grid, editions with passage comparison, recordings around landmark tempi, pedagogical arc.

--- a/src/components/ChangeLog.tsx
+++ b/src/components/ChangeLog.tsx
@@ -96,6 +96,7 @@ function formatUtc(iso: string): string {
 }
 
 function defaultSummary(r: ChangeLogEntry): string {
-  if (r.versionNumber === 1) return 'initial version';
-  return 'edited';
+  if (r.versionNumber === 1) return 'published';
+  if (r.versionNumber != null && r.versionNumber > 1) return 'edited';
+  return 'changed';
 }

--- a/src/components/EditionsList.tsx
+++ b/src/components/EditionsList.tsx
@@ -1,0 +1,395 @@
+// Wiki-edit editions: any signed-in user can add, edit, reorder, soft-delete.
+// Anon users see the affordances; clicking opens a shared sign-in prompt
+// (per memory: edit affordance at end of row, sign-in prompt for anon).
+//
+// Pattern mirrors MovementsList: end-of-row ↑/↓/pencil/× controls, inline
+// "Delete? Yes/No" confirmation, "+ Add edition" modal. Refetches on every
+// mutation so state stays consistent with DB order.
+
+import { useCallback, useState, useEffect, useRef } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+import { useAuth } from '../lib/useAuth';
+import { fetchEditionsForPiece, type Edition } from '../lib/editions';
+import { CHANGELOG_REFRESH_EVENT } from './ChangeLog';
+
+interface Props {
+  pieceId: string;
+  initialEditions: Edition[];
+}
+
+const TYPE_OPTIONS = ['urtext', 'scholarly', 'performer', 'facsimile', 'critical', 'practical'];
+
+type Busy = { kind: 'idle' } | { kind: 'working'; id?: string } | { kind: 'error'; message: string };
+
+export default function EditionsList({ pieceId, initialEditions }: Props) {
+  const { user } = useAuth();
+  const [editions, setEditions] = useState<Edition[]>(initialEditions);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const [signInOpen, setSignInOpen] = useState(false);
+  const [busy, setBusy] = useState<Busy>({ kind: 'idle' });
+
+  const broadcastChangelog = useCallback(() => {
+    window.dispatchEvent(new CustomEvent(CHANGELOG_REFRESH_EVENT, { detail: { pieceId } }));
+  }, [pieceId]);
+
+  const refetch = useCallback(async () => {
+    const next = await fetchEditionsForPiece(pieceId);
+    setEditions(next);
+    broadcastChangelog();
+  }, [pieceId, broadcastChangelog]);
+
+  const requireAuth = useCallback(() => {
+    if (!user) { setSignInOpen(true); return false; }
+    return true;
+  }, [user]);
+
+  const handleSwap = useCallback(async (i: number, dir: 'up' | 'down') => {
+    if (!requireAuth()) return;
+    const j = dir === 'up' ? i - 1 : i + 1;
+    if (j < 0 || j >= editions.length) return;
+    const a = editions[i], b = editions[j];
+    setBusy({ kind: 'working', id: a.id });
+    const { error } = await supabase.rpc('swap_edition_ordinals', { p_id_a: a.id, p_id_b: b.id });
+    if (error) {
+      setBusy({ kind: 'error', message: prettyError(error.message, 'Reorder failed') });
+      return;
+    }
+    await refetch();
+    setBusy({ kind: 'idle' });
+  }, [editions, refetch, requireAuth]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (!requireAuth()) return;
+    setBusy({ kind: 'working', id });
+    const { error } = await supabase.rpc('delete_edition', { p_id: id });
+    if (error) {
+      setBusy({ kind: 'error', message: prettyError(error.message, 'Delete failed') });
+      return;
+    }
+    setConfirmDeleteId(null);
+    await refetch();
+    setBusy({ kind: 'idle' });
+  }, [refetch, requireAuth]);
+
+  return (
+    <>
+      {editions.length === 0 ? (
+        <p className="empty-state">No editions listed yet.</p>
+      ) : (
+        <div className="editions">
+          {editions.map((e, i) => {
+            const isFirst = i === 0;
+            const isLast = i === editions.length - 1;
+            const isConfirming = confirmDeleteId === e.id;
+            const isEditing = editingId === e.id;
+            const rowWorking = busy.kind === 'working' && busy.id === e.id;
+
+            if (isEditing) {
+              return (
+                <EditionEditForm
+                  key={e.id}
+                  initial={e}
+                  busy={rowWorking}
+                  onCancel={() => setEditingId(null)}
+                  onSave={async (fields) => {
+                    setBusy({ kind: 'working', id: e.id });
+                    const { error } = await supabase.rpc('update_edition', {
+                      p_id: e.id,
+                      p_publisher: fields.publisher,
+                      p_editor: fields.editor,
+                      p_year: fields.year,
+                      p_description: fields.description,
+                      p_type: fields.type,
+                      p_url: fields.url,
+                    });
+                    if (error) {
+                      setBusy({ kind: 'error', message: prettyError(error.message, 'Save failed') });
+                      return;
+                    }
+                    setEditingId(null);
+                    await refetch();
+                    setBusy({ kind: 'idle' });
+                  }}
+                />
+              );
+            }
+
+            const openEdition = () => {
+              if (e.url) window.open(e.url, '_blank', 'noopener');
+            };
+            return (
+              <div
+                key={e.id}
+                className={`ed-row ed${e.url ? ' ed-clickable' : ''}`}
+                role={e.url ? 'link' : undefined}
+                tabIndex={e.url ? 0 : undefined}
+                aria-label={e.url ? `Open ${e.publisher}` : undefined}
+                onClick={(ev) => {
+                  if (!e.url) return;
+                  if ((ev.target as HTMLElement).closest('.ed-ctrls, button, a, input, select, textarea')) return;
+                  openEdition();
+                }}
+                onKeyDown={(ev) => {
+                  if (!e.url) return;
+                  if (ev.key === 'Enter' || ev.key === ' ') {
+                    if ((ev.target as HTMLElement).closest('.ed-ctrls, button, a, input, select, textarea')) return;
+                    ev.preventDefault();
+                    openEdition();
+                  }
+                }}
+              >
+                <div className="ed-head">
+                  <h3>{e.publisher}</h3>
+                  <div
+                    className="ed-ctrls"
+                    aria-label={`Controls for ${e.publisher}`}
+                  >
+                  <button type="button" className="ed-ctrl" aria-label={`Move ${e.publisher} up`}
+                    disabled={isFirst || rowWorking} onClick={() => handleSwap(i, 'up')}>
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                      <path d="M4 10l4-4 4 4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                  <button type="button" className="ed-ctrl" aria-label={`Move ${e.publisher} down`}
+                    disabled={isLast || rowWorking} onClick={() => handleSwap(i, 'down')}>
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                      <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                  <button type="button" className="ed-ctrl" aria-label={`Edit ${e.publisher}`}
+                    disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setEditingId(e.id); }}>
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                      <path d="M11.5 2.5l2 2L5 13H3v-2l8.5-8.5z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                  {isConfirming ? (
+                    <span className="ed-confirm" role="alertdialog">
+                      Delete?
+                      <button type="button" className="ed-confirm-yes" onClick={() => handleDelete(e.id)} disabled={rowWorking}>Yes</button>
+                      <button type="button" className="ed-confirm-no" onClick={() => setConfirmDeleteId(null)}>No</button>
+                    </span>
+                  ) : (
+                    <button type="button" className="ed-ctrl ed-ctrl-delete" aria-label={`Delete ${e.publisher}`}
+                      disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setConfirmDeleteId(e.id); }}>
+                      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                        <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                      </svg>
+                    </button>
+                  )}
+                  </div>
+                  {e.type && (
+                    <span className="type-chip">{e.type}</span>
+                  )}
+                </div>
+                <div className="meta">{e.editor}{e.year ? ` · ${e.year}` : ''}</div>
+                {e.description && <p className="desc">{e.description}</p>}
+                {e.url && <span className="ed-external-arrow" aria-hidden="true">↗</span>}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <button type="button" className="mvmt-add" onClick={() => { if (!requireAuth()) return; setAddOpen(true); }}>
+        + Add edition
+      </button>
+
+      {busy.kind === 'error' && (
+        <div className="mvmt-toast" role="alert">
+          {busy.message}
+          <button type="button" className="mvmt-toast-dismiss" onClick={() => setBusy({ kind: 'idle' })}>Dismiss</button>
+        </div>
+      )}
+
+      {signInOpen && <SignInPrompt onClose={() => setSignInOpen(false)} />}
+      {addOpen && (
+        <EditionAddModal
+          pieceId={pieceId}
+          onCancel={() => setAddOpen(false)}
+          onCreated={async () => { setAddOpen(false); await refetch(); }}
+        />
+      )}
+    </>
+  );
+}
+
+// ----------------------------------------------------------------------------
+
+function prettyError(msg: string, fallback: string): string {
+  if (msg.includes('rate limit')) return 'Too many edits — wait a moment.';
+  return `${fallback}: ${msg}`;
+}
+
+function SignInPrompt({ onClose }: { onClose: () => void }) {
+  const handleSignIn = useCallback(async () => {
+    if (!hasSupabase) return;
+    await supabase.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: window.location.href } });
+  }, []);
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', h);
+    return () => document.removeEventListener('keydown', h);
+  }, [onClose]);
+  return (
+    <>
+      <div className="movement-edit-backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="movement-edit-modal movement-edit-signin" role="dialog" aria-modal="true" aria-labelledby="ed-signin-title">
+        <h2 id="ed-signin-title" className="movement-edit-title">Sign in to edit</h2>
+        <p className="movement-edit-signin-body">
+          Editions are wiki-edit — any registered user can add, revise, reorder, or remove them.
+          Sign in or create an account to make your change.
+        </p>
+        <div className="movement-edit-actions">
+          <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="movement-edit-button movement-edit-button-primary" onClick={handleSignIn} autoFocus>
+            Sign in / Register
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// EditForm: inline editor for an existing edition row.
+// AddModal: modal editor for a new edition.
+// Both use the same field set.
+
+interface Fields {
+  publisher: string;
+  editor: string;
+  year: number | null;
+  description: string;
+  type: string | null;
+  url: string | null;
+}
+
+function EditionEditForm({ initial, busy, onCancel, onSave }: {
+  initial: Edition;
+  busy: boolean;
+  onCancel: () => void;
+  onSave: (f: Fields) => void | Promise<void>;
+}) {
+  const [f, setF] = useState<Fields>({
+    publisher: initial.publisher,
+    editor: initial.editor,
+    year: initial.year,
+    description: initial.description,
+    type: initial.type,
+    url: initial.url,
+  });
+  return (
+    <div className="ed ed-editing">
+      <EditionFields fields={f} onChange={setF} />
+      <div className="movement-edit-actions">
+        <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onCancel} disabled={busy}>Cancel</button>
+        <button type="button" className="movement-edit-button movement-edit-button-primary" onClick={() => onSave(f)} disabled={busy}>
+          {busy ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EditionAddModal({ pieceId, onCancel, onCreated }: {
+  pieceId: string;
+  onCancel: () => void;
+  onCreated: () => void | Promise<void>;
+}) {
+  const [f, setF] = useState<Fields>({
+    publisher: '', editor: '', year: null, description: '', type: null, url: null,
+  });
+  const [state, setState] = useState<{ kind: 'idle' } | { kind: 'saving' } | { kind: 'error'; message: string }>({ kind: 'idle' });
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => { if (e.key === 'Escape') onCancel(); };
+    document.addEventListener('keydown', h);
+    return () => document.removeEventListener('keydown', h);
+  }, [onCancel]);
+
+  const save = useCallback(async () => {
+    if (f.publisher.trim().length < 1) { setState({ kind: 'error', message: 'Publisher is required.' }); return; }
+    setState({ kind: 'saving' });
+    const { error } = await supabase.rpc('create_edition', {
+      p_piece_id: pieceId,
+      p_publisher: f.publisher.trim(),
+      p_editor: f.editor.trim() || '',
+      p_year: f.year,
+      p_description: f.description.trim() || '',
+      p_type: f.type || null,
+      p_url: f.url?.trim() || null,
+    });
+    if (error) {
+      setState({ kind: 'error', message: prettyError(error.message, 'Save failed') });
+      return;
+    }
+    await onCreated();
+  }, [f, pieceId, onCreated]);
+
+  return (
+    <>
+      <div className="movement-edit-backdrop" onClick={onCancel} aria-hidden="true" />
+      <div ref={modalRef} className="movement-edit-modal" role="dialog" aria-modal="true" aria-labelledby="ed-add-title">
+        <h2 id="ed-add-title" className="movement-edit-title">Add edition</h2>
+        <EditionFields fields={f} onChange={setF} autoFocusFirst />
+        {state.kind === 'error' && <div className="movement-edit-error" role="alert">{state.message}</div>}
+        <div className="movement-edit-actions">
+          <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onCancel} disabled={state.kind === 'saving'}>Cancel</button>
+          <button type="button" className="movement-edit-button movement-edit-button-primary" onClick={save} disabled={state.kind === 'saving'}>
+            {state.kind === 'saving' ? 'Saving…' : 'Add edition'}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function EditionFields({ fields, onChange, autoFocusFirst }: {
+  fields: Fields;
+  onChange: (f: Fields) => void;
+  autoFocusFirst?: boolean;
+}) {
+  return (
+    <>
+      <label className="movement-edit-field">
+        <span>Publisher</span>
+        <input
+          autoFocus={autoFocusFirst}
+          type="text"
+          value={fields.publisher}
+          onChange={(e) => onChange({ ...fields, publisher: e.target.value })}
+          maxLength={200}
+          required
+        />
+      </label>
+      <div className="movement-edit-row">
+        <label className="movement-edit-field">
+          <span>Editor</span>
+          <input type="text" value={fields.editor} onChange={(e) => onChange({ ...fields, editor: e.target.value })} maxLength={200} />
+        </label>
+        <label className="movement-edit-field">
+          <span>Year</span>
+          <input type="number" value={fields.year ?? ''} onChange={(e) => onChange({ ...fields, year: e.target.value ? Number(e.target.value) : null })} />
+        </label>
+        <label className="movement-edit-field">
+          <span>Type</span>
+          <select value={fields.type ?? ''} onChange={(e) => onChange({ ...fields, type: e.target.value || null })}>
+            <option value="">—</option>
+            {TYPE_OPTIONS.map((t) => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </label>
+      </div>
+      <label className="movement-edit-field">
+        <span>URL (optional)</span>
+        <input type="url" value={fields.url ?? ''} onChange={(e) => onChange({ ...fields, url: e.target.value || null })} placeholder="https://…" />
+      </label>
+      <label className="movement-edit-field">
+        <span>Description (optional)</span>
+        <input type="text" value={fields.description} onChange={(e) => onChange({ ...fields, description: e.target.value })} maxLength={500} />
+      </label>
+    </>
+  );
+}

--- a/src/components/ExternalRefsList.tsx
+++ b/src/components/ExternalRefsList.tsx
@@ -1,0 +1,318 @@
+// Wiki-edit external references. Handles the non-recording external_links
+// types (imslp, wikipedia, …). Same end-of-row control pattern as
+// EditionsList and MovementsList.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+import { useAuth } from '../lib/useAuth';
+import {
+  fetchExternalLinksForPiece,
+  REFERENCE_TYPES,
+  type ExternalLink,
+} from '../lib/externalLinks';
+import { CHANGELOG_REFRESH_EVENT } from './ChangeLog';
+
+interface Props {
+  pieceId: string;
+  initialLinks: ExternalLink[];
+}
+
+type Busy = { kind: 'idle' } | { kind: 'working'; id?: string } | { kind: 'error'; message: string };
+
+export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
+  const { user } = useAuth();
+  const [links, setLinks] = useState<ExternalLink[]>(initialLinks);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const [signInOpen, setSignInOpen] = useState(false);
+  const [busy, setBusy] = useState<Busy>({ kind: 'idle' });
+
+  const broadcastChangelog = useCallback(() => {
+    window.dispatchEvent(new CustomEvent(CHANGELOG_REFRESH_EVENT, { detail: { pieceId } }));
+  }, [pieceId]);
+
+  const refetch = useCallback(async () => {
+    const next = await fetchExternalLinksForPiece(pieceId);
+    setLinks(next.filter((l) => (REFERENCE_TYPES as readonly string[]).includes(l.type)));
+    broadcastChangelog();
+  }, [pieceId, broadcastChangelog]);
+
+  const requireAuth = useCallback(() => {
+    if (!user) { setSignInOpen(true); return false; }
+    return true;
+  }, [user]);
+
+  const handleSwap = useCallback(async (i: number, dir: 'up' | 'down') => {
+    if (!requireAuth()) return;
+    const j = dir === 'up' ? i - 1 : i + 1;
+    if (j < 0 || j >= links.length) return;
+    const a = links[i], b = links[j];
+    setBusy({ kind: 'working', id: a.id });
+    const { error } = await supabase.rpc('swap_external_link_ordinals', { p_id_a: a.id, p_id_b: b.id });
+    if (error) {
+      setBusy({ kind: 'error', message: pretty(error.message, 'Reorder failed') });
+      return;
+    }
+    await refetch();
+    setBusy({ kind: 'idle' });
+  }, [links, refetch, requireAuth]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (!requireAuth()) return;
+    setBusy({ kind: 'working', id });
+    const { error } = await supabase.rpc('delete_external_link', { p_id: id });
+    if (error) {
+      setBusy({ kind: 'error', message: pretty(error.message, 'Delete failed') });
+      return;
+    }
+    setConfirmDeleteId(null);
+    await refetch();
+    setBusy({ kind: 'idle' });
+  }, [refetch, requireAuth]);
+
+  return (
+    <>
+      {links.length === 0 ? (
+        <p className="empty-state">No external references yet.</p>
+      ) : (
+        <ul className="ext-refs">
+          {links.map((l, i) => {
+            const isFirst = i === 0;
+            const isLast = i === links.length - 1;
+            const isConfirming = confirmDeleteId === l.id;
+            const isEditing = editingId === l.id;
+            const rowWorking = busy.kind === 'working' && busy.id === l.id;
+
+            if (isEditing) {
+              return (
+                <li key={l.id} className="ext-ref-editing">
+                  <ExternalLinkEditForm
+                    initial={l}
+                    busy={rowWorking}
+                    onCancel={() => setEditingId(null)}
+                    onSave={async (f) => {
+                      setBusy({ kind: 'working', id: l.id });
+                      const { error } = await supabase.rpc('update_external_link', {
+                        p_id: l.id,
+                        p_type: f.type,
+                        p_url: f.url,
+                        p_label: f.label,
+                      });
+                      if (error) {
+                        setBusy({ kind: 'error', message: pretty(error.message, 'Save failed') });
+                        return;
+                      }
+                      setEditingId(null);
+                      await refetch();
+                      setBusy({ kind: 'idle' });
+                    }}
+                  />
+                </li>
+              );
+            }
+
+            return (
+              <li key={l.id} className="ext-ref-row">
+                <a className="ext-ref" href={l.url} target="_blank" rel="noopener">{l.label}</a>
+                <div className="ed-ctrls" aria-label={`Controls for ${l.label}`}>
+                  <button type="button" className="ed-ctrl" aria-label="Move up"
+                    disabled={isFirst || rowWorking} onClick={() => handleSwap(i, 'up')}>
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                      <path d="M4 10l4-4 4 4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                  <button type="button" className="ed-ctrl" aria-label="Move down"
+                    disabled={isLast || rowWorking} onClick={() => handleSwap(i, 'down')}>
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                      <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                  <button type="button" className="ed-ctrl" aria-label={`Edit ${l.label}`}
+                    disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setEditingId(l.id); }}>
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                      <path d="M11.5 2.5l2 2L5 13H3v-2l8.5-8.5z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                  {isConfirming ? (
+                    <span className="ed-confirm" role="alertdialog">
+                      Delete?
+                      <button type="button" className="ed-confirm-yes" onClick={() => handleDelete(l.id)} disabled={rowWorking}>Yes</button>
+                      <button type="button" className="ed-confirm-no" onClick={() => setConfirmDeleteId(null)}>No</button>
+                    </span>
+                  ) : (
+                    <button type="button" className="ed-ctrl ed-ctrl-delete" aria-label={`Delete ${l.label}`}
+                      disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setConfirmDeleteId(l.id); }}>
+                      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                        <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <button type="button" className="mvmt-add" onClick={() => { if (!requireAuth()) return; setAddOpen(true); }}>
+        + Add reference
+      </button>
+
+      {busy.kind === 'error' && (
+        <div className="mvmt-toast" role="alert">
+          {busy.message}
+          <button type="button" className="mvmt-toast-dismiss" onClick={() => setBusy({ kind: 'idle' })}>Dismiss</button>
+        </div>
+      )}
+
+      {signInOpen && <SignInPrompt onClose={() => setSignInOpen(false)} kind="reference" />}
+      {addOpen && (
+        <ExternalLinkAddModal
+          pieceId={pieceId}
+          onCancel={() => setAddOpen(false)}
+          onCreated={async () => { setAddOpen(false); await refetch(); }}
+        />
+      )}
+    </>
+  );
+}
+
+// ----------------------------------------------------------------------------
+
+function pretty(msg: string, fallback: string): string {
+  if (msg.includes('rate limit')) return 'Too many edits — wait a moment.';
+  return `${fallback}: ${msg}`;
+}
+
+function SignInPrompt({ onClose, kind }: { onClose: () => void; kind: string }) {
+  const handleSignIn = useCallback(async () => {
+    if (!hasSupabase) return;
+    await supabase.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: window.location.href } });
+  }, []);
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', h);
+    return () => document.removeEventListener('keydown', h);
+  }, [onClose]);
+  return (
+    <>
+      <div className="movement-edit-backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="movement-edit-modal movement-edit-signin" role="dialog" aria-modal="true" aria-labelledby="ext-signin-title">
+        <h2 id="ext-signin-title" className="movement-edit-title">Sign in to edit</h2>
+        <p className="movement-edit-signin-body">
+          {kind} entries are wiki-edit — any registered user can add, revise, reorder, or remove them.
+          Sign in or create an account to make your change.
+        </p>
+        <div className="movement-edit-actions">
+          <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="movement-edit-button movement-edit-button-primary" onClick={handleSignIn} autoFocus>
+            Sign in / Register
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+interface Fields { type: string; url: string; label: string }
+
+function ExternalLinkEditForm({ initial, busy, onCancel, onSave }: {
+  initial: ExternalLink;
+  busy: boolean;
+  onCancel: () => void;
+  onSave: (f: Fields) => void | Promise<void>;
+}) {
+  const [f, setF] = useState<Fields>({ type: initial.type, url: initial.url, label: initial.label });
+  return (
+    <div className="ed-editing">
+      <ExternalLinkFields fields={f} onChange={setF} />
+      <div className="movement-edit-actions">
+        <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onCancel} disabled={busy}>Cancel</button>
+        <button type="button" className="movement-edit-button movement-edit-button-primary" onClick={() => onSave(f)} disabled={busy}>
+          {busy ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ExternalLinkAddModal({ pieceId, onCancel, onCreated }: {
+  pieceId: string;
+  onCancel: () => void;
+  onCreated: () => void | Promise<void>;
+}) {
+  const [f, setF] = useState<Fields>({ type: 'imslp', url: '', label: '' });
+  const [state, setState] = useState<{ kind: 'idle' } | { kind: 'saving' } | { kind: 'error'; message: string }>({ kind: 'idle' });
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => { if (e.key === 'Escape') onCancel(); };
+    document.addEventListener('keydown', h);
+    return () => document.removeEventListener('keydown', h);
+  }, [onCancel]);
+
+  const save = useCallback(async () => {
+    if (f.url.trim().length < 1) { setState({ kind: 'error', message: 'URL is required.' }); return; }
+    if (f.label.trim().length < 1) { setState({ kind: 'error', message: 'Label is required.' }); return; }
+    setState({ kind: 'saving' });
+    const { error } = await supabase.rpc('create_external_link', {
+      p_piece_id: pieceId, p_type: f.type, p_url: f.url.trim(), p_label: f.label.trim(),
+    });
+    if (error) {
+      setState({ kind: 'error', message: pretty(error.message, 'Save failed') });
+      return;
+    }
+    await onCreated();
+  }, [f, pieceId, onCreated]);
+
+  return (
+    <>
+      <div className="movement-edit-backdrop" onClick={onCancel} aria-hidden="true" />
+      <div ref={modalRef} className="movement-edit-modal" role="dialog" aria-modal="true" aria-labelledby="ext-add-title">
+        <h2 id="ext-add-title" className="movement-edit-title">Add reference</h2>
+        <ExternalLinkFields fields={f} onChange={setF} autoFocusFirst />
+        {state.kind === 'error' && <div className="movement-edit-error" role="alert">{state.message}</div>}
+        <div className="movement-edit-actions">
+          <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onCancel} disabled={state.kind === 'saving'}>Cancel</button>
+          <button type="button" className="movement-edit-button movement-edit-button-primary" onClick={save} disabled={state.kind === 'saving'}>
+            {state.kind === 'saving' ? 'Saving…' : 'Add reference'}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ExternalLinkFields({ fields, onChange, autoFocusFirst }: {
+  fields: Fields;
+  onChange: (f: Fields) => void;
+  autoFocusFirst?: boolean;
+}) {
+  return (
+    <>
+      <label className="movement-edit-field">
+        <span>Type</span>
+        <select value={fields.type} onChange={(e) => onChange({ ...fields, type: e.target.value })}>
+          {REFERENCE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </label>
+      <label className="movement-edit-field">
+        <span>Label</span>
+        <input
+          autoFocus={autoFocusFirst}
+          type="text"
+          value={fields.label}
+          onChange={(e) => onChange({ ...fields, label: e.target.value })}
+          maxLength={200}
+          required
+          placeholder="e.g. IMSLP — 12 editions available"
+        />
+      </label>
+      <label className="movement-edit-field">
+        <span>URL</span>
+        <input type="url" value={fields.url} onChange={(e) => onChange({ ...fields, url: e.target.value })} placeholder="https://…" required />
+      </label>
+    </>
+  );
+}

--- a/src/components/InterpretiveSchools.tsx
+++ b/src/components/InterpretiveSchools.tsx
@@ -14,6 +14,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
 import type { PublishedInterpretiveSchool } from '../lib/interpretiveSchools';
+import VoteThumbs from './VoteThumbs';
+import OwnerEditDelete from './OwnerEditDelete';
 
 interface Props {
   pieceId: string;
@@ -35,6 +37,15 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
   const [mode, setMode] = useState<Mode>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pageIdx, setPageIdx] = useState(0);
+
+  const PAGE_SIZE = 3;
+  const totalPages = Math.max(1, Math.ceil(schools.length / PAGE_SIZE));
+  const safePage = Math.min(pageIdx, totalPages - 1);
+  const pageStart = safePage * PAGE_SIZE;
+  const visibleSchools = schools.slice(pageStart, pageStart + PAGE_SIZE);
+  const prevPage = () => setPageIdx((i) => (totalPages === 0 ? 0 : (i - 1 + totalPages) % totalPages));
+  const nextPage = () => setPageIdx((i) => (totalPages === 0 ? 0 : (i + 1) % totalPages));
 
   const loadViewer = useCallback(async () => {
     if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
@@ -156,8 +167,8 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
       {schools.length === 0 ? (
         <p className="empty-state">No interpretive schools recorded yet.</p>
       ) : (
-        <div className={`schools-grid schools-grid-${Math.min(schools.length, 3)}`}>
-          {schools.map((s) => {
+        <div className={`schools-grid schools-grid-${Math.min(visibleSchools.length, 3)}`}>
+          {visibleSchools.map((s) => {
             const isOwner = viewer?.userId === s.contributor.id;
             const isEditing = typeof mode === 'object' && mode?.action === 'edit' && mode.schoolId === s.schoolId;
             return (
@@ -185,26 +196,16 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
                           <span>{s.contributor.bioShort}</span>
                         </>
                       )}
+                      {isOwner && (
+                        <OwnerEditDelete
+                          itemLabel="interpretive school"
+                          onEdit={() => { setMode({ action: 'edit', schoolId: s.schoolId }); setError(null); }}
+                          onDelete={() => handleRemove(s.schoolId)}
+                          busy={busy}
+                        />
+                      )}
+                      <VoteThumbs subjectTable="interpretive_schools" subjectId={s.schoolId} />
                     </div>
-                    {isOwner && (
-                      <div className="owner-actions">
-                        <button
-                          type="button"
-                          onClick={() => { setMode({ action: 'edit', schoolId: s.schoolId }); setError(null); }}
-                          className="owner-btn"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleRemove(s.schoolId)}
-                          disabled={busy}
-                          className="owner-btn"
-                        >
-                          {busy ? 'Removing…' : 'Remove'}
-                        </button>
-                      </div>
-                    )}
                   </>
                 )}
 
@@ -222,6 +223,20 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
               </div>
             );
           })}
+        </div>
+      )}
+
+      {schools.length > PAGE_SIZE && (
+        <div className="notes-pager">
+          <button type="button" className="notes-pager-chev" aria-label="Previous schools" onClick={prevPage}>
+            ←
+          </button>
+          <span className="notes-pager-indicator" aria-live="polite">
+            {safePage + 1} <span className="notes-pager-sep">of</span> {totalPages}
+          </span>
+          <button type="button" className="notes-pager-chev" aria-label="Next schools" onClick={nextPage}>
+            →
+          </button>
         </div>
       )}
 
@@ -315,20 +330,6 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
         .school-card .by span:not(.name):not(.dot) {
           color: var(--muted);
         }
-        .owner-actions { display: flex; gap: 8px; margin-top: 12px; }
-        .owner-btn {
-          background: transparent;
-          border: 0.5px solid var(--border-strong);
-          color: var(--muted);
-          font-family: var(--font-sans);
-          font-size: 11px;
-          padding: 4px 10px;
-          border-radius: 6px;
-          cursor: pointer;
-          transition: color 0.12s, border-color 0.12s;
-        }
-        .owner-btn:hover { color: var(--ink); border-color: var(--ink); }
-        .owner-btn:disabled { opacity: 0.5; cursor: not-allowed; }
         .write-entry {
           margin-top: 24px;
           background: transparent;

--- a/src/components/OwnerEditDelete.tsx
+++ b/src/components/OwnerEditDelete.tsx
@@ -1,0 +1,86 @@
+// Unified pencil (edit) + × (delete) affordance for any item the current
+// viewer owns: performer's notes, interpretive schools, signed piece
+// descriptions, and any future signed content. Matches the movement header
+// pattern for consistency — same icons, same hover-reveal, same inline
+// "Delete? Yes / No" confirmation, same end-of-row placement.
+//
+// Placement: end of the byline / card row (per memory: edit affordance at
+// end of target row). The parent renders this as the trailing element.
+
+import { useState, useCallback } from 'react';
+
+interface Props {
+  itemLabel: string;
+  onEdit: () => void;
+  onDelete: () => void | Promise<void>;
+  busy?: boolean;
+}
+
+export default function OwnerEditDelete({ itemLabel, onEdit, onDelete, busy = false }: Props) {
+  const [confirming, setConfirming] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    await onDelete();
+    setConfirming(false);
+  }, [onDelete]);
+
+  return (
+    <span className="owner-ctrls" aria-label={`Actions for ${itemLabel}`}>
+      <button
+        type="button"
+        className="owner-ctrl"
+        aria-label={`Edit ${itemLabel}`}
+        onClick={onEdit}
+        disabled={busy || confirming}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M11.5 2.5l2 2L5 13H3v-2l8.5-8.5z"
+            stroke="currentColor"
+            strokeWidth="1"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {confirming ? (
+        <span className="owner-confirm" role="alertdialog">
+          Delete?
+          <button
+            type="button"
+            className="owner-confirm-yes"
+            onClick={handleDelete}
+            disabled={busy}
+          >
+            Yes
+          </button>
+          <button
+            type="button"
+            className="owner-confirm-no"
+            onClick={() => setConfirming(false)}
+            disabled={busy}
+          >
+            No
+          </button>
+        </span>
+      ) : (
+        <button
+          type="button"
+          className="owner-ctrl owner-ctrl-delete"
+          aria-label={`Delete ${itemLabel}`}
+          onClick={() => setConfirming(true)}
+          disabled={busy}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
+    </span>
+  );
+}

--- a/src/components/PerformersNotes.tsx
+++ b/src/components/PerformersNotes.tsx
@@ -14,6 +14,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
 import type { PublishedPerformersNote } from '../lib/performersNotes';
+import VoteThumbs from './VoteThumbs';
+import OwnerEditDelete from './OwnerEditDelete';
 
 interface Props {
   pieceId: string;
@@ -35,6 +37,15 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
   const [mode, setMode] = useState<Mode>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pageIdx, setPageIdx] = useState(0);
+
+  const PAGE_SIZE = 3;
+  const totalPages = Math.max(1, Math.ceil(notes.length / PAGE_SIZE));
+  const safePage = Math.min(pageIdx, totalPages - 1);
+  const pageStart = safePage * PAGE_SIZE;
+  const visibleNotes = notes.slice(pageStart, pageStart + PAGE_SIZE);
+  const prevPage = () => setPageIdx((i) => (totalPages === 0 ? 0 : (i - 1 + totalPages) % totalPages));
+  const nextPage = () => setPageIdx((i) => (totalPages === 0 ? 0 : (i + 1) % totalPages));
 
   const loadViewer = useCallback(async () => {
     if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
@@ -151,12 +162,13 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
         <p className="empty-state">No performer's notes yet.</p>
       ) : (
         <div className="performers-notes-list">
-          {notes.map((note, idx) => {
+          {visibleNotes.map((note, idxInPage) => {
+            const absoluteIdx = pageStart + idxInPage;
             const isOwner = viewer?.userId === note.contributor.id;
             const isEditing = typeof mode === 'object' && mode?.action === 'edit' && mode.noteId === note.noteId;
-            // First note is primary accent; any siblings get the muted
-            // contrasting-voice treatment per DESIGN.md.
-            const signedClass = idx === 0 ? 'signed' : 'signed alt';
+            // Leftmost (absolute index 0 — highest voted) gets the primary
+            // accent; everyone else gets the muted contrasting treatment.
+            const signedClass = absoluteIdx === 0 ? 'signed' : 'signed alt';
             return (
               <div key={note.noteId} className={signedClass}>
                 {!isEditing && (
@@ -172,26 +184,16 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
                           <span>{note.contributor.bioShort}</span>
                         </>
                       )}
+                      {isOwner && (
+                        <OwnerEditDelete
+                          itemLabel="performer's note"
+                          onEdit={() => { setMode({ action: 'edit', noteId: note.noteId }); setError(null); }}
+                          onDelete={() => handleRemove(note.noteId)}
+                          busy={busy}
+                        />
+                      )}
+                      <VoteThumbs subjectTable="performers_notes" subjectId={note.noteId} />
                     </div>
-                    {isOwner && (
-                      <div className="owner-actions">
-                        <button
-                          type="button"
-                          onClick={() => { setMode({ action: 'edit', noteId: note.noteId }); setError(null); }}
-                          className="owner-btn"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleRemove(note.noteId)}
-                          disabled={busy}
-                          className="owner-btn"
-                        >
-                          {busy ? 'Removing…' : 'Remove'}
-                        </button>
-                      </div>
-                    )}
                   </>
                 )}
 
@@ -207,6 +209,20 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
               </div>
             );
           })}
+        </div>
+      )}
+
+      {notes.length > PAGE_SIZE && (
+        <div className="notes-pager">
+          <button type="button" className="notes-pager-chev" aria-label="Previous notes" onClick={prevPage}>
+            ←
+          </button>
+          <span className="notes-pager-indicator" aria-live="polite">
+            {safePage + 1} <span className="notes-pager-sep">of</span> {totalPages}
+          </span>
+          <button type="button" className="notes-pager-chev" aria-label="Next notes" onClick={nextPage}>
+            →
+          </button>
         </div>
       )}
 
@@ -236,21 +252,57 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
       )}
 
       <style>{`
-        .performers-notes-list { display: flex; flex-direction: column; gap: 32px; }
-        .owner-actions { display: flex; gap: 8px; margin-top: 10px; }
-        .owner-btn {
-          background: transparent;
-          border: 0.5px solid var(--border-strong);
-          color: var(--muted);
-          font-family: var(--font-sans);
-          font-size: 11px;
-          padding: 4px 10px;
-          border-radius: 6px;
-          cursor: pointer;
-          transition: color 0.12s, border-color 0.12s;
+        .performers-notes-list {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 32px;
+          align-items: start;
         }
-        .owner-btn:hover { color: var(--ink); border-color: var(--ink); }
-        .owner-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        @media (max-width: 960px) {
+          .performers-notes-list { grid-template-columns: 1fr 1fr; }
+        }
+        @media (max-width: 640px) {
+          .performers-notes-list { grid-template-columns: 1fr; }
+        }
+        .notes-pager {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 16px;
+          margin-top: 28px;
+        }
+        .notes-pager-chev {
+          appearance: none;
+          background: transparent;
+          border: 0;
+          font: inherit;
+          font-size: 18px;
+          color: var(--muted);
+          cursor: pointer;
+          padding: 6px 10px;
+          border-radius: 4px;
+          line-height: 1;
+          transition: color 120ms ease, background-color 120ms ease;
+        }
+        .notes-pager-chev:hover,
+        .notes-pager-chev:focus-visible {
+          color: var(--accent);
+          background: var(--accent-soft);
+        }
+        .notes-pager-chev:focus-visible {
+          outline: 2px solid var(--accent);
+          outline-offset: 2px;
+        }
+        .notes-pager-indicator {
+          font-family: var(--font-mono);
+          font-size: 12px;
+          color: var(--tertiary);
+          font-variant-numeric: tabular-nums;
+        }
+        .notes-pager-sep {
+          font-style: italic;
+          margin: 0 2px;
+        }
         .write-entry {
           margin-top: 24px;
           background: transparent;

--- a/src/components/PiecePageLayout.astro
+++ b/src/components/PiecePageLayout.astro
@@ -24,23 +24,48 @@ import { getPublishedPerformersNotes } from '../lib/performersNotes';
 import { getPublishedInterpretiveSchools } from '../lib/interpretiveSchools';
 import { getPublishedPieceDescriptions } from '../lib/pieceDescriptions';
 import { fetchMovementsForPiece } from '../lib/movements';
+import { fetchOrderedSubjects } from '../lib/votes';
+import { fetchEditionsForPiece } from '../lib/editions';
 import PerformersNotes from './PerformersNotes';
 import InterpretiveSchools from './InterpretiveSchools';
 import SignedPieceDescription from './SignedPieceDescription';
 import MovementsList from './MovementsList';
 import RecordingsList from './RecordingsList';
+import EditionsList from './EditionsList';
+import ExternalRefsList from './ExternalRefsList';
+import { fetchExternalLinksForPiece, REFERENCE_TYPES } from '../lib/externalLinks';
 
 interface Props {
   piece: PieceFull;
 }
 
 const { piece } = Astro.props;
-const [performersNotes, interpretiveSchools, signedDescriptions, dbMovements] = await Promise.all([
+const [performersNotesRaw, interpretiveSchoolsRaw, signedDescriptionsRaw, dbMovements, dbEditions, dbLinks] = await Promise.all([
   getPublishedPerformersNotes(piece.id),
   getPublishedInterpretiveSchools(piece.id),
   getPublishedPieceDescriptions(piece.id),
   fetchMovementsForPiece(piece.id),
+  fetchEditionsForPiece(piece.id),
+  fetchExternalLinksForPiece(piece.id),
 ]);
+const dbReferenceLinks = dbLinks.filter((l) => (REFERENCE_TYPES as readonly string[]).includes(l.type));
+
+// Reorder signed content by vote_tallies.net_score DESC (tie-break by id)
+// via the fetch_ordered_subjects RPC. Never exposes raw counts.
+const [orderedNoteIds, orderedSchoolIds, orderedDescriptionIds] = await Promise.all([
+  fetchOrderedSubjects('performers_notes', performersNotesRaw.map((n) => n.noteId)),
+  fetchOrderedSubjects('interpretive_schools', interpretiveSchoolsRaw.map((s) => s.schoolId)),
+  fetchOrderedSubjects('piece_descriptions', signedDescriptionsRaw.map((d) => d.descriptionId)),
+]);
+const performersNotes = orderedNoteIds
+  .map((id) => performersNotesRaw.find((n) => n.noteId === id))
+  .filter((n): n is NonNullable<typeof n> => n != null);
+const interpretiveSchools = orderedSchoolIds
+  .map((id) => interpretiveSchoolsRaw.find((s) => s.schoolId === id))
+  .filter((s): s is NonNullable<typeof s> => s != null);
+const signedDescriptions = orderedDescriptionIds
+  .map((id) => signedDescriptionsRaw.find((d) => d.descriptionId === id))
+  .filter((d): d is NonNullable<typeof d> => d != null);
 const seedMovements = (piece.movements ?? []).map((m) => ({
   name: m.name,
   key: m.key,
@@ -128,15 +153,11 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <span class="pill">{piece.difficulty}</span>
   </div>
 
-  {/* 7A: unsigned pieces.description renders as italic metadata strip when
-      a signed description coexists; as a fuller intro paragraph when alone. */}
-  {piece.description && (
-    <p class={hasSignedDescription ? 'piece-meta-strip' : 'piece-intro'}>{piece.description}</p>
-  )}
-
-  {/* 7A: signed description renders as the editorial essay below the header. */}
+  {/* Signed descriptions stack (includes the unsigned pieces.description as
+      a synthetic "Seed data" card at the bottom of the stack; user-authored
+      entries sort above by vote score). */}
   <section class="block" id="signed-description">
-    <SignedPieceDescription client:load pieceId={piece.id} initialDescriptions={signedDescriptions} />
+    <SignedPieceDescription client:load pieceId={piece.id} initialDescriptions={signedDescriptions} seedDescription={piece.description} />
   </section>
 
 
@@ -183,33 +204,10 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <InterpretiveSchools client:load pieceId={piece.id} initialSchools={interpretiveSchools} />
   </section>
 
-  {/* ---------- Editions ---------- */}
+  {/* ---------- Editions (wiki-edit) ---------- */}
   <section class="block">
     <div class="kicker">Editions</div>
-    {piece.editions.length > 0 ? (
-      <div class="editions">
-        {piece.editions.map((e) => {
-          const Wrapper: any = e.url ? 'a' : 'div';
-          const wrapProps = e.url ? { href: e.url, target: '_blank', rel: 'noopener', class: 'ed' } : { class: 'ed' };
-          return (
-            <Wrapper {...wrapProps}>
-              <div class="ed-body">
-                <h3>{e.publisher}</h3>
-                <div class="meta">{e.editor}{e.year ? ` · ${e.year}` : ''}</div>
-                {e.description && <p class="desc">{e.description}</p>}
-              </div>
-              {e.type && (
-                <div class="right">
-                  <span class="type-chip">{e.type}</span>
-                </div>
-              )}
-            </Wrapper>
-          );
-        })}
-      </div>
-    ) : (
-      <p class="empty-state">No editions listed yet.</p>
-    )}
+    <EditionsList client:load pieceId={piece.id} initialEditions={dbEditions} />
   </section>
 
   {/* ---------- Recordings (collapsed list, open to play) ---------- */}
@@ -224,19 +222,11 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     <p class="empty-state">Prepare-with and natural-next connections not yet curated.</p>
   </section>
 
-  {/* ---------- External references (IMSLP, Wikipedia) ---------- */}
-  {refs.length > 0 && (
-    <section class="block">
-      <div class="kicker">External references</div>
-      <ul class="ext-refs">
-        {refs.map((r) => (
-          <li>
-            <a class="ext-ref" href={r.url} target="_blank" rel="noopener">{r.label}</a>
-          </li>
-        ))}
-      </ul>
-    </section>
-  )}
+  {/* ---------- External references (IMSLP, Wikipedia) — wiki-edit ---------- */}
+  <section class="block">
+    <div class="kicker">External references</div>
+    <ExternalRefsList client:load pieceId={piece.id} initialLinks={dbReferenceLinks} />
+  </section>
 
   {/* ---------- Change log link (its own page) ---------- */}
   <p class="change-log-link">
@@ -302,44 +292,10 @@ const refs = piece.external_links.filter(l => l.type === 'imslp' || l.type === '
     border-bottom-color: var(--accent);
   }
 
-  /* External reference list (IMSLP, Wikipedia) — Option D: serif accent
-     with a trailing ↗ (muted) marking outbound. Border-underline fades in
-     on hover. Pills retired; the glyph carries the external signal. */
-  .ext-refs {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-  .ext-refs li {
-    display: block;
-  }
-  .ext-refs a.ext-ref {
-    font-family: var(--font-serif);
-    font-size: 14px;
-    color: var(--accent);
-    text-decoration: none;
-    border-bottom: 0.5px solid transparent;
-    padding-bottom: 1px;
-    transition: border-color 160ms ease;
-  }
-  .ext-refs a.ext-ref::after {
-    content: ' ↗';
-    color: var(--muted);
-    font-family: var(--font-sans);
-    margin-left: 2px;
-  }
-  .ext-refs a.ext-ref:hover,
-  .ext-refs a.ext-ref:focus-visible {
-    border-bottom-color: var(--accent);
-  }
-  .ext-refs a.ext-ref:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 3px;
-    border-radius: 2px;
-  }
+  /* (External-references styling lives in src/styles/piece-page.css so
+     the React island's elements match the selectors — scoped Astro
+     styles here would be hashed to data-astro-cid-* attributes that the
+     island's DOM doesn't carry.) */
 
   /* Edition card list */
   .editions {

--- a/src/components/SignedPieceDescription.tsx
+++ b/src/components/SignedPieceDescription.tsx
@@ -9,11 +9,21 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
 import type { PublishedPieceDescription } from '../lib/pieceDescriptions';
+import VoteThumbs from './VoteThumbs';
+import OwnerEditDelete from './OwnerEditDelete';
 
 interface Props {
   pieceId: string;
   initialDescriptions: PublishedPieceDescription[];
+  // Unsigned pieces.description text — rendered as a synthetic "Seed data"
+  // card at the end of the stack. Seed has no votes; user-authored ties
+  // sort in front of it (§2.5 ordering rule plus client-side append).
+  seedDescription?: string | null;
 }
+
+type StackItem =
+  | { kind: 'user'; desc: PublishedPieceDescription }
+  | { kind: 'seed'; body: string };
 
 interface Viewer {
   userId: string | null;
@@ -24,12 +34,24 @@ interface Viewer {
 
 type Mode = null | 'write' | { action: 'edit'; descriptionId: string };
 
-export default function SignedPieceDescription({ pieceId, initialDescriptions }: Props) {
+export default function SignedPieceDescription({ pieceId, initialDescriptions, seedDescription }: Props) {
   const [descriptions, setDescriptions] = useState<PublishedPieceDescription[]>(initialDescriptions);
   const [viewer, setViewer] = useState<Viewer | null>(null);
   const [mode, setMode] = useState<Mode>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [stackIdx, setStackIdx] = useState(0);
+
+  const stackItems: StackItem[] = [
+    ...descriptions.map((desc) => ({ kind: 'user' as const, desc })),
+    ...(seedDescription && seedDescription.trim().length > 0
+      ? [{ kind: 'seed' as const, body: seedDescription }]
+      : []),
+  ];
+  const safeIdx = stackItems.length === 0 ? 0 : Math.min(stackIdx, stackItems.length - 1);
+  const active = stackItems[safeIdx];
+  const prev = () => setStackIdx((i) => (stackItems.length === 0 ? 0 : (i - 1 + stackItems.length) % stackItems.length));
+  const next = () => setStackIdx((i) => (stackItems.length === 0 ? 0 : (i + 1) % stackItems.length));
 
   const loadViewer = useCallback(async () => {
     if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
@@ -143,62 +165,81 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions }:
         </div>
       )}
 
-      {descriptions.length === 0 ? (
+      {stackItems.length === 0 ? (
         <p className="empty-state">No signed description yet.</p>
       ) : (
-        <div className="descriptions-list">
-          {descriptions.map((d) => {
-            const isOwner = viewer?.userId === d.contributor.id;
-            const isEditing = typeof mode === 'object' && mode?.action === 'edit' && mode.descriptionId === d.descriptionId;
-            return (
-              <article key={d.descriptionId} className="description-essay">
-                {!isEditing && (
-                  <>
-                    <div className="prose">
-                      {d.body.split(/\n\s*\n/).map((para, i) => <p key={i}>{para}</p>)}
-                    </div>
-                    <div className="by">
-                      <span className="name">{d.contributor.displayName}</span>
-                      {d.contributor.bioShort && (
-                        <>
-                          <span className="dot" aria-hidden="true"></span>
-                          <span>{d.contributor.bioShort}</span>
-                        </>
-                      )}
-                    </div>
-                    {isOwner && (
-                      <div className="owner-actions">
-                        <button
-                          type="button"
-                          onClick={() => { setMode({ action: 'edit', descriptionId: d.descriptionId }); setError(null); }}
-                          className="owner-btn"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleRemove(d.descriptionId)}
-                          disabled={busy}
-                          className="owner-btn"
-                        >
-                          {busy ? 'Removing…' : 'Remove'}
-                        </button>
+        <div className={`desc-stack${stackItems.length > 1 ? ' has-more' : ''}`}>
+          {/* Visual "behind" cards imply the stack depth. Non-interactive. */}
+          {stackItems.length > 2 && <div className="desc-stack-behind depth-2" aria-hidden="true" />}
+          {stackItems.length > 1 && <div className="desc-stack-behind depth-1" aria-hidden="true" />}
+
+          {active?.kind === 'user' ? (
+            (() => {
+              const d = active.desc;
+              const isOwner = viewer?.userId === d.contributor.id;
+              const isEditing = typeof mode === 'object' && mode?.action === 'edit' && mode.descriptionId === d.descriptionId;
+              return (
+                <article className="description-essay desc-stack-top">
+                  {!isEditing && (
+                    <>
+                      <div className="prose">
+                        {d.body.split(/\n\s*\n/).map((para, i) => <p key={i}>{para}</p>)}
                       </div>
-                    )}
-                  </>
-                )}
-                {isEditing && viewer && (
-                  <EssayEditForm
-                    initial={d.body}
-                    contributor={{ name: viewer.displayName ?? d.contributor.displayName, bio: viewer.bioShort }}
-                    submitting={busy}
-                    onCancel={() => { setMode(null); setError(null); }}
-                    onSubmit={(body) => handleEdit(d.descriptionId, body)}
-                  />
-                )}
+                      <div className="by">
+                        <span className="name">{d.contributor.displayName}</span>
+                        {d.contributor.bioShort && (
+                          <>
+                            <span className="dot" aria-hidden="true"></span>
+                            <span>{d.contributor.bioShort}</span>
+                          </>
+                        )}
+                        {isOwner && (
+                          <OwnerEditDelete
+                            itemLabel="piece description"
+                            onEdit={() => { setMode({ action: 'edit', descriptionId: d.descriptionId }); setError(null); }}
+                            onDelete={() => handleRemove(d.descriptionId)}
+                            busy={busy}
+                          />
+                        )}
+                        <VoteThumbs subjectTable="piece_descriptions" subjectId={d.descriptionId} />
+                      </div>
+                    </>
+                  )}
+                  {isEditing && viewer && (
+                    <EssayEditForm
+                      initial={d.body}
+                      contributor={{ name: viewer.displayName ?? d.contributor.displayName, bio: viewer.bioShort }}
+                      submitting={busy}
+                      onCancel={() => { setMode(null); setError(null); }}
+                      onSubmit={(body) => handleEdit(d.descriptionId, body)}
+                    />
+                  )}
+                </article>
+              );
+            })()
+          ) : (
+            active && (
+              <article className="description-essay desc-stack-top desc-seed">
+                <div className="prose">
+                  {active.body.split(/\n\s*\n/).map((para, i) => <p key={i}>{para}</p>)}
+                </div>
               </article>
-            );
-          })}
+            )
+          )}
+
+          {stackItems.length > 1 && (
+            <div className="desc-stack-controls">
+              <button type="button" className="desc-stack-chev" aria-label="Previous description" onClick={prev}>
+                ←
+              </button>
+              <span className="desc-stack-indicator" aria-live="polite">
+                {safeIdx + 1} <span className="desc-stack-sep">of</span> {stackItems.length}
+              </span>
+              <button type="button" className="desc-stack-chev" aria-label="Next description" onClick={next}>
+                →
+              </button>
+            </div>
+          )}
         </div>
       )}
 
@@ -255,20 +296,6 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions }:
           vertical-align: middle;
         }
         .description-essay .by span:not(.name):not(.dot) { color: var(--muted); }
-        .owner-actions { display: flex; gap: 8px; margin-top: 14px; }
-        .owner-btn {
-          background: transparent;
-          border: 0.5px solid var(--border-strong);
-          color: var(--muted);
-          font-family: var(--font-sans);
-          font-size: 11px;
-          padding: 4px 10px;
-          border-radius: 6px;
-          cursor: pointer;
-          transition: color 0.12s, border-color 0.12s;
-        }
-        .owner-btn:hover { color: var(--ink); border-color: var(--ink); }
-        .owner-btn:disabled { opacity: 0.5; cursor: not-allowed; }
         .write-entry {
           margin-top: 24px;
           background: transparent;

--- a/src/components/VoteThumbs.tsx
+++ b/src/components/VoteThumbs.tsx
@@ -1,0 +1,206 @@
+// Reusable thumbs-up / thumbs-down affordance for any voteable signed
+// subject (performers_notes, interpretive_schools, piece_descriptions, and
+// eventually landmarks).
+//
+// Invariants:
+//   - Never renders vote counts. Counts exist server-side in vote_tallies
+//     for stacking order; they're not exposed to the client, ever.
+//   - Anon users see the thumbs at 40% opacity; clicking opens a shared
+//     sign-in prompt (per memory: edit-affordance always visible, click
+//     prompts sign-in).
+//   - Own-vote state is loaded on mount via a direct SELECT against the
+//     votes table (RLS restricts the row set to the current user's own
+//     votes, so the client never sees other users' rows).
+//   - Optimistic UI: click fills/unfills immediately, RPC fires, revert on
+//     error (with a toast via the shared emitter).
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+import { useAuth } from '../lib/useAuth';
+
+export type VoteSubjectTable =
+  | 'performers_notes'
+  | 'interpretive_schools'
+  | 'piece_descriptions'
+  | 'landmarks';
+
+interface Props {
+  subjectTable: VoteSubjectTable;
+  subjectId: string;
+}
+
+type Vote = -1 | 0 | 1;
+
+export default function VoteThumbs({ subjectTable, subjectId }: Props) {
+  const { user, loading: authLoading } = useAuth();
+  const [vote, setVote] = useState<Vote>(0);
+  const [error, setError] = useState<string | null>(null);
+  const [signInOpen, setSignInOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  // Load the user's existing vote on mount (or when auth resolves).
+  useEffect(() => {
+    let cancelled = false;
+    if (authLoading || !user || !hasSupabase) return;
+    (async () => {
+      const { data, error: err } = await supabase
+        .from('votes')
+        .select('vote_value')
+        .eq('subject_table', subjectTable)
+        .eq('subject_id', subjectId)
+        .eq('user_id', user.id)
+        .maybeSingle();
+      if (cancelled) return;
+      if (err) return;
+      setVote(((data?.vote_value as Vote | undefined) ?? 0) as Vote);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading, subjectTable, subjectId]);
+
+  const cast = useCallback(
+    async (desired: 1 | -1) => {
+      if (!user) {
+        setSignInOpen(true);
+        return;
+      }
+      if (pending) return;
+      const prev = vote;
+      // Clicking the already-filled thumb clears the vote; otherwise sets.
+      const next: Vote = prev === desired ? 0 : desired;
+      setVote(next);
+      setPending(true);
+      setError(null);
+      const { error: rpcErr } =
+        next === 0
+          ? await supabase.rpc('clear_vote', {
+              p_subject_table: subjectTable,
+              p_subject_id: subjectId,
+            })
+          : await supabase.rpc('cast_vote', {
+              p_subject_table: subjectTable,
+              p_subject_id: subjectId,
+              p_vote_value: next,
+            });
+      setPending(false);
+      if (rpcErr) {
+        setVote(prev); // revert optimistic
+        const pretty = rpcErr.message.includes('rate limit')
+          ? 'Voting too fast — wait a second.'
+          : `Vote failed: ${rpcErr.message}`;
+        setError(pretty);
+      }
+    },
+    [user, vote, pending, subjectTable, subjectId],
+  );
+
+  const handleSignIn = useCallback(async () => {
+    if (!hasSupabase) return;
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: window.location.href },
+    });
+  }, []);
+
+  const ariaUp = user
+    ? vote === 1
+      ? 'Remove upvote'
+      : 'Upvote'
+    : 'Sign in to upvote';
+  const ariaDown = user
+    ? vote === -1
+      ? 'Remove downvote'
+      : 'Downvote'
+    : 'Sign in to downvote';
+
+  return (
+    <>
+      <span
+        className={`vote-thumbs${pending ? ' is-pending' : ''}`}
+        role="group"
+        aria-label="Vote on this contribution"
+      >
+        <button
+          type="button"
+          className={`vote-thumb vote-thumb-up${vote === 1 ? ' is-active' : ''}`}
+          aria-pressed={vote === 1}
+          aria-label={ariaUp}
+          onClick={() => cast(1)}
+          disabled={pending}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path
+              d="M3 14V7h2.5l2-4.5a1.5 1.5 0 012.9.9L9.5 7H13a1.5 1.5 0 011.5 1.7l-.8 4.5A2 2 0 0111.7 15H5.5A2.5 2.5 0 013 14z"
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeLinejoin="round"
+              fill={vote === 1 ? 'currentColor' : 'none'}
+            />
+          </svg>
+        </button>
+        <button
+          type="button"
+          className={`vote-thumb vote-thumb-down${vote === -1 ? ' is-active' : ''}`}
+          aria-pressed={vote === -1}
+          aria-label={ariaDown}
+          onClick={() => cast(-1)}
+          disabled={pending}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path
+              d="M13 2v7h-2.5l-2 4.5a1.5 1.5 0 01-2.9-.9L6.5 9H3a1.5 1.5 0 01-1.5-1.7l.8-4.5A2 2 0 014.3 1h6.2A2.5 2.5 0 0113 2z"
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeLinejoin="round"
+              fill={vote === -1 ? 'currentColor' : 'none'}
+            />
+          </svg>
+        </button>
+      </span>
+
+      {error && (
+        <span className="vote-error" role="alert">
+          {error}
+        </span>
+      )}
+
+      {signInOpen && (
+        <>
+          <div className="movement-edit-backdrop" onClick={() => setSignInOpen(false)} aria-hidden="true" />
+          <div
+            className="movement-edit-modal movement-edit-signin"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="vote-signin-title"
+          >
+            <h2 id="vote-signin-title" className="movement-edit-title">
+              Sign in to vote
+            </h2>
+            <p className="movement-edit-signin-body">
+              Voting helps the community surface the most trusted signed contributions.
+              Sign in or create an account to cast your vote.
+            </p>
+            <div className="movement-edit-actions">
+              <button
+                type="button"
+                className="movement-edit-button movement-edit-button-ghost"
+                onClick={() => setSignInOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="movement-edit-button movement-edit-button-primary"
+                onClick={handleSignIn}
+                autoFocus
+              >
+                Sign in / Register
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/integration/editionsRpcs.test.ts
+++ b/src/integration/editionsRpcs.test.ts
@@ -1,0 +1,239 @@
+// Integration tests for editions wiki-edit RPCs.
+//
+// Covers create_edition, update_edition, delete_edition (soft),
+// swap_edition_ordinals, plus auth / validation / already-deleted guards
+// and rate-limit via the shared 'content_edit' bucket.
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  admin,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+} from './helpers';
+
+const PIECE = 'editions-rpcs-test';
+const OTHER_PIECE = 'editions-rpcs-other-test';
+
+let userId: string;
+let user: SupabaseClient;
+
+async function clearRateLimit(): Promise<void> {
+  await admin.from('rate_limit_log').delete().eq('user_id', userId);
+}
+async function clearEditions(): Promise<void> {
+  await admin.from('editions').delete().in('piece_id', [PIECE, OTHER_PIECE]);
+}
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'Editions RPC Test Piece');
+  await createTestPiece(OTHER_PIECE, 'Editions RPC Other Piece');
+  const u = await createAuthUser({ displayName: 'Editions Tester' });
+  userId = u.id;
+  user = u.client;
+});
+
+afterAll(async () => {
+  await clearEditions();
+  await clearRateLimit();
+  await deleteAuthUser(userId);
+  await deleteTestPiece(PIECE);
+  await deleteTestPiece(OTHER_PIECE);
+});
+
+afterEach(async () => {
+  await clearEditions();
+  await clearRateLimit();
+});
+
+async function createViaRpc(
+  publisher: string,
+  piece: string = PIECE,
+): Promise<string> {
+  const { data, error } = await user.rpc('create_edition', {
+    p_piece_id: piece,
+    p_publisher: publisher,
+    p_editor: 'Ed',
+    p_year: 2020,
+    p_description: '',
+    p_type: null,
+    p_url: null,
+  });
+  if (error) throw new Error(`create_edition: ${error.message}`);
+  return data as string;
+}
+
+describe('create_edition', () => {
+  test('appends at max ordinal + 1 with content_edit log', async () => {
+    const a = await createViaRpc('Henle');
+    const b = await createViaRpc('Bärenreiter');
+
+    const { data: rows } = await admin
+      .from('editions')
+      .select('id, ordinal, publisher, created_by')
+      .eq('piece_id', PIECE)
+      .order('ordinal');
+    expect(rows).toHaveLength(2);
+    expect(rows![0]).toMatchObject({ id: a, ordinal: 1, publisher: 'Henle', created_by: userId });
+    expect(rows![1]).toMatchObject({ id: b, ordinal: 2, publisher: 'Bärenreiter' });
+
+    const { data: log } = await admin
+      .from('content_mutation_log')
+      .select('action, subject_type, subject_label')
+      .eq('piece_id', PIECE)
+      .order('occurred_at');
+    expect(log).toHaveLength(2);
+    expect(log!.every((r: any) => r.subject_type === 'edition' && r.action === 'added')).toBe(true);
+  });
+
+  test('rejects unauthenticated caller', async () => {
+    const { createClient } = await import('@supabase/supabase-js');
+    const anon = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!);
+    const { error } = await anon.rpc('create_edition', {
+      p_piece_id: PIECE, p_publisher: 'X', p_editor: '', p_year: null,
+      p_description: '', p_type: null, p_url: null,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/unauthenticated/);
+  });
+
+  test('rejects missing piece and empty publisher', async () => {
+    const { error: missingPiece } = await user.rpc('create_edition', {
+      p_piece_id: 'no-such-piece', p_publisher: 'X', p_editor: '', p_year: null,
+      p_description: '', p_type: null, p_url: null,
+    });
+    expect(missingPiece).not.toBeNull();
+
+    const { error: blank } = await user.rpc('create_edition', {
+      p_piece_id: PIECE, p_publisher: '', p_editor: '', p_year: null,
+      p_description: '', p_type: null, p_url: null,
+    });
+    expect(blank).not.toBeNull();
+  });
+});
+
+describe('update_edition', () => {
+  test('updates fields and writes updated-log row', async () => {
+    const id = await createViaRpc('Henle');
+    const { error } = await user.rpc('update_edition', {
+      p_id: id, p_publisher: 'Henle Verlag', p_editor: 'Wenzinger',
+      p_year: 2019, p_description: 'updated desc', p_type: 'urtext', p_url: 'https://example.com',
+    });
+    expect(error).toBeNull();
+
+    const { data: row } = await admin
+      .from('editions')
+      .select('publisher, editor, year, type, url')
+      .eq('id', id).single();
+    expect(row).toMatchObject({
+      publisher: 'Henle Verlag',
+      editor: 'Wenzinger',
+      year: 2019,
+      type: 'urtext',
+      url: 'https://example.com',
+    });
+
+    const { data: log } = await admin.from('content_mutation_log')
+      .select('action').eq('subject_id', id).order('occurred_at');
+    expect(log!.map((r: any) => r.action)).toEqual(['added', 'updated']);
+  });
+
+  test('rejects edit on soft-deleted row', async () => {
+    const id = await createViaRpc('Henle');
+    await user.rpc('delete_edition', { p_id: id });
+    const { error } = await user.rpc('update_edition', {
+      p_id: id, p_publisher: 'X', p_editor: '', p_year: null,
+      p_description: '', p_type: null, p_url: null,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/deleted/);
+  });
+});
+
+describe('delete_edition', () => {
+  test('soft-deletes and allows reinserting at freed ordinal via create_edition', async () => {
+    const a = await createViaRpc('A');
+    await createViaRpc('B');
+    await user.rpc('delete_edition', { p_id: a });
+
+    const { data: rows } = await admin
+      .from('editions')
+      .select('publisher, ordinal, deleted_at')
+      .eq('piece_id', PIECE).order('ordinal');
+    // Deleted row still present; active query excludes it — verify both.
+    const active = rows!.filter((r: any) => r.deleted_at == null);
+    expect(active).toHaveLength(1);
+    expect(active[0].publisher).toBe('B');
+
+    // Partial unique index lets a new edition take the same ordinal.
+    await createViaRpc('A replacement');
+    const { data: after } = await admin
+      .from('editions')
+      .select('publisher')
+      .eq('piece_id', PIECE)
+      .is('deleted_at', null)
+      .order('ordinal');
+    expect(after!.map((r: any) => r.publisher)).toEqual(['B', 'A replacement']);
+  });
+
+  test('rejects double delete', async () => {
+    const id = await createViaRpc('Henle');
+    await user.rpc('delete_edition', { p_id: id });
+    const { error } = await user.rpc('delete_edition', { p_id: id });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/already deleted/);
+  });
+});
+
+describe('swap_edition_ordinals', () => {
+  test('swaps ordinals', async () => {
+    const a = await createViaRpc('First');
+    const b = await createViaRpc('Second');
+
+    const { error } = await user.rpc('swap_edition_ordinals', { p_id_a: a, p_id_b: b });
+    expect(error).toBeNull();
+
+    const { data: rows } = await admin
+      .from('editions')
+      .select('id, ordinal')
+      .eq('piece_id', PIECE).order('ordinal');
+    expect(rows![0].id).toBe(b);
+    expect(rows![1].id).toBe(a);
+  });
+
+  test('rejects cross-piece swap', async () => {
+    const a = await createViaRpc('A', PIECE);
+    const b = await createViaRpc('B', OTHER_PIECE);
+    const { error } = await user.rpc('swap_edition_ordinals', { p_id_a: a, p_id_b: b });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/different pieces/);
+  });
+
+  test('rejects swap involving a soft-deleted row', async () => {
+    const a = await createViaRpc('A');
+    const b = await createViaRpc('B');
+    await user.rpc('delete_edition', { p_id: b });
+    const { error } = await user.rpc('swap_edition_ordinals', { p_id_a: a, p_id_b: b });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/deleted/);
+  });
+});
+
+describe('content_edit rate limit (shared 30/hour bucket)', () => {
+  test('update_edition rejected after 30 entries in the bucket', async () => {
+    const id = await createViaRpc('Henle'); // 1 entry in bucket
+    const rows = Array.from({ length: 29 }, () => ({
+      user_id: userId, action: 'content_edit',
+    }));
+    await admin.from('rate_limit_log').insert(rows);
+
+    const { error } = await user.rpc('update_edition', {
+      p_id: id, p_publisher: 'Over cap', p_editor: '', p_year: null,
+      p_description: '', p_type: null, p_url: null,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/rate limit/);
+  });
+});

--- a/src/integration/externalLinksRpcs.test.ts
+++ b/src/integration/externalLinksRpcs.test.ts
@@ -1,0 +1,166 @@
+// Integration tests for external_links wiki-edit RPCs (shared by the
+// Recordings + External references surfaces — UI splits by type).
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  admin,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+} from './helpers';
+
+const PIECE = 'xlinks-rpcs-test';
+const OTHER_PIECE = 'xlinks-rpcs-other';
+
+let userId: string;
+let user: SupabaseClient;
+
+async function clearRateLimit(): Promise<void> {
+  await admin.from('rate_limit_log').delete().eq('user_id', userId);
+}
+async function clearLinks(): Promise<void> {
+  await admin.from('external_links').delete().in('piece_id', [PIECE, OTHER_PIECE]);
+}
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'External Links Test');
+  await createTestPiece(OTHER_PIECE, 'External Links Other');
+  const u = await createAuthUser({ displayName: 'Links Tester' });
+  userId = u.id;
+  user = u.client;
+});
+
+afterAll(async () => {
+  await clearLinks();
+  await clearRateLimit();
+  await deleteAuthUser(userId);
+  await deleteTestPiece(PIECE);
+  await deleteTestPiece(OTHER_PIECE);
+});
+
+afterEach(async () => {
+  await clearLinks();
+  await clearRateLimit();
+});
+
+async function createViaRpc(
+  type: string,
+  label: string,
+  url: string,
+  piece: string = PIECE,
+): Promise<string> {
+  const { data, error } = await user.rpc('create_external_link', {
+    p_piece_id: piece, p_type: type, p_url: url, p_label: label,
+  });
+  if (error) throw new Error(`create_external_link: ${error.message}`);
+  return data as string;
+}
+
+describe('create_external_link', () => {
+  test('creates row + logs with correct subject_type (recording vs reference)', async () => {
+    const rec = await createViaRpc('youtube', 'Intro', 'https://www.youtube.com/watch?v=abc');
+    const ref = await createViaRpc('imslp', 'Score', 'https://imslp.org/x');
+
+    const { data: rows } = await admin
+      .from('external_links')
+      .select('id, type, ordinal, source, created_by')
+      .eq('piece_id', PIECE).order('ordinal');
+    expect(rows).toHaveLength(2);
+    expect(rows![0].source).toBe('user');
+    expect(rows![0].created_by).toBe(userId);
+
+    const { data: log } = await admin
+      .from('content_mutation_log')
+      .select('subject_id, subject_type, action')
+      .eq('piece_id', PIECE).order('occurred_at');
+    expect(log).toHaveLength(2);
+    const recLog = log!.find((r: any) => r.subject_id === rec);
+    const refLog = log!.find((r: any) => r.subject_id === ref);
+    expect(recLog!.subject_type).toBe('recording');
+    expect(refLog!.subject_type).toBe('external reference');
+    expect(recLog!.action).toBe('added');
+  });
+
+  test('rejects bad link_type enum value', async () => {
+    const { error } = await user.rpc('create_external_link', {
+      p_piece_id: PIECE, p_type: 'not-a-real-type', p_url: 'https://x', p_label: 'X',
+    });
+    expect(error).not.toBeNull();
+  });
+
+  test('rejects empty url or empty label', async () => {
+    const { error: noUrl } = await user.rpc('create_external_link', {
+      p_piece_id: PIECE, p_type: 'imslp', p_url: '', p_label: 'X',
+    });
+    expect(noUrl).not.toBeNull();
+    const { error: noLabel } = await user.rpc('create_external_link', {
+      p_piece_id: PIECE, p_type: 'imslp', p_url: 'https://x', p_label: '',
+    });
+    expect(noLabel).not.toBeNull();
+  });
+});
+
+describe('update_external_link', () => {
+  test('updates fields', async () => {
+    const id = await createViaRpc('imslp', 'Old', 'https://imslp.org/old');
+    const { error } = await user.rpc('update_external_link', {
+      p_id: id, p_type: 'wikipedia', p_url: 'https://en.wikipedia.org/new', p_label: 'New',
+    });
+    expect(error).toBeNull();
+
+    const { data: row } = await admin
+      .from('external_links')
+      .select('type, url, label')
+      .eq('id', id).single();
+    expect(row).toMatchObject({ type: 'wikipedia', url: 'https://en.wikipedia.org/new', label: 'New' });
+  });
+
+  test('rejects update on soft-deleted link', async () => {
+    const id = await createViaRpc('imslp', 'X', 'https://imslp.org/x');
+    await user.rpc('delete_external_link', { p_id: id });
+    const { error } = await user.rpc('update_external_link', {
+      p_id: id, p_type: 'imslp', p_url: 'https://imslp.org/x', p_label: 'X',
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/deleted/);
+  });
+});
+
+describe('delete_external_link (soft)', () => {
+  test('sets deleted_at and logs delete', async () => {
+    const id = await createViaRpc('imslp', 'X', 'https://imslp.org/x');
+    await user.rpc('delete_external_link', { p_id: id });
+
+    const { data: row } = await admin
+      .from('external_links').select('deleted_at').eq('id', id).single();
+    expect(row!.deleted_at).not.toBeNull();
+
+    const { data: log } = await admin
+      .from('content_mutation_log').select('action').eq('subject_id', id).order('occurred_at');
+    expect(log!.map((r: any) => r.action)).toEqual(['added', 'deleted']);
+  });
+});
+
+describe('swap_external_link_ordinals', () => {
+  test('swaps two links in the same piece', async () => {
+    const a = await createViaRpc('imslp', 'A', 'https://imslp.org/a');
+    const b = await createViaRpc('wikipedia', 'B', 'https://en.wikipedia.org/b');
+    const { error } = await user.rpc('swap_external_link_ordinals', { p_id_a: a, p_id_b: b });
+    expect(error).toBeNull();
+
+    const { data: rows } = await admin
+      .from('external_links').select('id, ordinal').eq('piece_id', PIECE).order('ordinal');
+    expect(rows![0].id).toBe(b);
+    expect(rows![1].id).toBe(a);
+  });
+
+  test('rejects cross-piece swap', async () => {
+    const a = await createViaRpc('imslp', 'A', 'https://imslp.org/a', PIECE);
+    const b = await createViaRpc('imslp', 'B', 'https://imslp.org/b', OTHER_PIECE);
+    const { error } = await user.rpc('swap_external_link_ordinals', { p_id_a: a, p_id_b: b });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/different pieces/);
+  });
+});

--- a/src/integration/orderedChangelog.test.ts
+++ b/src/integration/orderedChangelog.test.ts
@@ -1,0 +1,190 @@
+// Integration tests for two cross-cutting read surfaces:
+//   - fetch_ordered_subjects(subject_table, ids[]) — orders IDs by
+//     vote_tallies.net_score DESC without leaking counts.
+//   - fetch_piece_changelog(piece_id) — subject-agnostic UNION across
+//     versioned tables + content_mutation_log.
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  admin,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+} from './helpers';
+
+const PIECE = 'ordered-changelog-test';
+
+let author: Awaited<ReturnType<typeof createAuthUser>>;
+let voter: Awaited<ReturnType<typeof createAuthUser>>;
+
+async function clearPiece(): Promise<void> {
+  await admin.from('content_mutation_log').delete().eq('piece_id', PIECE);
+  await admin.from('vote_tallies').delete().eq('subject_table', 'performers_notes');
+  await admin.from('votes').delete().eq('subject_table', 'performers_notes');
+  await admin.from('performers_notes').update({ current_version_id: null }).eq('piece_id', PIECE);
+  await admin.from('performers_note_versions').delete().eq('piece_id', PIECE);
+  await admin.from('performers_notes').delete().eq('piece_id', PIECE);
+  await admin.from('movements').update({ current_version_id: null }).eq('piece_id', PIECE);
+  await admin.from('movement_versions').delete().eq('piece_id', PIECE);
+  await admin.from('movements').delete().eq('piece_id', PIECE);
+  await admin.from('editions').delete().eq('piece_id', PIECE);
+  await admin.from('rate_limit_log').delete().eq('user_id', author.id);
+  await admin.from('rate_limit_log').delete().eq('user_id', voter.id);
+}
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'Ordered + Changelog Test');
+  author = await createAuthUser({ isContributor: true, displayName: 'Ordered Author' });
+  voter = await createAuthUser({ displayName: 'Ordered Voter' });
+});
+
+afterAll(async () => {
+  await clearPiece();
+  await deleteAuthUser(author.id);
+  await deleteAuthUser(voter.id);
+  await deleteTestPiece(PIECE);
+});
+
+afterEach(async () => {
+  await clearPiece();
+});
+
+// ============================================================================
+// fetch_ordered_subjects
+// ============================================================================
+
+describe('fetch_ordered_subjects', () => {
+  test('orders IDs by net_score DESC with stable id tie-break', async () => {
+    const { data: n1 } = await author.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE, p_body: 'note one',
+    });
+    const { data: n2 } = await author.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE, p_body: 'note two',
+    });
+    const { data: n3 } = await author.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE, p_body: 'note three',
+    });
+
+    // Vote n2 up, leave n1 + n3 at 0.
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes', p_subject_id: n2, p_vote_value: 1,
+    });
+
+    const { data: ordered, error } = await voter.client.rpc('fetch_ordered_subjects', {
+      p_subject_table: 'performers_notes',
+      p_subject_ids: [n1, n2, n3],
+    });
+    expect(error).toBeNull();
+    expect(ordered).toHaveLength(3);
+    // n2 (net_score=1) must come first. n1 / n3 follow in id ASC order.
+    expect(ordered![0]).toBe(n2);
+    const [first, ...rest] = ordered as string[];
+    expect(first).toBe(n2);
+    expect([...rest].sort()).toEqual([n1, n3].sort());
+  });
+
+  test('returns empty array for empty id list', async () => {
+    const { data, error } = await voter.client.rpc('fetch_ordered_subjects', {
+      p_subject_table: 'performers_notes', p_subject_ids: [],
+    });
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+  });
+
+  test('preserves input IDs even when they have no vote_tallies row', async () => {
+    const { data: n1 } = await author.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE, p_body: 'a',
+    });
+    const { data: n2 } = await author.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE, p_body: 'b',
+    });
+    const { data: ordered } = await voter.client.rpc('fetch_ordered_subjects', {
+      p_subject_table: 'performers_notes', p_subject_ids: [n1, n2],
+    });
+    expect(ordered).toHaveLength(2);
+    expect([...(ordered as string[])].sort()).toEqual([n1, n2].sort());
+  });
+});
+
+// ============================================================================
+// fetch_piece_changelog — UNION across sources
+// ============================================================================
+
+describe('fetch_piece_changelog', () => {
+  test('returns movement edits, performer note publishes, and edition adds unified', async () => {
+    // Movement
+    const mvId = await createMovement();
+    // Performer's note (versioned subject)
+    const { data: noteId } = await author.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE, p_body: 'a note',
+    });
+    // Edition (non-versioned, via content_mutation_log)
+    const { data: edId } = await author.client.rpc('create_edition', {
+      p_piece_id: PIECE, p_publisher: 'Henle', p_editor: '', p_year: null,
+      p_description: '', p_type: null, p_url: null,
+    });
+
+    const { data: rows, error } = await voter.client.rpc('fetch_piece_changelog', {
+      p_piece_id: PIECE,
+    });
+    expect(error).toBeNull();
+    expect(rows!.length).toBeGreaterThanOrEqual(3);
+
+    const types = new Set(rows!.map((r: any) => r.subject_type));
+    expect(types.has('movement')).toBe(true);
+    expect(types.has("performer's note")).toBe(true);
+    expect(types.has('edition')).toBe(true);
+
+    const mvRow = rows!.find((r: any) => r.subject_id === mvId);
+    expect(mvRow).toBeTruthy();
+    expect(mvRow!.edit_summary).toBe('created');
+
+    const noteRow = rows!.find((r: any) => r.subject_id === noteId);
+    expect(noteRow).toBeTruthy();
+    expect(noteRow!.edit_summary).toBe('published');
+
+    const edRow = rows!.find((r: any) => r.subject_id === edId);
+    expect(edRow).toBeTruthy();
+    expect(edRow!.edit_summary).toBe('added');
+    expect(edRow!.subject_label).toMatch(/Henle/);
+  });
+
+  test('soft-removed performer note emits a "removed" entry alongside version entries', async () => {
+    const { data: noteId } = await author.client.rpc('publish_contributor_note', {
+      p_piece_id: PIECE, p_body: 'to be removed',
+    });
+    await author.client.rpc('remove_performers_note', { p_note_id: noteId });
+
+    const { data: rows } = await voter.client.rpc('fetch_piece_changelog', {
+      p_piece_id: PIECE,
+    });
+    const forNote = rows!.filter((r: any) => r.subject_id === noteId);
+    expect(forNote.map((r: any) => r.edit_summary)).toContain('published');
+    expect(forNote.map((r: any) => r.edit_summary)).toContain('removed');
+  });
+
+  test('ordered DESC by created_at', async () => {
+    await createMovement('First');
+    await new Promise((r) => setTimeout(r, 10));
+    await createMovement('Second');
+
+    const { data: rows } = await voter.client.rpc('fetch_piece_changelog', {
+      p_piece_id: PIECE,
+    });
+    const labels = rows!
+      .filter((r: any) => r.subject_type === 'movement')
+      .map((r: any) => r.subject_label);
+    expect(labels[0]).toBe('Second'); // most recent first
+    expect(labels[labels.length - 1]).toBe('First');
+  });
+});
+
+async function createMovement(name: string = 'Test mvmt'): Promise<string> {
+  const { data, error } = await author.client.rpc('create_movement', {
+    p_piece_id: PIECE, p_name: name,
+  });
+  if (error) throw new Error(`create_movement: ${error.message}`);
+  return data as string;
+}

--- a/src/integration/pedagogicalArcRpcs.test.ts
+++ b/src/integration/pedagogicalArcRpcs.test.ts
@@ -1,0 +1,178 @@
+// Integration tests for pedagogical_arc CRUD RPCs + log trigger.
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  admin,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+} from './helpers';
+
+const PIECE = 'pedagogical-rpcs-test';
+const RELATED = 'pedagogical-related-test';
+const OTHER_RELATED = 'pedagogical-other-related';
+
+let userId: string;
+let user: SupabaseClient;
+
+async function clearRateLimit(): Promise<void> {
+  await admin.from('rate_limit_log').delete().eq('user_id', userId);
+}
+async function clearConnections(): Promise<void> {
+  await admin.from('pedagogical_connections').delete().eq('piece_id', PIECE);
+}
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'Pedagogical Subject');
+  await createTestPiece(RELATED, 'Related Piece');
+  await createTestPiece(OTHER_RELATED, 'Other Related Piece');
+  const u = await createAuthUser({ displayName: 'Arc Tester' });
+  userId = u.id;
+  user = u.client;
+});
+
+afterAll(async () => {
+  await clearConnections();
+  await clearRateLimit();
+  await deleteAuthUser(userId);
+  await deleteTestPiece(PIECE);
+  await deleteTestPiece(RELATED);
+  await deleteTestPiece(OTHER_RELATED);
+});
+
+afterEach(async () => {
+  await clearConnections();
+  await clearRateLimit();
+});
+
+async function createViaRpc(
+  related: string,
+  kind: 'prepare_with' | 'natural_next',
+): Promise<string> {
+  const { data, error } = await user.rpc('create_pedagogical_connection', {
+    p_piece_id: PIECE,
+    p_related_piece_id: related,
+    p_kind: kind,
+    p_note: null,
+  });
+  if (error) throw new Error(`create_pedagogical_connection: ${error.message}`);
+  return data as string;
+}
+
+describe('create_pedagogical_connection', () => {
+  test('creates with ordinal=1 per (piece, kind) and logs with pedagogical arc subject_type', async () => {
+    const a = await createViaRpc(RELATED, 'prepare_with');
+    const b = await createViaRpc(OTHER_RELATED, 'prepare_with');
+    const c = await createViaRpc(RELATED, 'natural_next');
+
+    const { data: rows } = await admin
+      .from('pedagogical_connections')
+      .select('id, related_piece_id, kind, ordinal, created_by')
+      .eq('piece_id', PIECE)
+      .order('kind').order('ordinal');
+    expect(rows).toHaveLength(3);
+
+    const prepareWith = rows!.filter((r: any) => r.kind === 'prepare_with');
+    expect(prepareWith.map((r: any) => r.ordinal)).toEqual([1, 2]);
+    const natural = rows!.filter((r: any) => r.kind === 'natural_next');
+    expect(natural.map((r: any) => r.ordinal)).toEqual([1]);
+    expect(rows!.every((r: any) => r.created_by === userId)).toBe(true);
+
+    const { data: log } = await admin
+      .from('content_mutation_log')
+      .select('subject_id, subject_type, subject_label, action')
+      .eq('piece_id', PIECE).order('occurred_at');
+    expect(log).toHaveLength(3);
+    expect(log!.every((r: any) => r.subject_type === 'pedagogical arc' && r.action === 'added')).toBe(true);
+    // Labels include the prefix based on kind.
+    expect(log!.find((r: any) => r.subject_id === a)!.subject_label).toMatch(/^prepare with/);
+    expect(log!.find((r: any) => r.subject_id === c)!.subject_label).toMatch(/^natural next/);
+  });
+
+  test('rejects self-reference', async () => {
+    const { error } = await user.rpc('create_pedagogical_connection', {
+      p_piece_id: PIECE, p_related_piece_id: PIECE, p_kind: 'prepare_with', p_note: null,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/cannot connect a piece to itself/);
+  });
+
+  test('rejects invalid kind', async () => {
+    const { error } = await user.rpc('create_pedagogical_connection', {
+      p_piece_id: PIECE, p_related_piece_id: RELATED, p_kind: 'random', p_note: null,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/kind must be/);
+  });
+});
+
+describe('update_pedagogical_connection', () => {
+  test('updates related piece + kind + note', async () => {
+    const id = await createViaRpc(RELATED, 'prepare_with');
+    const { error } = await user.rpc('update_pedagogical_connection', {
+      p_id: id, p_related_piece_id: OTHER_RELATED, p_kind: 'natural_next', p_note: 'revised',
+    });
+    expect(error).toBeNull();
+
+    const { data: row } = await admin
+      .from('pedagogical_connections')
+      .select('related_piece_id, kind, note')
+      .eq('id', id).single();
+    expect(row).toMatchObject({
+      related_piece_id: OTHER_RELATED,
+      kind: 'natural_next',
+      note: 'revised',
+    });
+  });
+
+  test('rejects update on soft-deleted row', async () => {
+    const id = await createViaRpc(RELATED, 'prepare_with');
+    await user.rpc('delete_pedagogical_connection', { p_id: id });
+    const { error } = await user.rpc('update_pedagogical_connection', {
+      p_id: id, p_related_piece_id: RELATED, p_kind: 'prepare_with', p_note: null,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/deleted/);
+  });
+});
+
+describe('delete_pedagogical_connection (soft)', () => {
+  test('sets deleted_at and emits a deleted log entry', async () => {
+    const id = await createViaRpc(RELATED, 'prepare_with');
+    await user.rpc('delete_pedagogical_connection', { p_id: id });
+
+    const { data: row } = await admin
+      .from('pedagogical_connections').select('deleted_at').eq('id', id).single();
+    expect(row!.deleted_at).not.toBeNull();
+
+    const { data: log } = await admin
+      .from('content_mutation_log').select('action').eq('subject_id', id).order('occurred_at');
+    expect(log!.map((r: any) => r.action)).toEqual(['added', 'deleted']);
+  });
+});
+
+describe('swap_pedagogical_ordinals', () => {
+  test('swaps within the same (piece, kind) section', async () => {
+    const a = await createViaRpc(RELATED, 'prepare_with');
+    const b = await createViaRpc(OTHER_RELATED, 'prepare_with');
+    const { error } = await user.rpc('swap_pedagogical_ordinals', { p_id_a: a, p_id_b: b });
+    expect(error).toBeNull();
+
+    const { data: rows } = await admin
+      .from('pedagogical_connections')
+      .select('id, ordinal')
+      .eq('piece_id', PIECE).eq('kind', 'prepare_with').order('ordinal');
+    expect(rows![0].id).toBe(b);
+    expect(rows![1].id).toBe(a);
+  });
+
+  test('rejects swap across kinds (prepare_with vs natural_next)', async () => {
+    const a = await createViaRpc(RELATED, 'prepare_with');
+    const b = await createViaRpc(RELATED, 'natural_next');
+    const { error } = await user.rpc('swap_pedagogical_ordinals', { p_id_a: a, p_id_b: b });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/different sections/);
+  });
+});

--- a/src/integration/pieceCssGuardrail.test.ts
+++ b/src/integration/pieceCssGuardrail.test.ts
@@ -1,0 +1,118 @@
+// Piece page CSS guardrail. Lightweight protection against two recurring
+// regressions observed during the Slice-C push:
+//
+//   1. CSS that should style React-island DOM (ChangeLog, ExternalRefsList,
+//      etc.) drifts into Astro scoped <style> blocks. Astro scopes every
+//      selector with [data-astro-cid-xxx]; island DOM doesn't carry that
+//      attribute, so the rules silently fail and the page falls back to
+//      default UA styles (list bullets, blue underlined links).
+//
+//   2. Someone accidentally deletes a load-bearing rule (e.g. the
+//      .ext-refs a.ext-ref::after ↗ glyph, or the .ed-title inline-block
+//      click target).
+//
+// This test is a plain file-read + regex check — no dev server, no jsdom,
+// runs in milliseconds. When a rule genuinely should change, the snapshot
+// (this test) is the explicit place to update, which is the whole point.
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dir, '..', '..');
+const pieceCss = readFileSync(resolve(root, 'src/styles/piece-page.css'), 'utf8');
+const piecePageAstro = readFileSync(resolve(root, 'src/components/PiecePageLayout.astro'), 'utf8');
+const changeLogPageAstro = readFileSync(resolve(root, 'src/pages/piece/[id]/change-log.astro'), 'utf8');
+
+// Extract the single <style>…</style> block (scoped) from an Astro file.
+function scopedStyleOf(source: string): string {
+  const match = source.match(/<style>([\s\S]*?)<\/style>/);
+  return match ? match[1] : '';
+}
+
+describe('External references — Option D styling', () => {
+  test('.ext-refs rules live in GLOBAL piece-page.css, not in scoped <style>', () => {
+    expect(pieceCss).toMatch(/\.ext-refs\s*\{/);
+    expect(pieceCss).toMatch(/\.ext-refs\s+a\.ext-ref\s*\{/);
+    // Scoped style block in PiecePageLayout.astro must NOT carry these —
+    // React-island DOM doesn't get Astro's data-astro-cid scope.
+    const scoped = scopedStyleOf(piecePageAstro);
+    expect(scoped).not.toMatch(/\.ext-refs\s*\{/);
+    expect(scoped).not.toMatch(/\.ext-refs\s+a\.ext-ref\s*\{/);
+  });
+
+  test('serif accent, no underline, trailing ↗ glyph', () => {
+    const rule = pieceCss.match(/\.ext-refs\s+a\.ext-ref\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(rule).toMatch(/font-family:\s*var\(--font-serif\)/);
+    expect(rule).toMatch(/color:\s*var\(--accent\)/);
+    expect(rule).toMatch(/text-decoration:\s*none/);
+    expect(pieceCss).toMatch(/\.ext-refs\s+a\.ext-ref::after\s*\{[^}]*↗/);
+  });
+
+  test('hover adds 0.5px underline (border-bottom fade)', () => {
+    expect(pieceCss).toMatch(
+      /\.ext-refs\s+a\.ext-ref:hover[\s\S]*?border-bottom-color:\s*var\(--accent\)/,
+    );
+  });
+
+  test('list-style: none on the ul (no bullets)', () => {
+    const rule = pieceCss.match(/\.ext-refs\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(rule).toMatch(/list-style:\s*none/);
+  });
+});
+
+describe('Change log — global CSS reaches the React island', () => {
+  test('.changelog-* rules live in global piece-page.css', () => {
+    expect(pieceCss).toMatch(/\.changelog-list\s*\{/);
+    expect(pieceCss).toMatch(/\.changelog-row\s*\{/);
+  });
+
+  test('change-log page imports piece-page.css from frontmatter, not as scoped @import', () => {
+    // Frontmatter side-effect import is unscoped — keeps CSS rules applicable
+    // to the React-rendered ChangeLog island.
+    expect(changeLogPageAstro).toMatch(
+      /---[\s\S]*?import\s+['"]\.\.\/\.\.\/\.\.\/styles\/piece-page\.css['"];[\s\S]*?---/,
+    );
+    // Must NOT re-import via @import inside scoped <style> (prior bug:
+    // the @import scoped the rules to data-astro-cid-xxx and missed the
+    // island elements).
+    const scoped = scopedStyleOf(changeLogPageAstro);
+    expect(scoped).not.toMatch(/@import\s+['"][^'"]*piece-page\.css['"]/);
+  });
+});
+
+describe('Edition card — Option D clickable treatment', () => {
+  test('.ed-external-arrow matches External-references ↗ (muted, sans, 14px)', () => {
+    const rule = pieceCss.match(/\.ed-external-arrow\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(rule).toMatch(/color:\s*var\(--muted\)/);
+    expect(rule).toMatch(/font-family:\s*var\(--font-sans\)/);
+    expect(rule).toMatch(/font-size:\s*14px/);
+    expect(rule).toMatch(/position:\s*absolute/);
+  });
+
+  test('clickable row shows pointer cursor + focus-visible outline', () => {
+    expect(pieceCss).toMatch(/\.ed-row\.ed-clickable\s*\{[^}]*cursor:\s*pointer/);
+    expect(pieceCss).toMatch(
+      /\.ed-row\.ed-clickable:focus-visible\s*\{[^}]*outline:\s*2px\s+solid\s+var\(--accent\)/,
+    );
+  });
+});
+
+describe('Movement wiki-edit pencil placement', () => {
+  test('.movement-edit-pencil is end-of-row, hover-revealed on desktop, 40% on touch', () => {
+    expect(pieceCss).toMatch(/\.movement-edit-pencil\s*\{[^}]*opacity:\s*0/);
+    expect(pieceCss).toMatch(/@media\s*\(\s*pointer:\s*coarse\s*\)[\s\S]*?\.movement-edit-pencil\s*\{\s*opacity:\s*0\.4/);
+    expect(pieceCss).toMatch(/@media\s*\(\s*prefers-reduced-motion:\s*reduce\s*\)/);
+  });
+});
+
+describe('Change log link at piece-page bottom — Option D', () => {
+  test('serif accent with trailing → via ::after', () => {
+    // This one lives in PiecePageLayout.astro's scoped <style> because it's
+    // on Astro-rendered markup, not an island — so it's fine to be scoped.
+    const scoped = scopedStyleOf(piecePageAstro);
+    expect(scoped).toMatch(/\.change-log-link\s*\{/);
+    expect(scoped).toMatch(/\.change-log-link\s+a\s*\{[^}]*color:\s*var\(--accent\)/);
+    expect(scoped).toMatch(/\.change-log-link\s+a::after\s*\{[^}]*content:\s*'\s*→'/);
+  });
+});

--- a/src/integration/votes.test.ts
+++ b/src/integration/votes.test.ts
@@ -1,0 +1,363 @@
+// Slice C Step 4 integration tests: votes + vote_tallies RPCs + triggers.
+//
+// Covers:
+//   • cast_vote — upsert semantics, flip path, idempotent same-vote,
+//                 vote_value + subject_table validation, unauth rejection,
+//                 30/min rate-limit (shared cast_vote bucket).
+//   • clear_vote — deletes vote, decrements tally, safe no-op on nothing.
+//   • Trigger correctness (trg_votes_delta) — up_count / down_count /
+//                 net_score stay in sync across insert / flip / delete /
+//                 multiple users.
+//   • RLS on votes — authenticated user sees only their own rows.
+//   • Orphan cleanup (_clear_votes_on_subject_delete) — deleting a
+//                 performers_notes row cleans up vote rows and tally.
+//
+// Uses `publish_contributor_note` to create a real subject row for each
+// test so the integration path mirrors how votes are cast in production.
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  admin,
+  createAuthUser,
+  deleteAuthUser,
+  createTestPiece,
+  deleteTestPiece,
+} from './helpers';
+
+const PIECE = 'votes-test-piece';
+
+let voter: Awaited<ReturnType<typeof createAuthUser>>;
+let otherVoter: Awaited<ReturnType<typeof createAuthUser>>;
+let author: Awaited<ReturnType<typeof createAuthUser>>;
+
+async function publishNote(authorClient: SupabaseClient, body: string): Promise<string> {
+  const { data, error } = await authorClient.rpc('publish_contributor_note', {
+    p_piece_id: PIECE,
+    p_body: body,
+  });
+  if (error) throw new Error(`publish_contributor_note: ${error.message}`);
+  return data as string;
+}
+
+async function getTally(noteId: string): Promise<{ up: number; down: number; net: number } | null> {
+  const { data } = await admin
+    .from('vote_tallies')
+    .select('up_count, down_count, net_score')
+    .eq('subject_table', 'performers_notes')
+    .eq('subject_id', noteId)
+    .maybeSingle();
+  return data
+    ? { up: data.up_count, down: data.down_count, net: data.net_score }
+    : null;
+}
+
+async function clearRateLimit(userId: string): Promise<void> {
+  await admin.from('rate_limit_log').delete().eq('user_id', userId);
+}
+
+async function clearNotes(): Promise<void> {
+  await admin.from('performers_notes').update({ current_version_id: null }).eq('piece_id', PIECE);
+  await admin.from('performers_note_versions').delete().eq('piece_id', PIECE);
+  await admin.from('performers_notes').delete().eq('piece_id', PIECE);
+  // vote_tallies rows for deleted notes hang around under their own key —
+  // clear them so DB state is pristine between tests.
+  await admin.from('vote_tallies').delete().eq('subject_table', 'performers_notes');
+}
+
+beforeAll(async () => {
+  await createTestPiece(PIECE, 'Votes Test Piece');
+  voter = await createAuthUser({ displayName: 'Voter' });
+  otherVoter = await createAuthUser({ displayName: 'Other Voter' });
+  author = await createAuthUser({ isContributor: true, displayName: 'Author' });
+});
+
+afterAll(async () => {
+  await clearNotes();
+  await clearRateLimit(voter.id);
+  await clearRateLimit(otherVoter.id);
+  await clearRateLimit(author.id);
+  await deleteAuthUser(voter.id);
+  await deleteAuthUser(otherVoter.id);
+  await deleteAuthUser(author.id);
+  await deleteTestPiece(PIECE);
+});
+
+afterEach(async () => {
+  await clearNotes();
+  await clearRateLimit(voter.id);
+  await clearRateLimit(otherVoter.id);
+  await clearRateLimit(author.id);
+});
+
+// ============================================================================
+// cast_vote — happy path + tally sync
+// ============================================================================
+
+describe('cast_vote', () => {
+  test('insert upvote writes row + tally (+1/1/0)', async () => {
+    const noteId = await publishNote(author.client, 'subject');
+    const { error } = await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    expect(error).toBeNull();
+
+    const { data: voteRow } = await admin
+      .from('votes')
+      .select('vote_value, user_id')
+      .eq('subject_id', noteId)
+      .single();
+    expect(voteRow).toMatchObject({ vote_value: 1, user_id: voter.id });
+
+    const tally = await getTally(noteId);
+    expect(tally).toEqual({ up: 1, down: 0, net: 1 });
+  });
+
+  test('flip upvote → downvote via second cast_vote updates tally in place', async () => {
+    const noteId = await publishNote(author.client, 'flip target');
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: -1,
+    });
+
+    const { data: rows } = await admin
+      .from('votes')
+      .select('vote_value')
+      .eq('subject_id', noteId);
+    expect(rows).toHaveLength(1);
+    expect(rows![0].vote_value).toBe(-1);
+
+    const tally = await getTally(noteId);
+    expect(tally).toEqual({ up: 0, down: 1, net: -1 });
+  });
+
+  test('idempotent same-value call leaves tally unchanged', async () => {
+    const noteId = await publishNote(author.client, 'idempotent');
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+
+    const { count } = await admin
+      .from('votes')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_id', noteId);
+    expect(count).toBe(1);
+
+    const tally = await getTally(noteId);
+    expect(tally).toEqual({ up: 1, down: 0, net: 1 });
+  });
+
+  test('two users voting reconciles to up=1, down=1, net=0', async () => {
+    const noteId = await publishNote(author.client, 'multiuser');
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    await otherVoter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: -1,
+    });
+
+    const tally = await getTally(noteId);
+    expect(tally).toEqual({ up: 1, down: 1, net: 0 });
+  });
+
+  test('rejects vote_value outside {-1, 1}', async () => {
+    const noteId = await publishNote(author.client, 'range check');
+    const { error: zero } = await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 0,
+    });
+    expect(zero).not.toBeNull();
+    const { error: two } = await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 2,
+    });
+    expect(two).not.toBeNull();
+  });
+
+  test('rejects unknown subject_table', async () => {
+    const { error } = await voter.client.rpc('cast_vote', {
+      p_subject_table: 'movements',
+      p_subject_id: '00000000-0000-0000-0000-000000000000',
+      p_vote_value: 1,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/invalid subject_table/);
+  });
+
+  test('rejects unauthenticated caller', async () => {
+    const { createClient } = await import('@supabase/supabase-js');
+    const anonClient = createClient(
+      process.env.SUPABASE_URL!,
+      process.env.SUPABASE_ANON_KEY!,
+    );
+    const { error } = await anonClient.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: '00000000-0000-0000-0000-000000000000',
+      p_vote_value: 1,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/unauthenticated/);
+  });
+
+  test('rate-limited at 30/minute (shared cast_vote bucket)', async () => {
+    const noteId = await publishNote(author.client, 'rate target');
+    const rows = Array.from({ length: 30 }, () => ({
+      user_id: voter.id,
+      action: 'cast_vote',
+    }));
+    await admin.from('rate_limit_log').insert(rows);
+
+    const { error } = await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/rate limit/);
+  });
+});
+
+// ============================================================================
+// clear_vote
+// ============================================================================
+
+describe('clear_vote', () => {
+  test('deletes existing vote and decrements tally', async () => {
+    const noteId = await publishNote(author.client, 'clearable');
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    const { error } = await voter.client.rpc('clear_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+    });
+    expect(error).toBeNull();
+
+    const { count } = await admin
+      .from('votes')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_id', noteId);
+    expect(count).toBe(0);
+
+    const tally = await getTally(noteId);
+    expect(tally).toEqual({ up: 0, down: 0, net: 0 });
+  });
+
+  test('no-op when no vote exists', async () => {
+    const noteId = await publishNote(author.client, 'never voted');
+    const { error } = await voter.client.rpc('clear_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+    });
+    expect(error).toBeNull();
+  });
+});
+
+// ============================================================================
+// RLS on votes — authenticated user sees only own rows
+// ============================================================================
+
+describe('RLS on votes', () => {
+  test('voter only sees their own vote rows, not other voters', async () => {
+    const noteId = await publishNote(author.client, 'rls subject');
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    await otherVoter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: -1,
+    });
+
+    const { data: asVoter } = await voter.client.from('votes').select('vote_value, user_id');
+    expect(asVoter).toHaveLength(1);
+    expect(asVoter![0]).toMatchObject({ vote_value: 1, user_id: voter.id });
+
+    const { data: asOther } = await otherVoter.client.from('votes').select('vote_value, user_id');
+    expect(asOther).toHaveLength(1);
+    expect(asOther![0]).toMatchObject({ vote_value: -1, user_id: otherVoter.id });
+  });
+
+  test('anon gets no vote rows at all', async () => {
+    const noteId = await publishNote(author.client, 'anon subject');
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    const { createClient } = await import('@supabase/supabase-js');
+    const anonClient = createClient(
+      process.env.SUPABASE_URL!,
+      process.env.SUPABASE_ANON_KEY!,
+    );
+    const { data } = await anonClient.from('votes').select('vote_value');
+    expect(data ?? []).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Orphan cleanup — deleting a subject clears votes + tally
+// ============================================================================
+
+describe('_clear_votes_on_subject_delete', () => {
+  test('deleting a performers_note row clears its votes', async () => {
+    const noteId = await publishNote(author.client, 'doomed');
+    await voter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: 1,
+    });
+    await otherVoter.client.rpc('cast_vote', {
+      p_subject_table: 'performers_notes',
+      p_subject_id: noteId,
+      p_vote_value: -1,
+    });
+
+    // Hard-delete the note via admin (the RPC path soft-statuses to 'removed',
+    // which doesn't fire AFTER DELETE). Direct delete mimics piece cascade.
+    await admin.from('performers_notes').update({ current_version_id: null }).eq('id', noteId);
+    await admin.from('performers_note_versions').delete().eq('note_id', noteId);
+    const { error } = await admin.from('performers_notes').delete().eq('id', noteId);
+    expect(error).toBeNull();
+
+    const { count } = await admin
+      .from('votes')
+      .select('id', { count: 'exact', head: true })
+      .eq('subject_id', noteId);
+    expect(count).toBe(0);
+
+    const tally = await getTally(noteId);
+    // _apply_vote_delta fires on each vote DELETE and decrements. After both
+    // votes are cleared the tally is back to zero — but the ROW stays at
+    // zero (tallies don't self-delete). Either net=0 + zeros, or null if
+    // the row was otherwise cleaned — both acceptable states here.
+    if (tally !== null) {
+      expect(tally).toEqual({ up: 0, down: 0, net: 0 });
+    }
+  });
+});

--- a/src/lib/editions.ts
+++ b/src/lib/editions.ts
@@ -1,0 +1,42 @@
+// Editions: wiki-edit CRUD helpers. Any authenticated user can create,
+// edit, reorder, and soft-delete via the RPCs shipped in
+// 20260507000000_editions_wiki_crud.sql. Reads filter deleted_at IS NULL.
+
+import { supabase, hasSupabase } from './supabase';
+
+export interface Edition {
+  id: string;
+  pieceId: string;
+  publisher: string;
+  editor: string;
+  year: number | null;
+  description: string;
+  type: string | null;
+  url: string | null;
+  ordinal: number;
+}
+
+export async function fetchEditionsForPiece(pieceId: string): Promise<Edition[]> {
+  if (!hasSupabase) return [];
+  const { data, error } = await supabase
+    .from('editions')
+    .select('id, piece_id, publisher, editor, year, description, type, url, ordinal')
+    .eq('piece_id', pieceId)
+    .is('deleted_at', null)
+    .order('ordinal', { ascending: true });
+  if (error) {
+    console.error('fetchEditionsForPiece', error);
+    return [];
+  }
+  return (data ?? []).map((r: any) => ({
+    id: r.id,
+    pieceId: r.piece_id,
+    publisher: r.publisher,
+    editor: r.editor,
+    year: r.year,
+    description: r.description,
+    type: r.type,
+    url: r.url,
+    ordinal: r.ordinal,
+  }));
+}

--- a/src/lib/externalLinks.ts
+++ b/src/lib/externalLinks.ts
@@ -1,0 +1,43 @@
+// External-link CRUD helpers. Shared by the Recordings surface and the
+// External references surface — the UI splits rows by type.
+
+import { supabase, hasSupabase } from './supabase';
+
+export const REFERENCE_TYPES = ['imslp', 'wikipedia'] as const;
+export const RECORDING_TYPES = [
+  'youtube', 'vimeo', 'spotify', 'internet_archive', 'soundcloud', 'bandcamp',
+] as const;
+export type ExternalLinkType = typeof REFERENCE_TYPES[number] | typeof RECORDING_TYPES[number];
+
+export interface ExternalLink {
+  id: string;
+  pieceId: string;
+  type: string;
+  url: string;
+  label: string;
+  source: string;
+  ordinal: number;
+}
+
+export async function fetchExternalLinksForPiece(pieceId: string): Promise<ExternalLink[]> {
+  if (!hasSupabase) return [];
+  const { data, error } = await supabase
+    .from('external_links')
+    .select('id, piece_id, type, url, label, source, ordinal')
+    .eq('piece_id', pieceId)
+    .is('deleted_at', null)
+    .order('ordinal', { ascending: true });
+  if (error) {
+    console.error('fetchExternalLinksForPiece', error);
+    return [];
+  }
+  return (data ?? []).map((r: any) => ({
+    id: r.id,
+    pieceId: r.piece_id,
+    type: r.type,
+    url: r.url,
+    label: r.label,
+    source: r.source,
+    ordinal: r.ordinal,
+  }));
+}

--- a/src/lib/movements.ts
+++ b/src/lib/movements.ts
@@ -114,16 +114,25 @@ export async function fetchMovementHistory(movementId: string): Promise<Movement
 // Page-level change log
 // ============================================================================
 
+export type ChangeLogSubjectType =
+  | 'movement'
+  | "performer's note"
+  | 'interpretive school'
+  | 'piece description'
+  | 'edition'
+  | 'recording'
+  | 'external reference';
+
 export interface ChangeLogEntry {
   id: string;
   createdAt: string;
   authoredBy: string | null;
   authoredByDisplayName: string;
-  subjectType: 'movement'; // more types as they land
+  subjectType: ChangeLogSubjectType;
   subjectId: string;
   subjectLabel: string;
   editSummary: string | null;
-  versionNumber: number;
+  versionNumber: number | null;
 }
 
 /**

--- a/src/lib/votes.ts
+++ b/src/lib/votes.ts
@@ -1,0 +1,34 @@
+// Server + client helpers for the voting surface. Today the public
+// read-path is fetchOrderedSubjects — returns IDs sorted by
+// vote_tallies.net_score DESC without exposing the counts themselves (per
+// plan §2.5: vote_tallies is REVOKE'd from anon + authenticated, only the
+// SECURITY DEFINER RPC fetch_ordered_subjects is callable).
+
+import { supabase, hasSupabase } from './supabase';
+
+export type VoteSubjectTable =
+  | 'performers_notes'
+  | 'interpretive_schools'
+  | 'piece_descriptions'
+  | 'landmarks';
+
+/**
+ * Reorder a list of subject IDs by vote_tallies.net_score DESC (tie-break
+ * on id ASC). Returns the same IDs as the input in a new order, or the
+ * input unchanged if the RPC is unavailable.
+ */
+export async function fetchOrderedSubjects(
+  subjectTable: VoteSubjectTable,
+  ids: string[],
+): Promise<string[]> {
+  if (!hasSupabase || ids.length === 0) return ids;
+  const { data, error } = await supabase.rpc('fetch_ordered_subjects', {
+    p_subject_table: subjectTable,
+    p_subject_ids: ids,
+  });
+  if (error) {
+    console.error('fetchOrderedSubjects', error);
+    return ids;
+  }
+  return (data as string[]) ?? ids;
+}

--- a/src/pages/piece/[id]/change-log.astro
+++ b/src/pages/piece/[id]/change-log.astro
@@ -4,6 +4,7 @@ import Navbar from '../../../components/Navbar.astro';
 import ChangeLog from '../../../components/ChangeLog';
 import { getPieceBasic } from '../../../lib/pieces';
 import { fetchPieceChangelog } from '../../../lib/movements';
+import '../../../styles/piece-page.css';
 
 const { id } = Astro.params;
 const piece = await getPieceBasic(id || '');
@@ -48,8 +49,6 @@ const seoDescription = `Change log for ${piece.title} by ${piece.composer_name} 
 </Layout>
 
 <style>
-  @import '../../../styles/piece-page.css';
-
   .change-log-page {
     max-width: 820px;
     margin: 0 auto;

--- a/src/styles/piece-page.css
+++ b/src/styles/piece-page.css
@@ -469,6 +469,391 @@ h2.section { font-family: var(--font-serif); font-size: 22px; font-weight: 500; 
 .rec-table a.ext { color: var(--accent); text-decoration: none; font-size: 12px; }
 .rec-table a.ext:hover { text-decoration: underline; text-underline-offset: 2px; }
 
+/* External reference list (IMSLP, Wikipedia) — Option D: serif accent
+   with a trailing ↗ (muted) marking outbound. Border-underline fades in
+   on hover. Pills retired; the glyph carries the external signal. Lives
+   in global CSS (not the Astro scoped block) because the list is rendered
+   inside a React island whose DOM doesn't carry Astro's data-astro-cid
+   scope attribute. */
+.ext-refs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ext-refs li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ext-refs li.ext-ref-row { display: flex; }
+.ext-refs li.ext-ref-row .ext-ref { flex: 1; }
+.ext-refs li .ed-ctrls { opacity: 0; transition: opacity 120ms ease; }
+.ext-refs li:hover .ed-ctrls,
+.ext-refs li:focus-within .ed-ctrls { opacity: 1; }
+@media (pointer: coarse) { .ext-refs li .ed-ctrls { opacity: 0.6; } }
+.ext-refs a.ext-ref {
+  font-family: var(--font-serif);
+  font-size: 14px;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 0.5px solid transparent;
+  padding-bottom: 1px;
+  transition: border-color 160ms ease;
+}
+.ext-refs a.ext-ref::after {
+  content: ' ↗';
+  color: var(--muted);
+  font-family: var(--font-sans);
+  margin-left: 2px;
+}
+.ext-refs a.ext-ref:hover,
+.ext-refs a.ext-ref:focus-visible {
+  border-bottom-color: var(--accent);
+}
+.ext-refs a.ext-ref:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* Editions wiki-edit row. When the edition has a url, the whole card is
+   clickable (JS navigation on click/Enter/Space); controls stopPropagation
+   via their closest('.ed-ctrls') check so they don't also fire the
+   navigation. A trailing ↗ glyph at right-middle signals the outbound link
+   (Option D link style: serif accent, lightweight). */
+.ed-row.ed {
+  display: block;
+  padding: 16px 22px;
+  position: relative;
+}
+.ed-row.ed-clickable { cursor: pointer; }
+.ed-row.ed-clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.ed-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+  padding-right: 0;
+}
+.ed-head h3 { margin: 0; flex-shrink: 0; transition: color 120ms ease; }
+/* Matches the External-references ↗: sans, muted, 14px. Positioned at
+   right-middle of the card (vs inline ::after on ext-refs) since the
+   edition card has other content below the title. */
+.ed-external-arrow {
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1;
+  pointer-events: none;
+}
+.ed-row.ed-clickable:hover h3,
+.ed-row.ed-clickable:focus-visible h3 { color: var(--accent); }
+.ed-head .type-chip { margin-left: auto; }
+.ed-ctrls {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.ed-row:hover .ed-ctrls,
+.ed-row:focus-within .ed-ctrls {
+  opacity: 1;
+}
+@media (pointer: coarse) {
+  .ed-ctrls { opacity: 0.6; }
+}
+.ed-ctrl {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 12px;
+  margin: 0;
+  cursor: pointer;
+  color: var(--muted);
+  transition: color 120ms ease;
+  line-height: 0;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.ed-ctrl:hover:not(:disabled),
+.ed-ctrl:focus-visible { color: var(--accent); }
+.ed-ctrl-delete:hover:not(:disabled),
+.ed-ctrl-delete:focus-visible { color: var(--danger); }
+.ed-ctrl:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.ed-ctrl:disabled { opacity: 0; cursor: default; }
+.ed-confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--ink);
+  background: var(--danger-soft);
+  padding: 4px 8px;
+  border-radius: 4px;
+  margin-left: 4px;
+}
+.ed-confirm-yes, .ed-confirm-no {
+  appearance: none;
+  background: transparent;
+  border: 0.5px solid transparent;
+  padding: 2px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 500;
+}
+.ed-confirm-yes { color: var(--danger); border-color: var(--danger); }
+.ed-confirm-yes:hover:not(:disabled) { background: var(--danger); color: #fff; }
+.ed-confirm-no { color: var(--muted); border-color: var(--border-strong); }
+.ed-confirm-no:hover:not(:disabled) { color: var(--ink); }
+.ed-editing {
+  border: 0.5px solid var(--accent) !important;
+  padding: 16px 20px !important;
+  background: var(--bg);
+  display: block !important;
+}
+
+/* Signed description stack — a single active card with 1-2 "behind"
+   cards hinted by offset + shadow. Cycle chevrons below. Top card (active)
+   is the highest-voted; the synthetic "Seed data" card slots at the
+   bottom of the stack (user-authored ties win). */
+.desc-stack {
+  position: relative;
+  padding-bottom: 44px; /* room for controls */
+}
+.desc-stack-behind {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 44px;
+  background: var(--bg);
+  border: 0.5px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(26, 26, 26, 0.04);
+  pointer-events: none;
+}
+.desc-stack-behind.depth-1 {
+  transform: translate(6px, 6px);
+  opacity: 0.65;
+}
+.desc-stack-behind.depth-2 {
+  transform: translate(12px, 12px);
+  opacity: 0.35;
+}
+.desc-stack-top {
+  position: relative;
+  background: var(--bg);
+  border: 0.5px solid var(--border);
+  border-radius: 4px;
+  padding: 20px 24px;
+  box-shadow: 0 4px 12px rgba(26, 26, 26, 0.06);
+}
+.desc-seed .by .name {
+  font-style: italic;
+  color: var(--muted);
+}
+.desc-stack-controls {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding-top: 12px;
+}
+.desc-stack-chev {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: 18px;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: 4px;
+  line-height: 1;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+.desc-stack-chev:hover,
+.desc-stack-chev:focus-visible {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.desc-stack-chev:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.desc-stack-indicator {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--tertiary);
+  font-variant-numeric: tabular-nums;
+}
+.desc-stack-sep {
+  font-style: italic;
+  margin: 0 2px;
+}
+
+/* Owner edit/delete affordance for signed content (performer's notes,
+   interpretive schools, signed piece descriptions). Mirrors the movement
+   header pattern: pencil + × at end of byline row, hover-reveal on desktop,
+   40% on mobile, inline "Delete? Yes/No" confirmation in place of the ×.
+   Placed adjacent to the byline text, before VoteThumbs. */
+.owner-ctrls {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 6px;
+}
+.owner-ctrl {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 10px;
+  margin: -10px 0;
+  cursor: pointer;
+  color: var(--muted);
+  opacity: 0;
+  transition: opacity 120ms ease, color 120ms ease;
+  line-height: 0;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.owner-ctrl:hover:not(:disabled),
+.owner-ctrl:focus-visible {
+  opacity: 1;
+  color: var(--accent);
+}
+.owner-ctrl-delete:hover:not(:disabled),
+.owner-ctrl-delete:focus-visible {
+  color: var(--danger);
+}
+.owner-ctrl:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.owner-ctrl:disabled { opacity: 0; cursor: default; }
+.by:hover .owner-ctrl:not(:disabled),
+.by:focus-within .owner-ctrl:not(:disabled) {
+  opacity: 0.7;
+}
+@media (pointer: coarse) {
+  .owner-ctrl:not(:disabled) { opacity: 0.4; }
+  .by:hover .owner-ctrl:not(:disabled) { opacity: 0.4; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .owner-ctrl { transition: none; }
+}
+
+/* Inline delete confirmation, replaces the × while confirming. */
+.owner-confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--ink);
+  background: var(--danger-soft);
+  padding: 4px 8px;
+  border-radius: 4px;
+  margin-left: 4px;
+}
+.owner-confirm-yes,
+.owner-confirm-no {
+  appearance: none;
+  background: transparent;
+  border: 0.5px solid transparent;
+  padding: 2px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 500;
+}
+.owner-confirm-yes {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+.owner-confirm-yes:hover:not(:disabled) {
+  background: var(--danger);
+  color: #fff;
+}
+.owner-confirm-no {
+  color: var(--muted);
+  border-color: var(--border-strong);
+}
+.owner-confirm-no:hover:not(:disabled) { color: var(--ink); }
+.owner-confirm-yes:disabled,
+.owner-confirm-no:disabled { opacity: 0.55; cursor: default; }
+
+/* VoteThumbs — up/down affordance on signed content cards. Never renders
+   counts (plan §1.2). Active thumb uses success-emphasis (plan §7.3 /
+   §7.12) — NOT the brand purple, to avoid semantic collision with selected-
+   chrome. Placed at end of the byline row per user-feedback memory. */
+.vote-thumbs {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 4px;
+}
+.vote-thumb {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 10px;
+  margin: -10px 0;
+  cursor: pointer;
+  color: var(--tertiary);
+  transition: color 120ms ease, transform 120ms ease;
+  line-height: 0;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.vote-thumb:hover:not(:disabled),
+.vote-thumb:focus-visible {
+  color: var(--ink);
+}
+.vote-thumb:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.vote-thumb.is-active {
+  color: var(--success);
+}
+.vote-thumb.is-active:hover:not(:disabled) {
+  color: var(--success);
+  transform: scale(1.05);
+}
+.vote-thumbs.is-pending .vote-thumb { opacity: 0.6; cursor: progress; }
+@media (pointer: coarse) {
+  .vote-thumb { color: var(--muted); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .vote-thumb { transition: none; }
+  .vote-thumb.is-active:hover:not(:disabled) { transform: none; }
+}
+.vote-error {
+  display: inline-block;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  color: var(--danger);
+  margin-left: 8px;
+}
+
 /* Collapsed recordings list. One row per recording; click to expand the
    iframe inline. Iframe mounts on open (autoplay for YouTube/Vimeo) and
    unmounts on close so audio actually stops. */

--- a/supabase/migrations/20260502000000_votes_schema.sql
+++ b/supabase/migrations/20260502000000_votes_schema.sql
@@ -1,0 +1,176 @@
+-- Slice C Step 4: votes + trigger-maintained tallies.
+--
+-- Subject-agnostic votes. Users get up/down on any signed-content subject.
+-- Step 4 lights up voting on Slice A/B surfaces:
+--   - performers_notes
+--   - interpretive_schools
+--   - piece_descriptions
+-- `landmarks` is listed in the CHECK vocabulary so the constraint doesn't
+-- have to change when Step 6 lands, but no orphan trigger for it yet (the
+-- table doesn't exist).
+--
+-- Rev 5 design (per plan §2.5): trigger-maintained tally table instead of
+-- a materialized view. O(1) per vote, private by default (no public count
+-- display, ever — per PRD invariant).
+--
+-- RLS:
+--   - votes: authenticated users SELECT their own rows only (user_id =
+--     auth.uid()). Writes flow through cast_vote / clear_vote RPCs
+--     (SECURITY DEFINER). No anon read.
+--   - vote_tallies: REVOKE all from anon + authenticated. Reads go through
+--     a future `fetch_ordered_subjects` RPC (Step 5 stacking) or internal
+--     admin audits. This PR does not land that RPC — Step 4 only needs
+--     write path + per-user read for highlighting own thumb.
+
+begin;
+
+-- ============================================================================
+-- votes
+-- ============================================================================
+
+create table public.votes (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  subject_table text not null,
+  subject_id uuid not null,
+  vote_value smallint not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, subject_table, subject_id),
+  check (vote_value in (-1, 1)),
+  check (subject_table in (
+    'performers_notes', 'interpretive_schools', 'piece_descriptions', 'landmarks'
+  ))
+);
+
+create index ix_votes_subject on public.votes (subject_table, subject_id);
+create index ix_votes_user on public.votes (user_id);
+
+alter table public.votes enable row level security;
+
+-- Users can read only their own votes. The UI uses this to highlight the
+-- user's selected thumb. Other users' votes are invisible (no count leakage).
+create policy votes_select_own
+  on public.votes
+  for select
+  to authenticated
+  using (user_id = auth.uid());
+
+-- No direct insert/update/delete from the client — RPCs only.
+
+-- ============================================================================
+-- vote_tallies (trigger-maintained)
+-- ============================================================================
+
+create table public.vote_tallies (
+  subject_table text not null,
+  subject_id uuid not null,
+  net_score integer not null default 0,
+  up_count integer not null default 0,
+  down_count integer not null default 0,
+  updated_at timestamptz not null default now(),
+  primary key (subject_table, subject_id)
+);
+
+alter table public.vote_tallies enable row level security;
+
+-- REVOKE all — counts never reach the client. Reads happen server-side via
+-- SECURITY DEFINER RPCs (stacking order in Step 5).
+revoke all on public.vote_tallies from anon, authenticated;
+
+-- ============================================================================
+-- _apply_vote_delta — trigger that mutates vote_tallies on votes churn
+-- ============================================================================
+
+create or replace function public._apply_vote_delta() returns trigger
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  d_net integer := 0;
+  d_up integer := 0;
+  d_down integer := 0;
+begin
+  if TG_OP = 'INSERT' then
+    d_net := NEW.vote_value;
+    d_up := case when NEW.vote_value = 1 then 1 else 0 end;
+    d_down := case when NEW.vote_value = -1 then 1 else 0 end;
+    insert into public.vote_tallies
+      (subject_table, subject_id, net_score, up_count, down_count, updated_at)
+    values (NEW.subject_table, NEW.subject_id, d_net, d_up, d_down, now())
+    on conflict (subject_table, subject_id) do update
+      set net_score = vote_tallies.net_score + excluded.net_score,
+          up_count = vote_tallies.up_count + excluded.up_count,
+          down_count = vote_tallies.down_count + excluded.down_count,
+          updated_at = now();
+  elsif TG_OP = 'UPDATE' and OLD.vote_value <> NEW.vote_value then
+    d_net := NEW.vote_value - OLD.vote_value;
+    d_up := (case when NEW.vote_value = 1 then 1 else 0 end)
+          - (case when OLD.vote_value = 1 then 1 else 0 end);
+    d_down := (case when NEW.vote_value = -1 then 1 else 0 end)
+            - (case when OLD.vote_value = -1 then 1 else 0 end);
+    update public.vote_tallies
+      set net_score = net_score + d_net,
+          up_count = up_count + d_up,
+          down_count = down_count + d_down,
+          updated_at = now()
+      where subject_table = NEW.subject_table
+        and subject_id = NEW.subject_id;
+  elsif TG_OP = 'DELETE' then
+    d_net := -OLD.vote_value;
+    d_up := -(case when OLD.vote_value = 1 then 1 else 0 end);
+    d_down := -(case when OLD.vote_value = -1 then 1 else 0 end);
+    update public.vote_tallies
+      set net_score = net_score + d_net,
+          up_count = up_count + d_up,
+          down_count = down_count + d_down,
+          updated_at = now()
+      where subject_table = OLD.subject_table
+        and subject_id = OLD.subject_id;
+  end if;
+  return null;
+end;
+$$;
+
+create trigger trg_votes_delta
+  after insert or update or delete on public.votes
+  for each row execute function public._apply_vote_delta();
+
+-- ============================================================================
+-- _clear_votes_on_subject_delete — parameterized orphan cleanup
+-- ============================================================================
+--
+-- Votes are polymorphic and have no FK to the subject rows. When a subject
+-- is hard-deleted (performers_notes / interpretive_schools / piece_
+-- descriptions row goes away), its votes must be removed. The vote DELETE
+-- fires trg_votes_delta which reconciles vote_tallies automatically.
+
+create or replace function public._clear_votes_on_subject_delete() returns trigger
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+begin
+  delete from public.votes
+    where subject_table = TG_ARGV[0]
+      and subject_id = OLD.id;
+  return OLD;
+end;
+$$;
+
+create trigger trg_clear_votes_performers_notes
+  after delete on public.performers_notes
+  for each row execute function public._clear_votes_on_subject_delete('performers_notes');
+
+create trigger trg_clear_votes_interpretive_schools
+  after delete on public.interpretive_schools
+  for each row execute function public._clear_votes_on_subject_delete('interpretive_schools');
+
+create trigger trg_clear_votes_piece_descriptions
+  after delete on public.piece_descriptions
+  for each row execute function public._clear_votes_on_subject_delete('piece_descriptions');
+
+-- (landmarks orphan trigger lands with Step 6 when the table exists.)
+
+commit;

--- a/supabase/migrations/20260503000000_vote_rpcs.sql
+++ b/supabase/migrations/20260503000000_vote_rpcs.sql
@@ -1,0 +1,94 @@
+-- Slice C Step 4: cast_vote + clear_vote RPCs.
+--
+-- Both are SECURITY DEFINER and share a single 30/min rate-limit bucket
+-- (action key 'cast_vote') so rapid toggling between up/down counts against
+-- the same cap. Reuses the rate_limit_log + _check_rate_limit helper
+-- shipped in Step 3 (20260428000000).
+--
+-- cast_vote uses upsert semantics. Calling it with the same vote_value as
+-- an existing vote is a no-op (idempotent); calling it with a different
+-- value flips the vote (UPDATE path in trg_votes_delta reconciles tally).
+--
+-- clear_vote deletes the vote row. No error if the vote didn't exist —
+-- lets the client call it unconditionally when the user un-selects.
+
+begin;
+
+-- ============================================================================
+-- cast_vote
+-- ============================================================================
+
+create or replace function public.cast_vote(
+  p_subject_table text,
+  p_subject_id uuid,
+  p_vote_value smallint
+) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+begin
+  if v_uid is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  if p_vote_value not in (-1, 1) then
+    raise exception 'vote_value must be -1 or 1';
+  end if;
+
+  if p_subject_table not in (
+    'performers_notes', 'interpretive_schools', 'piece_descriptions', 'landmarks'
+  ) then
+    raise exception 'invalid subject_table: %', p_subject_table;
+  end if;
+
+  perform public._check_rate_limit('cast_vote', 30, 60);
+
+  -- Upsert. ON CONFLICT fires when the user already voted on this subject;
+  -- updating vote_value triggers trg_votes_delta's UPDATE branch which
+  -- reconciles the tally.
+  insert into public.votes (user_id, subject_table, subject_id, vote_value)
+  values (v_uid, p_subject_table, p_subject_id, p_vote_value)
+  on conflict (user_id, subject_table, subject_id) do update
+    set vote_value = excluded.vote_value,
+        updated_at = now();
+end;
+$$;
+
+revoke execute on function public.cast_vote(text, uuid, smallint) from public;
+grant execute on function public.cast_vote(text, uuid, smallint) to authenticated;
+
+-- ============================================================================
+-- clear_vote
+-- ============================================================================
+
+create or replace function public.clear_vote(
+  p_subject_table text,
+  p_subject_id uuid
+) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+begin
+  if v_uid is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  perform public._check_rate_limit('cast_vote', 30, 60);
+
+  delete from public.votes
+    where user_id = v_uid
+      and subject_table = p_subject_table
+      and subject_id = p_subject_id;
+end;
+$$;
+
+revoke execute on function public.clear_vote(text, uuid) from public;
+grant execute on function public.clear_vote(text, uuid) to authenticated;
+
+commit;

--- a/supabase/migrations/20260504000000_fetch_ordered_subjects.sql
+++ b/supabase/migrations/20260504000000_fetch_ordered_subjects.sql
@@ -1,0 +1,34 @@
+-- Slice C Step 5 (early): fetch_ordered_subjects RPC.
+--
+-- Returns the input IDs ordered by vote_tallies.net_score DESC, with a
+-- stable tie-break on id. Counts never leave the server — only the ordered
+-- ID list. vote_tallies is REVOKE'd from anon + authenticated (per plan
+-- §2.5), and this SECURITY DEFINER RPC is the public read surface.
+--
+-- Callers pass the IDs they already have permission to see (e.g. published
+-- performer's-note IDs, published signed-description IDs). The RPC never
+-- reveals existence of an ID the caller didn't already pass in.
+
+begin;
+
+create or replace function public.fetch_ordered_subjects(
+  p_subject_table text,
+  p_subject_ids uuid[]
+) returns uuid[]
+  language sql
+  security definer
+  set search_path = public
+as $$
+  select coalesce(
+    array_agg(s.id order by coalesce(t.net_score, 0) desc, s.id::text asc),
+    '{}'::uuid[]
+  )
+  from unnest(p_subject_ids) as s(id)
+  left join public.vote_tallies t
+    on t.subject_table = p_subject_table
+   and t.subject_id = s.id;
+$$;
+
+grant execute on function public.fetch_ordered_subjects(text, uuid[]) to anon, authenticated;
+
+commit;

--- a/supabase/migrations/20260505000000_content_mutation_log.sql
+++ b/supabase/migrations/20260505000000_content_mutation_log.sql
@@ -1,0 +1,149 @@
+-- Subject-agnostic audit log for piece-scoped content that doesn't have
+-- its own *_versions table (editions, external_links, and eventually the
+-- pedagogical arc when it lands).
+--
+-- Write path: AFTER INSERT / UPDATE / DELETE triggers on the covered
+-- tables. Each trigger logs one row here capturing who did it (auth.uid()
+-- captured at trigger fire time, or null for seed/admin-path writes),
+-- what subject, what action, and a derived human-readable label for the
+-- change log UI.
+--
+-- Read path: public.fetch_piece_changelog (amended in the next migration)
+-- UNIONs this table with every existing *_versions table. The RPC is
+-- SECURITY DEFINER; this table itself is REVOKE'd from clients so direct
+-- reads that might leak actor timestamps or detail blobs can't happen.
+
+begin;
+
+create table public.content_mutation_log (
+  id bigserial primary key,
+  piece_id text not null references public.pieces(id) on delete cascade,
+  subject_table text not null,
+  -- text (not uuid): editions.id + external_links.id are both text today;
+  -- versioned signed content uses uuid which we cast to text at union time.
+  subject_id text,
+  subject_label text,
+  subject_type text not null,
+  action text not null check (action in ('added', 'updated', 'deleted')),
+  actor_id uuid references public.users(id),
+  occurred_at timestamptz not null default now(),
+  detail jsonb not null default '{}'::jsonb
+);
+
+create index ix_cml_piece_time on public.content_mutation_log (piece_id, occurred_at desc);
+
+alter table public.content_mutation_log enable row level security;
+revoke all on public.content_mutation_log from anon, authenticated;
+-- Reads flow through fetch_piece_changelog (SECURITY DEFINER).
+
+-- ============================================================================
+-- _log_edition_mutation — trigger for public.editions INSERT/UPDATE/DELETE
+-- ============================================================================
+
+create or replace function public._log_edition_mutation() returns trigger
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_action text;
+  v_row record;
+  v_label text;
+begin
+  if TG_OP = 'INSERT' then
+    v_action := 'added';
+    v_row := NEW;
+  elsif TG_OP = 'UPDATE' then
+    v_action := 'updated';
+    v_row := NEW;
+  else
+    v_action := 'deleted';
+    v_row := OLD;
+  end if;
+
+  v_label := coalesce(v_row.publisher, 'Edition')
+           || case when v_row.year is not null then ' (' || v_row.year || ')' else '' end;
+
+  insert into public.content_mutation_log
+    (piece_id, subject_table, subject_id, subject_label, subject_type, action, actor_id, detail)
+  values (
+    v_row.piece_id,
+    'editions',
+    v_row.id,
+    v_label,
+    'edition',
+    v_action,
+    auth.uid(),
+    jsonb_build_object(
+      'publisher', v_row.publisher,
+      'editor', v_row.editor,
+      'year', v_row.year
+    )
+  );
+  return null;
+end;
+$$;
+
+create trigger trg_editions_log
+  after insert or update or delete on public.editions
+  for each row execute function public._log_edition_mutation();
+
+-- ============================================================================
+-- _log_external_link_mutation — trigger for public.external_links
+-- ============================================================================
+--
+-- Differentiates recordings from references via link type:
+--   youtube | vimeo | spotify | internet_archive | soundcloud | bandcamp → recording
+--   imslp | wikipedia | <other> → external reference
+
+create or replace function public._log_external_link_mutation() returns trigger
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_action text;
+  v_row record;
+  v_subject_type text;
+begin
+  if TG_OP = 'INSERT' then
+    v_action := 'added';
+    v_row := NEW;
+  elsif TG_OP = 'UPDATE' then
+    v_action := 'updated';
+    v_row := NEW;
+  else
+    v_action := 'deleted';
+    v_row := OLD;
+  end if;
+
+  v_subject_type := case
+    when v_row.type in ('youtube', 'vimeo', 'spotify', 'internet_archive', 'soundcloud', 'bandcamp')
+      then 'recording'
+    else 'external reference'
+  end;
+
+  insert into public.content_mutation_log
+    (piece_id, subject_table, subject_id, subject_label, subject_type, action, actor_id, detail)
+  values (
+    v_row.piece_id,
+    'external_links',
+    v_row.id,
+    coalesce(v_row.label, v_row.url),
+    v_subject_type,
+    v_action,
+    auth.uid(),
+    jsonb_build_object(
+      'type', v_row.type,
+      'url', v_row.url
+    )
+  );
+  return null;
+end;
+$$;
+
+create trigger trg_external_links_log
+  after insert or update or delete on public.external_links
+  for each row execute function public._log_external_link_mutation();
+
+commit;

--- a/supabase/migrations/20260506000000_fetch_piece_changelog_union.sql
+++ b/supabase/migrations/20260506000000_fetch_piece_changelog_union.sql
@@ -1,0 +1,195 @@
+-- Extended fetch_piece_changelog — UNIONs every versioned subject table
+-- plus content_mutation_log for non-versioned content (editions, external
+-- references, recordings). Pedagogical arc will join the union when its
+-- schema lands.
+--
+-- Return shape change: subject_id is now text (not uuid). Uuids from the
+-- versioned tables are cast to text at union time; editions.id and
+-- external_links.id are text natively. The change log UI treats subject_id
+-- as an opaque identifier — no existing caller computes on its type.
+--
+-- Edit-summary derivation:
+--   * movements: uses movement_versions.edit_summary verbatim
+--     (Step 3 RPCs populate 'created' / 'deleted' / 'reordered: N → M').
+--   * performer's notes / interpretive schools / piece descriptions:
+--     version_number = 1 → 'published', higher → 'edited', and soft-
+--     removed parent rows emit a trailing 'removed' entry.
+--   * editions / external references / recordings: content_mutation_log
+--     stores 'added' / 'updated' / 'deleted' directly.
+
+begin;
+
+drop function if exists public.fetch_piece_changelog(text);
+
+create or replace function public.fetch_piece_changelog(
+  p_piece_id text
+) returns table (
+  id text,
+  created_at timestamptz,
+  authored_by uuid,
+  authored_by_display_name text,
+  subject_type text,
+  subject_id text,
+  subject_label text,
+  edit_summary text,
+  version_number integer
+)
+  language sql
+  security definer
+  set search_path = public
+as $$
+  -- Movements: version rows carry author, timestamp, and an explicit
+  -- edit_summary string (added/edited/reordered/deleted).
+  select
+    mv.id::text as id,
+    mv.created_at,
+    mv.authored_by,
+    coalesce(u.display_name, 'Seed data') as authored_by_display_name,
+    'movement'::text as subject_type,
+    mv.movement_id::text as subject_id,
+    mv.name as subject_label,
+    mv.edit_summary,
+    mv.version_number
+  from public.movement_versions mv
+  left join public.users u on u.id = mv.authored_by
+  where mv.piece_id = p_piece_id
+
+  union all
+
+  -- Performer's notes: each version row = publish or edit.
+  select
+    pnv.id::text,
+    pnv.created_at,
+    pnv.authored_by,
+    coalesce(u.display_name, 'Seed data'),
+    'performer''s note'::text,
+    pnv.note_id::text,
+    substring(pnv.body from 1 for 80) as subject_label,
+    case when pnv.version_number = 1 then 'published' else 'edited' end,
+    pnv.version_number
+  from public.performers_note_versions pnv
+  left join public.users u on u.id = pnv.authored_by
+  where pnv.piece_id = p_piece_id
+    and pnv.approved_at is not null
+
+  union all
+
+  -- Soft-removals of performer's notes.
+  select
+    ('pnrm-' || pn.id::text),
+    pn.removed_at,
+    pn.removed_by,
+    coalesce(u.display_name, 'Seed data'),
+    'performer''s note'::text,
+    pn.id::text,
+    substring(coalesce(pnv.body, '') from 1 for 80),
+    'removed'::text,
+    null::integer
+  from public.performers_notes pn
+  left join public.performers_note_versions pnv on pnv.id = pn.current_version_id
+  left join public.users u on u.id = pn.removed_by
+  where pn.piece_id = p_piece_id
+    and pn.status = 'removed'
+    and pn.removed_at is not null
+
+  union all
+
+  -- Interpretive schools: each version row = publish or edit. Name lives
+  -- on the parent interpretive_schools table.
+  select
+    isv.id::text,
+    isv.created_at,
+    isv.authored_by,
+    coalesce(u.display_name, 'Seed data'),
+    'interpretive school'::text,
+    isv.school_id::text,
+    s.name,
+    case when isv.version_number = 1 then 'published' else 'edited' end,
+    isv.version_number
+  from public.interpretive_school_versions isv
+  join public.interpretive_schools s on s.id = isv.school_id
+  left join public.users u on u.id = isv.authored_by
+  where isv.piece_id = p_piece_id
+    and isv.approved_at is not null
+
+  union all
+
+  -- Soft-removals of interpretive schools.
+  select
+    ('isrm-' || s.id::text),
+    s.removed_at,
+    s.removed_by,
+    coalesce(u.display_name, 'Seed data'),
+    'interpretive school'::text,
+    s.id::text,
+    s.name,
+    'removed'::text,
+    null::integer
+  from public.interpretive_schools s
+  left join public.users u on u.id = s.removed_by
+  where s.piece_id = p_piece_id
+    and s.status = 'removed'
+    and s.removed_at is not null
+
+  union all
+
+  -- Piece descriptions: each version row = publish or edit.
+  select
+    pdv.id::text,
+    pdv.created_at,
+    pdv.authored_by,
+    coalesce(u.display_name, 'Seed data'),
+    'piece description'::text,
+    pdv.description_id::text,
+    substring(pdv.body from 1 for 80) as subject_label,
+    case when pdv.version_number = 1 then 'published' else 'edited' end,
+    pdv.version_number
+  from public.piece_description_versions pdv
+  left join public.users u on u.id = pdv.authored_by
+  where pdv.piece_id = p_piece_id
+    and pdv.approved_at is not null
+
+  union all
+
+  -- Soft-removals of piece descriptions.
+  select
+    ('pdrm-' || d.id::text),
+    d.removed_at,
+    d.removed_by,
+    coalesce(u.display_name, 'Seed data'),
+    'piece description'::text,
+    d.id::text,
+    substring(coalesce(pdv.body, '') from 1 for 80),
+    'removed'::text,
+    null::integer
+  from public.piece_descriptions d
+  left join public.piece_description_versions pdv on pdv.id = d.current_version_id
+  left join public.users u on u.id = d.removed_by
+  where d.piece_id = p_piece_id
+    and d.status = 'removed'
+    and d.removed_at is not null
+
+  union all
+
+  -- Editions / external references / recordings / (future) pedagogical
+  -- arc — non-versioned, audited via content_mutation_log triggers.
+  select
+    ('cml-' || cml.id::text),
+    cml.occurred_at,
+    cml.actor_id,
+    coalesce(u.display_name, 'Seed data'),
+    cml.subject_type,
+    cml.subject_id,
+    cml.subject_label,
+    cml.action,
+    null::integer
+  from public.content_mutation_log cml
+  left join public.users u on u.id = cml.actor_id
+  where cml.piece_id = p_piece_id
+
+  order by created_at desc, version_number desc nulls last;
+$$;
+
+grant execute on function public.fetch_piece_changelog(text) to anon, authenticated;
+
+commit;

--- a/supabase/migrations/20260507000000_editions_wiki_crud.sql
+++ b/supabase/migrations/20260507000000_editions_wiki_crud.sql
@@ -1,0 +1,221 @@
+-- Editions wiki-edit parity with movements: any authenticated user can
+-- create / update / reorder / (soft-)delete. Shares the 'content_edit'
+-- rate-limit bucket with external-link and pedagogical-arc CRUD.
+--
+-- Schema changes:
+--   - url text (optional, used by the UI to link out to publisher pages)
+--   - type text (optional: 'urtext' | 'scholarly' | 'performer' | 'facsimile' | 'critical' | 'practical')
+--   - ordinal smallint: display order per piece; new editions append at max+1
+--   - deleted_at timestamptz: soft-delete
+--   - created_by uuid: who added this edition (null for seed data)
+--   - Partial unique(piece_id, ordinal) WHERE deleted_at IS NULL so
+--     tombstones don't reserve ordinals
+
+begin;
+
+alter table public.editions add column if not exists url text;
+alter table public.editions add column if not exists type text;
+alter table public.editions add column if not exists ordinal smallint;
+alter table public.editions add column if not exists deleted_at timestamptz;
+alter table public.editions add column if not exists created_by uuid references public.users(id);
+
+-- Backfill ordinal for pre-existing rows based on insertion order.
+update public.editions e
+  set ordinal = sub.rn
+  from (
+    select id, row_number() over (partition by piece_id order by id) as rn
+    from public.editions
+    where ordinal is null
+  ) sub
+  where e.id = sub.id
+    and e.ordinal is null;
+
+alter table public.editions alter column ordinal set not null;
+alter table public.editions alter column ordinal set default 1;
+
+create unique index if not exists ux_editions_piece_ordinal_active
+  on public.editions (piece_id, ordinal)
+  where deleted_at is null;
+
+-- ============================================================================
+-- create_edition
+-- ============================================================================
+
+create or replace function public.create_edition(
+  p_piece_id text,
+  p_publisher text,
+  p_editor text,
+  p_year integer default null,
+  p_description text default '',
+  p_type text default null,
+  p_url text default null
+) returns text
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_id text;
+  v_next smallint;
+begin
+  if v_uid is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found: %', p_piece_id;
+  end if;
+  if char_length(coalesce(p_publisher, '')) < 1 or char_length(p_publisher) > 200 then
+    raise exception 'publisher must be 1-200 chars';
+  end if;
+  if char_length(coalesce(p_editor, '')) > 200 then
+    raise exception 'editor must be <= 200 chars';
+  end if;
+
+  select coalesce(max(ordinal), 0) + 1 into v_next
+    from public.editions
+    where piece_id = p_piece_id
+      and deleted_at is null;
+
+  v_id := 'ed-' || gen_random_uuid()::text;
+
+  insert into public.editions (
+    id, piece_id, publisher, editor, year, description, type, url, ordinal, created_by
+  ) values (
+    v_id, p_piece_id, p_publisher, coalesce(p_editor, ''), p_year,
+    coalesce(p_description, ''), p_type, p_url, v_next, v_uid
+  );
+
+  return v_id;
+end;
+$$;
+
+revoke execute on function public.create_edition(text, text, text, integer, text, text, text) from public;
+grant execute on function public.create_edition(text, text, text, integer, text, text, text) to authenticated;
+
+-- ============================================================================
+-- update_edition
+-- ============================================================================
+
+create or replace function public.update_edition(
+  p_id text,
+  p_publisher text,
+  p_editor text,
+  p_year integer default null,
+  p_description text default '',
+  p_type text default null,
+  p_url text default null
+) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_deleted_at timestamptz;
+begin
+  if v_uid is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select deleted_at into v_deleted_at from public.editions where id = p_id;
+  if not found then raise exception 'edition not found: %', p_id; end if;
+  if v_deleted_at is not null then raise exception 'edition is deleted'; end if;
+
+  if char_length(coalesce(p_publisher, '')) < 1 or char_length(p_publisher) > 200 then
+    raise exception 'publisher must be 1-200 chars';
+  end if;
+
+  update public.editions
+    set publisher = p_publisher,
+        editor = coalesce(p_editor, ''),
+        year = p_year,
+        description = coalesce(p_description, ''),
+        type = p_type,
+        url = p_url
+    where id = p_id;
+end;
+$$;
+
+revoke execute on function public.update_edition(text, text, text, integer, text, text, text) from public;
+grant execute on function public.update_edition(text, text, text, integer, text, text, text) to authenticated;
+
+-- ============================================================================
+-- delete_edition — soft-delete
+-- ============================================================================
+
+create or replace function public.delete_edition(p_id text) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_deleted_at timestamptz;
+begin
+  if v_uid is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select deleted_at into v_deleted_at from public.editions where id = p_id;
+  if not found then raise exception 'edition not found: %', p_id; end if;
+  if v_deleted_at is not null then raise exception 'edition already deleted'; end if;
+
+  update public.editions set deleted_at = now() where id = p_id;
+end;
+$$;
+
+revoke execute on function public.delete_edition(text) from public;
+grant execute on function public.delete_edition(text) to authenticated;
+
+-- ============================================================================
+-- swap_edition_ordinals
+-- ============================================================================
+
+create or replace function public.swap_edition_ordinals(
+  p_id_a text,
+  p_id_b text
+) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_a record;
+  v_b record;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+  if p_id_a = p_id_b then raise exception 'cannot swap with itself'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select * into v_a from public.editions where id = p_id_a;
+  if not found then raise exception 'edition A not found'; end if;
+  if v_a.deleted_at is not null then raise exception 'edition A is deleted'; end if;
+
+  select * into v_b from public.editions where id = p_id_b;
+  if not found then raise exception 'edition B not found'; end if;
+  if v_b.deleted_at is not null then raise exception 'edition B is deleted'; end if;
+
+  if v_a.piece_id <> v_b.piece_id then
+    raise exception 'editions belong to different pieces';
+  end if;
+
+  update public.editions set ordinal = -1 where id = p_id_a;
+  update public.editions set ordinal = v_a.ordinal where id = p_id_b;
+  update public.editions set ordinal = v_b.ordinal where id = p_id_a;
+end;
+$$;
+
+revoke execute on function public.swap_edition_ordinals(text, text) from public;
+grant execute on function public.swap_edition_ordinals(text, text) to authenticated;
+
+commit;

--- a/supabase/migrations/20260508000000_external_links_wiki_crud.sql
+++ b/supabase/migrations/20260508000000_external_links_wiki_crud.sql
@@ -1,0 +1,208 @@
+-- External-link wiki-edit parity (recordings + external references).
+-- `external_links` is the shared table; UI splits by type: recordings
+-- (youtube / vimeo / spotify / internet_archive / soundcloud / bandcamp)
+-- vs external references (imslp / wikipedia / anything else).
+--
+-- Schema changes:
+--   - ordinal smallint: display order per (piece, kind)  — UI orders each
+--     kind independently, but one shared numeric column is enough as long
+--     as the UI filters its own subset.
+--   - deleted_at timestamptz: soft-delete
+--   - created_by uuid: who added this link
+--   - Partial unique(piece_id, ordinal) WHERE deleted_at IS NULL — not
+--     per-kind since ordinal is only a sort key per-section in the UI;
+--     making the uniqueness span the whole piece keeps the swap RPC simple.
+--     Downside: a reorder in recordings can shift an external reference's
+--     absolute ordinal. UI handles this by swapping only within-kind IDs.
+
+begin;
+
+alter table public.external_links add column if not exists ordinal smallint;
+alter table public.external_links add column if not exists deleted_at timestamptz;
+alter table public.external_links add column if not exists created_by uuid references public.users(id);
+
+update public.external_links e
+  set ordinal = sub.rn
+  from (
+    select id, row_number() over (partition by piece_id order by id) as rn
+    from public.external_links
+    where ordinal is null
+  ) sub
+  where e.id = sub.id
+    and e.ordinal is null;
+
+alter table public.external_links alter column ordinal set not null;
+alter table public.external_links alter column ordinal set default 1;
+
+create unique index if not exists ux_external_links_piece_ordinal_active
+  on public.external_links (piece_id, ordinal)
+  where deleted_at is null;
+
+-- ============================================================================
+-- create_external_link
+-- ============================================================================
+
+create or replace function public.create_external_link(
+  p_piece_id text,
+  p_type text,
+  p_url text,
+  p_label text
+) returns text
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_id text;
+  v_next smallint;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found: %', p_piece_id;
+  end if;
+  if char_length(coalesce(p_url, '')) < 1 then
+    raise exception 'url required';
+  end if;
+  if char_length(coalesce(p_label, '')) < 1 or char_length(p_label) > 200 then
+    raise exception 'label must be 1-200 chars';
+  end if;
+
+  -- p_type must be a valid link_type enum value; cast raises on bad input.
+  perform p_type::public.link_type;
+
+  select coalesce(max(ordinal), 0) + 1 into v_next
+    from public.external_links
+    where piece_id = p_piece_id
+      and deleted_at is null;
+
+  v_id := 'xl-' || gen_random_uuid()::text;
+
+  insert into public.external_links (id, piece_id, type, url, label, source, ordinal, created_by)
+  values (v_id, p_piece_id, p_type::public.link_type, p_url, p_label, 'user', v_next, v_uid);
+
+  return v_id;
+end;
+$$;
+
+revoke execute on function public.create_external_link(text, text, text, text) from public;
+grant execute on function public.create_external_link(text, text, text, text) to authenticated;
+
+-- ============================================================================
+-- update_external_link
+-- ============================================================================
+
+create or replace function public.update_external_link(
+  p_id text,
+  p_type text,
+  p_url text,
+  p_label text
+) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_deleted_at timestamptz;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select deleted_at into v_deleted_at from public.external_links where id = p_id;
+  if not found then raise exception 'external link not found'; end if;
+  if v_deleted_at is not null then raise exception 'external link is deleted'; end if;
+
+  if char_length(coalesce(p_url, '')) < 1 then raise exception 'url required'; end if;
+  if char_length(coalesce(p_label, '')) < 1 or char_length(p_label) > 200 then
+    raise exception 'label must be 1-200 chars';
+  end if;
+  perform p_type::public.link_type;
+
+  update public.external_links
+    set type = p_type::public.link_type,
+        url = p_url,
+        label = p_label
+    where id = p_id;
+end;
+$$;
+
+revoke execute on function public.update_external_link(text, text, text, text) from public;
+grant execute on function public.update_external_link(text, text, text, text) to authenticated;
+
+-- ============================================================================
+-- delete_external_link — soft-delete
+-- ============================================================================
+
+create or replace function public.delete_external_link(p_id text) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_deleted_at timestamptz;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select deleted_at into v_deleted_at from public.external_links where id = p_id;
+  if not found then raise exception 'external link not found'; end if;
+  if v_deleted_at is not null then raise exception 'external link already deleted'; end if;
+
+  update public.external_links set deleted_at = now() where id = p_id;
+end;
+$$;
+
+revoke execute on function public.delete_external_link(text) from public;
+grant execute on function public.delete_external_link(text) to authenticated;
+
+-- ============================================================================
+-- swap_external_link_ordinals
+-- ============================================================================
+
+create or replace function public.swap_external_link_ordinals(
+  p_id_a text,
+  p_id_b text
+) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_a record;
+  v_b record;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+  if p_id_a = p_id_b then raise exception 'cannot swap with itself'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select * into v_a from public.external_links where id = p_id_a;
+  if not found then raise exception 'link A not found'; end if;
+  if v_a.deleted_at is not null then raise exception 'link A is deleted'; end if;
+
+  select * into v_b from public.external_links where id = p_id_b;
+  if not found then raise exception 'link B not found'; end if;
+  if v_b.deleted_at is not null then raise exception 'link B is deleted'; end if;
+
+  if v_a.piece_id <> v_b.piece_id then
+    raise exception 'links belong to different pieces';
+  end if;
+
+  update public.external_links set ordinal = -1 where id = p_id_a;
+  update public.external_links set ordinal = v_a.ordinal where id = p_id_b;
+  update public.external_links set ordinal = v_b.ordinal where id = p_id_a;
+end;
+$$;
+
+revoke execute on function public.swap_external_link_ordinals(text, text) from public;
+grant execute on function public.swap_external_link_ordinals(text, text) to authenticated;
+
+commit;

--- a/supabase/migrations/20260509000000_pedagogical_arc.sql
+++ b/supabase/migrations/20260509000000_pedagogical_arc.sql
@@ -1,0 +1,286 @@
+-- Pedagogical arc: directed piece-to-piece connections (prepare-with and
+-- natural-next). Per PRD: "prepare-with and natural-next connections" are
+-- the pedagogical arc — what to play before this piece to build the skills
+-- it demands, and what to study after it to extend that arc.
+--
+-- Schema:
+--   - piece_id: the subject of the arc
+--   - related_piece_id: the other piece (FK to pieces, cascade on delete)
+--   - kind: 'prepare_with' (before) | 'natural_next' (after)
+--   - note: optional short editorial line explaining the relationship
+--   - ordinal: display order within (piece_id, kind)
+--   - created_by: who added this connection
+--   - deleted_at: soft-delete
+--   - CHECK piece_id <> related_piece_id
+--
+-- Wiki-editable: any authenticated user can add/update/reorder/delete.
+-- Shares the 'content_edit' rate-limit bucket with editions + external
+-- links. Changes tracked through content_mutation_log (next migration).
+
+begin;
+
+create table public.pedagogical_connections (
+  id uuid primary key default gen_random_uuid(),
+  piece_id text not null references public.pieces(id) on delete cascade,
+  related_piece_id text not null references public.pieces(id) on delete cascade,
+  kind text not null check (kind in ('prepare_with', 'natural_next')),
+  note text,
+  ordinal smallint not null default 1,
+  created_by uuid references public.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz,
+  check (piece_id <> related_piece_id)
+);
+
+create index ix_pedagogical_piece_kind_ordinal
+  on public.pedagogical_connections (piece_id, kind, ordinal)
+  where deleted_at is null;
+
+-- Partial unique per (piece_id, kind, ordinal) — ordinals scoped per section.
+create unique index ux_pedagogical_piece_kind_ordinal_active
+  on public.pedagogical_connections (piece_id, kind, ordinal)
+  where deleted_at is null;
+
+alter table public.pedagogical_connections enable row level security;
+
+create policy pedagogical_select_public
+  on public.pedagogical_connections
+  for select
+  to anon, authenticated
+  using (true);
+
+-- Mutations go through RPCs (SECURITY DEFINER). No direct write policies.
+
+-- ============================================================================
+-- create_pedagogical_connection
+-- ============================================================================
+
+create or replace function public.create_pedagogical_connection(
+  p_piece_id text,
+  p_related_piece_id text,
+  p_kind text,
+  p_note text default null
+) returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_id uuid;
+  v_next smallint;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  if p_kind not in ('prepare_with', 'natural_next') then
+    raise exception 'kind must be prepare_with or natural_next';
+  end if;
+  if p_piece_id = p_related_piece_id then
+    raise exception 'cannot connect a piece to itself';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found: %', p_piece_id;
+  end if;
+  if not exists (select 1 from public.pieces where id = p_related_piece_id) then
+    raise exception 'related piece not found: %', p_related_piece_id;
+  end if;
+
+  select coalesce(max(ordinal), 0) + 1 into v_next
+    from public.pedagogical_connections
+    where piece_id = p_piece_id
+      and kind = p_kind
+      and deleted_at is null;
+
+  insert into public.pedagogical_connections
+    (piece_id, related_piece_id, kind, note, ordinal, created_by)
+  values
+    (p_piece_id, p_related_piece_id, p_kind, p_note, v_next, v_uid)
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+revoke execute on function public.create_pedagogical_connection(text, text, text, text) from public;
+grant execute on function public.create_pedagogical_connection(text, text, text, text) to authenticated;
+
+-- ============================================================================
+-- update_pedagogical_connection
+-- ============================================================================
+
+create or replace function public.update_pedagogical_connection(
+  p_id uuid,
+  p_related_piece_id text,
+  p_kind text,
+  p_note text default null
+) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_row record;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select * into v_row from public.pedagogical_connections where id = p_id;
+  if not found then raise exception 'connection not found'; end if;
+  if v_row.deleted_at is not null then raise exception 'connection is deleted'; end if;
+
+  if p_kind not in ('prepare_with', 'natural_next') then
+    raise exception 'kind must be prepare_with or natural_next';
+  end if;
+  if v_row.piece_id = p_related_piece_id then
+    raise exception 'cannot connect a piece to itself';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_related_piece_id) then
+    raise exception 'related piece not found: %', p_related_piece_id;
+  end if;
+
+  update public.pedagogical_connections
+    set related_piece_id = p_related_piece_id,
+        kind = p_kind,
+        note = p_note,
+        updated_at = now()
+    where id = p_id;
+end;
+$$;
+
+revoke execute on function public.update_pedagogical_connection(uuid, text, text, text) from public;
+grant execute on function public.update_pedagogical_connection(uuid, text, text, text) to authenticated;
+
+-- ============================================================================
+-- delete_pedagogical_connection — soft-delete
+-- ============================================================================
+
+create or replace function public.delete_pedagogical_connection(p_id uuid) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_deleted_at timestamptz;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select deleted_at into v_deleted_at from public.pedagogical_connections where id = p_id;
+  if not found then raise exception 'connection not found'; end if;
+  if v_deleted_at is not null then raise exception 'connection already deleted'; end if;
+
+  update public.pedagogical_connections set deleted_at = now(), updated_at = now() where id = p_id;
+end;
+$$;
+
+revoke execute on function public.delete_pedagogical_connection(uuid) from public;
+grant execute on function public.delete_pedagogical_connection(uuid) to authenticated;
+
+-- ============================================================================
+-- swap_pedagogical_ordinals — swap within the same (piece, kind)
+-- ============================================================================
+
+create or replace function public.swap_pedagogical_ordinals(
+  p_id_a uuid,
+  p_id_b uuid
+) returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_a record;
+  v_b record;
+begin
+  if v_uid is null then raise exception 'unauthenticated'; end if;
+  if p_id_a = p_id_b then raise exception 'cannot swap with itself'; end if;
+
+  perform public._check_rate_limit('content_edit', 30, 3600);
+
+  select * into v_a from public.pedagogical_connections where id = p_id_a;
+  if not found then raise exception 'connection A not found'; end if;
+  if v_a.deleted_at is not null then raise exception 'connection A is deleted'; end if;
+
+  select * into v_b from public.pedagogical_connections where id = p_id_b;
+  if not found then raise exception 'connection B not found'; end if;
+  if v_b.deleted_at is not null then raise exception 'connection B is deleted'; end if;
+
+  if v_a.piece_id <> v_b.piece_id or v_a.kind <> v_b.kind then
+    raise exception 'connections belong to different sections';
+  end if;
+
+  update public.pedagogical_connections set ordinal = -1 where id = p_id_a;
+  update public.pedagogical_connections set ordinal = v_a.ordinal where id = p_id_b;
+  update public.pedagogical_connections set ordinal = v_b.ordinal where id = p_id_a;
+
+  update public.pedagogical_connections
+    set updated_at = now()
+    where id in (p_id_a, p_id_b);
+end;
+$$;
+
+revoke execute on function public.swap_pedagogical_ordinals(uuid, uuid) from public;
+grant execute on function public.swap_pedagogical_ordinals(uuid, uuid) to authenticated;
+
+-- ============================================================================
+-- Trigger: log mutations to content_mutation_log
+-- ============================================================================
+
+create or replace function public._log_pedagogical_mutation() returns trigger
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_action text;
+  v_row record;
+  v_related_title text;
+begin
+  if TG_OP = 'INSERT' then v_action := 'added'; v_row := NEW;
+  elsif TG_OP = 'UPDATE' then
+    -- Soft-delete: set deleted_at — treat as delete action in the log.
+    if OLD.deleted_at is null and NEW.deleted_at is not null then
+      v_action := 'deleted';
+      v_row := OLD;
+    else
+      v_action := 'updated';
+      v_row := NEW;
+    end if;
+  else v_action := 'deleted'; v_row := OLD;
+  end if;
+
+  select title into v_related_title from public.pieces where id = v_row.related_piece_id;
+
+  insert into public.content_mutation_log
+    (piece_id, subject_table, subject_id, subject_label, subject_type, action, actor_id, detail)
+  values (
+    v_row.piece_id,
+    'pedagogical_connections',
+    v_row.id::text,
+    case v_row.kind
+      when 'prepare_with' then 'prepare with ' || coalesce(v_related_title, v_row.related_piece_id)
+      when 'natural_next' then 'natural next → ' || coalesce(v_related_title, v_row.related_piece_id)
+      else coalesce(v_related_title, v_row.related_piece_id)
+    end,
+    'pedagogical arc',
+    v_action,
+    auth.uid(),
+    jsonb_build_object('kind', v_row.kind, 'related_piece_id', v_row.related_piece_id, 'note', v_row.note)
+  );
+  return null;
+end;
+$$;
+
+create trigger trg_pedagogical_log
+  after insert or update or delete on public.pedagogical_connections
+  for each row execute function public._log_pedagogical_mutation();
+
+commit;

--- a/supabase/migrations/20260510000000_soft_delete_trigger_fix.sql
+++ b/supabase/migrations/20260510000000_soft_delete_trigger_fix.sql
@@ -1,0 +1,102 @@
+-- Fix: edition + external_link triggers logged soft-deletes as 'updated'.
+-- The pedagogical_connections trigger already handles the transition
+-- OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL → 'deleted'.
+-- Replicate that branch in the other two so the change log shows the
+-- correct action when delete_edition / delete_external_link fire.
+
+begin;
+
+create or replace function public._log_edition_mutation() returns trigger
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_action text;
+  v_row record;
+  v_label text;
+begin
+  if TG_OP = 'INSERT' then
+    v_action := 'added';
+    v_row := NEW;
+  elsif TG_OP = 'UPDATE' then
+    if OLD.deleted_at is null and NEW.deleted_at is not null then
+      v_action := 'deleted';
+      v_row := OLD;
+    else
+      v_action := 'updated';
+      v_row := NEW;
+    end if;
+  else
+    v_action := 'deleted';
+    v_row := OLD;
+  end if;
+
+  v_label := coalesce(v_row.publisher, 'Edition')
+           || case when v_row.year is not null then ' (' || v_row.year || ')' else '' end;
+
+  insert into public.content_mutation_log
+    (piece_id, subject_table, subject_id, subject_label, subject_type, action, actor_id, detail)
+  values (
+    v_row.piece_id,
+    'editions',
+    v_row.id,
+    v_label,
+    'edition',
+    v_action,
+    auth.uid(),
+    jsonb_build_object('publisher', v_row.publisher, 'editor', v_row.editor, 'year', v_row.year)
+  );
+  return null;
+end;
+$$;
+
+create or replace function public._log_external_link_mutation() returns trigger
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_action text;
+  v_row record;
+  v_subject_type text;
+begin
+  if TG_OP = 'INSERT' then
+    v_action := 'added';
+    v_row := NEW;
+  elsif TG_OP = 'UPDATE' then
+    if OLD.deleted_at is null and NEW.deleted_at is not null then
+      v_action := 'deleted';
+      v_row := OLD;
+    else
+      v_action := 'updated';
+      v_row := NEW;
+    end if;
+  else
+    v_action := 'deleted';
+    v_row := OLD;
+  end if;
+
+  v_subject_type := case
+    when v_row.type in ('youtube', 'vimeo', 'spotify', 'internet_archive', 'soundcloud', 'bandcamp')
+      then 'recording'
+    else 'external reference'
+  end;
+
+  insert into public.content_mutation_log
+    (piece_id, subject_table, subject_id, subject_label, subject_type, action, actor_id, detail)
+  values (
+    v_row.piece_id,
+    'external_links',
+    v_row.id,
+    coalesce(v_row.label, v_row.url),
+    v_subject_type,
+    v_action,
+    auth.uid(),
+    jsonb_build_object('type', v_row.type, 'url', v_row.url)
+  );
+  return null;
+end;
+$$;
+
+commit;


### PR DESCRIPTION
## Summary

Scope grew beyond plan Step 4 during review. This PR delivers:

1. **Step 4 — Votes + VoteThumbs**
2. **Early Step 5 — ordering-by-votes** for signed content (stacking)
3. **Unified page-level Change Log** across 7 subject types
4. **Wiki-edit CRUD** for editions + external references (new; movements parity)

### Votes + VoteThumbs
- `votes` + `vote_tallies` schema, trigger-maintained O(1) tallies (plan §2.5 Rev 5 — no materialized-view refresh, no public count exposure)
- \`cast_vote\` + \`clear_vote\` RPCs, 30/min shared \`cast_vote\` rate bucket
- RLS: \`votes\` select-own only; \`vote_tallies\` REVOKE all (reads via \`fetch_ordered_subjects\` SECURITY DEFINER only)
- Orphan-cleanup triggers on \`performers_notes\`, \`interpretive_schools\`, \`piece_descriptions\` (landmarks joins when schema lands in Step 6)
- \`VoteThumbs\` component (up/down, success-emphasis fill — not brand purple), mounted on all three Slice A/B signed surfaces, always-visible per the edit-affordance memory, anon click → shared sign-in prompt
- 13 new integration tests (RPC + trigger + RLS + orphan cleanup) — **119/119 passing**

### Early Step 5 (ordering by votes)
- \`fetch_ordered_subjects\` RPC returns IDs sorted by \`net_score DESC\`, tie-break id ASC; counts never reach the client
- \`SignedPieceDescription\` → single-card stack with cycle chevrons + synthetic "Seed data" card (\`pieces.description\`) slotted at stack end
- \`PerformersNotes\` + \`InterpretiveSchools\` → 3-at-a-time rotation, leftmost = highest-voted, \`← N of M →\` pager
- SSR reorder in \`PiecePageLayout\`

### Page-level Change Log
- \`content_mutation_log\` audit table + triggers on editions + external_links + pedagogical_connections
- \`fetch_piece_changelog\` UNIONs every versioned table + mutation log + soft-removal tombstones from Slice A/B parents
- Row format: \`{who} · {UTC timestamp} · {subject_type} {label} — {summary}\` for 7 subject types
- Fixed a recurring Astro-scoped-CSS-vs-React-island trap (memory: \`feedback_astro_scoped_css_react_island.md\`)

### Content CRUD (wiki-edit parity with movements)
- **Editions:** \`url\` + \`type\` + \`ordinal\` + \`deleted_at\` + \`created_by\` columns, partial unique index, \`create_edition\` / \`update_edition\` / \`delete_edition\` / \`swap_edition_ordinals\`
- **External_links:** \`ordinal\` + \`deleted_at\` + \`created_by\`, same CRUD quartet
- **Pedagogical arc:** new \`pedagogical_connections\` table (\`piece_id → related piece\`, \`kind=prepare_with|natural_next\`, ordinal, note, deleted_at) + CRUD RPCs + \`content_mutation_log\` trigger
- Shared \`content_edit\` 30/hour rate bucket reusing the Step 3 \`_check_rate_limit\` helper
- \`EditionsList\` — clickable card opens URL in new tab, trailing ↗ right-middle, type-chip flush right, hover-revealed ↑ ↓ ✎ × controls with inline delete confirm, + Add modal
- \`ExternalRefsList\` — same pattern, filters to reference link types
- \`OwnerEditDelete\` — unified pencil/× for owner-owned signed content (performers_notes / interpretive_schools / piece_descriptions), replacing the old Edit/Remove text buttons
- Option D link style: serif accent, no underline, trailing → (internal) / ↗ (external muted), 0.5px underline fades in on hover

### Deferred (schema + RPCs already shipped in this PR, UI pending) — logged in TODOS.md
- Recordings CRUD UI (extends \`RecordingsList\` on top of the collapse-to-play disclosure pattern)
- Pedagogical arc CRUD UI (needs a piece-picker autocomplete)

## Migrations

1. \`20260502_votes_schema\`
2. \`20260503_vote_rpcs\`
3. \`20260504_fetch_ordered_subjects\`
4. \`20260505_content_mutation_log\`
5. \`20260506_fetch_piece_changelog_union\`
6. \`20260507_editions_wiki_crud\`
7. \`20260508_external_links_wiki_crud\`
8. \`20260509_pedagogical_arc\`

Applied locally; CI auto-applies on merge via #50.

## Test plan

- [x] \`bun run test:integration\` — 119/119 passing (13 new votes tests)
- [x] Local verification against \`bach-cello-suite-1\` (seeded with 11 notes + 11 descriptions + 10 schools + sample votes to show ordering):
  - [x] Vote thumbs toggle + reconcile (up → filled / unvote / flip to down)
  - [x] Description stack cycles, synthetic "Seed data" card renders bodyless at end
  - [x] Notes / schools rotate 3 at a time with highest-voted leftmost
  - [x] Edition: edit in place, delete with inline confirm, reorder, add new; URL makes whole box clickable; ↗ subtle match with External references
  - [x] External refs: pencil/×/↑↓/Add; styling stays Option D (no bullets, no default blue underline)
  - [x] Change log page shows all 7 subject types
- [x] Browser smoke test on the merged artifact (reviewer)

## Still open (future PR)

- Recordings CRUD UI
- Pedagogical arc CRUD UI + piece picker
- Collision detection on concurrent edit (plan §7.7)
- \`database.types.ts\` regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)