### PR TITLE
feat(auth): email/password auth alongside Google SSO

### DIFF
--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
 import type { User } from '@supabase/supabase-js';
 import GenerativeAvatar from './GenerativeAvatar';
+import SignInPanel from './SignInPanel';
 
 export default function AuthButton() {
   const [user, setUser] = useState<User | null>(null);
@@ -9,6 +10,7 @@ export default function AuthButton() {
   const [userRole, setUserRole] = useState<string>('user');
   const [isMaestro, setIsMaestro] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [signInOpen, setSignInOpen] = useState(false);
 
   useEffect(() => {
     if (!hasSupabase) {
@@ -18,17 +20,17 @@ export default function AuthButton() {
 
     supabase.auth.getSession().then(({ data: { session } }) => {
       setUser(session?.user ?? null);
+      setLoading(false);
       if (session?.user) {
-        // Fetch avatar_url from public.users (respects user's choice)
+        // Fetch avatar_url from public.users (respects user's choice).
+        // Don't block the navbar on this — if the row is missing or the
+        // query fails, we still render the avatar via GenerativeAvatar.
         supabase.from('users').select('avatar_url, role, is_maestro').eq('id', session.user.id).single()
           .then(({ data }) => {
             setDbAvatarUrl(data?.avatar_url ?? null);
             setUserRole((data as any)?.role || 'user');
             setIsMaestro((data as any)?.is_maestro === true);
-            setLoading(false);
           });
-      } else {
-        setLoading(false);
       }
     });
 
@@ -38,15 +40,6 @@ export default function AuthButton() {
 
     return () => subscription.unsubscribe();
   }, []);
-
-  const handleSignIn = async () => {
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: window.location.href,
-      },
-    });
-  };
 
   if (loading) {
     return <span className="text-sm text-gray-400">...</span>;
@@ -84,11 +77,14 @@ export default function AuthButton() {
   }
 
   return (
-    <button
-      onClick={handleSignIn}
-      className="text-sm font-medium text-[#6B4E7C] hover:text-[#4C385C] transition-colors bg-transparent border-none cursor-pointer p-0"
-    >
-      Sign in
-    </button>
+    <>
+      <button
+        onClick={() => setSignInOpen(true)}
+        className="text-sm font-medium text-[#6B4E7C] hover:text-[#4C385C] transition-colors bg-transparent border-none cursor-pointer p-0"
+      >
+        Sign in
+      </button>
+      {signInOpen && <SignInPanel onClose={() => setSignInOpen(false)} />}
+    </>
   );
 }

--- a/src/components/CheckInbox.tsx
+++ b/src/components/CheckInbox.tsx
@@ -1,0 +1,77 @@
+// Post-signup landing page. Shown after a successful signup where email
+// confirmation is required. Tells the user to check their inbox, surfaces
+// the email they signed up with, and offers a resend button.
+//
+// The email is passed via ?email=... in the URL. We don't trust it for auth,
+// only for display + resend-target — Supabase will only send if that email
+// actually has an unconfirmed account.
+
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'busy' }
+  | { kind: 'sent' }
+  | { kind: 'error'; message: string };
+
+export default function CheckInbox() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setEmail(params.get('email') ?? '');
+  }, []);
+
+  const resend = useCallback(async (e: FormEvent) => {
+    e.preventDefault();
+    if (!hasSupabase || !email) return;
+    setStatus({ kind: 'busy' });
+    const { error } = await supabase.auth.resend({
+      type: 'signup',
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/auth/confirm` },
+    });
+    if (error) {
+      setStatus({ kind: 'error', message: error.message });
+      return;
+    }
+    setStatus({ kind: 'sent' });
+  }, [email]);
+
+  return (
+    <>
+      <h1 className="font-display text-[28px] mb-4">Check your inbox</h1>
+      <p className="text-ink text-[15px] leading-relaxed mb-2">
+        We&rsquo;ve sent a confirmation link{email ? <> to <strong className="text-ink">{email}</strong></> : null}.
+      </p>
+      <p className="text-muted text-sm mb-8">
+        Click the link in the email to finish creating your account. You can close this tab
+        in the meantime — once you confirm, you&rsquo;ll be signed in automatically.
+      </p>
+
+      {status.kind === 'sent' && (
+        <div className="ip-signin-info mb-4" role="status">
+          Confirmation email resent. Check your inbox.
+        </div>
+      )}
+      {status.kind === 'error' && (
+        <div className="ip-signin-error mb-4" role="alert">{status.message}</div>
+      )}
+
+      <form onSubmit={resend} className="flex items-center gap-3">
+        <button
+          type="submit"
+          className="ip-signin-btn ip-signin-btn-ghost"
+          disabled={status.kind === 'busy' || !email}
+        >
+          {status.kind === 'busy' ? 'Sending…' : 'Resend confirmation email'}
+        </button>
+        <a href="/" className="text-sm text-muted underline hover:text-accent">
+          Back to home
+        </a>
+      </form>
+    </>
+  );
+}

--- a/src/components/ConfirmEmail.tsx
+++ b/src/components/ConfirmEmail.tsx
@@ -1,0 +1,96 @@
+// Landing page for the Supabase signup-confirmation email link. Supabase
+// includes an access token in the URL hash; the JS client parses it on page
+// load and fires onAuthStateChange("SIGNED_IN") with a real session. We wait
+// briefly for that event and then show a success state + auto-redirect.
+//
+// If no session materializes within a short window, the link was either
+// malformed, expired, or already consumed — in that case we surface a
+// "link invalid or expired" message and let the user go back to sign in.
+
+import { useEffect, useState } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+
+type State =
+  | { kind: 'waiting' }
+  | { kind: 'confirmed' }
+  | { kind: 'error'; message: string };
+
+const REDIRECT_DELAY_MS = 1800;
+const WAIT_TIMEOUT_MS = 5000;
+
+export default function ConfirmEmail() {
+  const [state, setState] = useState<State>({ kind: 'waiting' });
+
+  useEffect(() => {
+    if (!hasSupabase) {
+      setState({ kind: 'error', message: 'Supabase is not configured.' });
+      return;
+    }
+
+    let settled = false;
+    const finish = (next: State) => {
+      if (settled) return;
+      settled = true;
+      setState(next);
+    };
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) finish({ kind: 'confirmed' });
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+      if (!session) return;
+      if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION' || event === 'TOKEN_REFRESHED') {
+        finish({ kind: 'confirmed' });
+      }
+    });
+
+    const timeout = window.setTimeout(() => {
+      finish({
+        kind: 'error',
+        message: 'This confirmation link is invalid or has expired. Try signing in — if your email is still unconfirmed, you can resend the link from there.',
+      });
+    }, WAIT_TIMEOUT_MS);
+
+    return () => {
+      sub.subscription.unsubscribe();
+      window.clearTimeout(timeout);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (state.kind !== 'confirmed') return;
+    const id = window.setTimeout(() => { window.location.href = '/'; }, REDIRECT_DELAY_MS);
+    return () => window.clearTimeout(id);
+  }, [state.kind]);
+
+  if (state.kind === 'waiting') {
+    return (
+      <>
+        <h1 className="font-display text-[26px] mb-4">Confirming your email…</h1>
+        <p className="text-sm text-muted">One moment while we finish signing you in.</p>
+      </>
+    );
+  }
+
+  if (state.kind === 'confirmed') {
+    return (
+      <>
+        <h1 className="font-display text-[26px] mb-4">Welcome to Irregular Pearl</h1>
+        <div className="ip-signin-info" role="status">
+          Email confirmed. Redirecting you home…
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h1 className="font-display text-[26px] mb-4">Confirmation link issue</h1>
+      <div className="ip-signin-error" role="alert">{state.message}</div>
+      <p className="mt-6 text-sm">
+        <a href="/" className="text-accent underline">Go home</a>
+      </p>
+    </>
+  );
+}

--- a/src/components/EditionsList.tsx
+++ b/src/components/EditionsList.tsx
@@ -7,10 +7,11 @@
 // mutation so state stays consistent with DB order.
 
 import { useCallback, useState, useEffect, useRef } from 'react';
-import { supabase, hasSupabase } from '../lib/supabase';
+import { supabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
 import { fetchEditionsForPiece, type Edition } from '../lib/editions';
 import { CHANGELOG_REFRESH_EVENT } from './ChangeLog';
+import SignInPanel from './SignInPanel';
 
 interface Props {
   pieceId: string;
@@ -203,7 +204,18 @@ export default function EditionsList({ pieceId, initialEditions }: Props) {
         </div>
       )}
 
-      {signInOpen && <SignInPrompt onClose={() => setSignInOpen(false)} />}
+      {signInOpen && (
+        <SignInPanel
+          onClose={() => setSignInOpen(false)}
+          title="Sign in to edit"
+          body={
+            <>
+              Editions are wiki-edit — any registered user can add, revise, reorder, or remove them.
+              Sign in or create an account to make your change.
+            </>
+          }
+        />
+      )}
       {addOpen && (
         <EditionAddModal
           pieceId={pieceId}
@@ -220,36 +232,6 @@ export default function EditionsList({ pieceId, initialEditions }: Props) {
 function prettyError(msg: string, fallback: string): string {
   if (msg.includes('rate limit')) return 'Too many edits — wait a moment.';
   return `${fallback}: ${msg}`;
-}
-
-function SignInPrompt({ onClose }: { onClose: () => void }) {
-  const handleSignIn = useCallback(async () => {
-    if (!hasSupabase) return;
-    await supabase.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: window.location.href } });
-  }, []);
-  useEffect(() => {
-    const h = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    document.addEventListener('keydown', h);
-    return () => document.removeEventListener('keydown', h);
-  }, [onClose]);
-  return (
-    <>
-      <div className="movement-edit-backdrop" onClick={onClose} aria-hidden="true" />
-      <div className="movement-edit-modal movement-edit-signin" role="dialog" aria-modal="true" aria-labelledby="ed-signin-title">
-        <h2 id="ed-signin-title" className="movement-edit-title">Sign in to edit</h2>
-        <p className="movement-edit-signin-body">
-          Editions are wiki-edit — any registered user can add, revise, reorder, or remove them.
-          Sign in or create an account to make your change.
-        </p>
-        <div className="movement-edit-actions">
-          <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onClose}>Cancel</button>
-          <button type="button" className="movement-edit-button movement-edit-button-primary" onClick={handleSignIn} autoFocus>
-            Sign in / Register
-          </button>
-        </div>
-      </div>
-    </>
-  );
 }
 
 // ----------------------------------------------------------------------------

--- a/src/components/ExternalRefsList.tsx
+++ b/src/components/ExternalRefsList.tsx
@@ -3,7 +3,7 @@
 // EditionsList and MovementsList.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { supabase, hasSupabase } from '../lib/supabase';
+import { supabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
 import {
   fetchExternalLinksForPiece,
@@ -11,6 +11,7 @@ import {
   type ExternalLink,
 } from '../lib/externalLinks';
 import { CHANGELOG_REFRESH_EVENT } from './ChangeLog';
+import SignInPanel from './SignInPanel';
 
 interface Props {
   pieceId: string;
@@ -166,7 +167,18 @@ export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
         </div>
       )}
 
-      {signInOpen && <SignInPrompt onClose={() => setSignInOpen(false)} kind="reference" />}
+      {signInOpen && (
+        <SignInPanel
+          onClose={() => setSignInOpen(false)}
+          title="Sign in to edit"
+          body={
+            <>
+              Reference entries are wiki-edit — any registered user can add, revise, reorder, or remove them.
+              Sign in or create an account to make your change.
+            </>
+          }
+        />
+      )}
       {addOpen && (
         <ExternalLinkAddModal
           pieceId={pieceId}
@@ -183,36 +195,6 @@ export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
 function pretty(msg: string, fallback: string): string {
   if (msg.includes('rate limit')) return 'Too many edits — wait a moment.';
   return `${fallback}: ${msg}`;
-}
-
-function SignInPrompt({ onClose, kind }: { onClose: () => void; kind: string }) {
-  const handleSignIn = useCallback(async () => {
-    if (!hasSupabase) return;
-    await supabase.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: window.location.href } });
-  }, []);
-  useEffect(() => {
-    const h = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    document.addEventListener('keydown', h);
-    return () => document.removeEventListener('keydown', h);
-  }, [onClose]);
-  return (
-    <>
-      <div className="movement-edit-backdrop" onClick={onClose} aria-hidden="true" />
-      <div className="movement-edit-modal movement-edit-signin" role="dialog" aria-modal="true" aria-labelledby="ext-signin-title">
-        <h2 id="ext-signin-title" className="movement-edit-title">Sign in to edit</h2>
-        <p className="movement-edit-signin-body">
-          {kind} entries are wiki-edit — any registered user can add, revise, reorder, or remove them.
-          Sign in or create an account to make your change.
-        </p>
-        <div className="movement-edit-actions">
-          <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onClose}>Cancel</button>
-          <button type="button" className="movement-edit-button movement-edit-button-primary" onClick={handleSignIn} autoFocus>
-            Sign in / Register
-          </button>
-        </div>
-      </div>
-    </>
-  );
 }
 
 interface Fields { type: string; url: string; label: string }

--- a/src/components/MovementEdit.tsx
+++ b/src/components/MovementEdit.tsx
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
 import type { Movement } from '../lib/movements';
+import SignInPanel from './SignInPanel';
 
 interface Props {
   movement: Movement;
@@ -75,13 +76,6 @@ export default function MovementEdit({ movement, onUpdated }: Props) {
   const closeSignInPrompt = useCallback(() => {
     setSignInPrompt(false);
     requestAnimationFrame(() => pencilRef.current?.focus());
-  }, []);
-
-  const handleSignIn = useCallback(async () => {
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo: window.location.href },
-    });
   }, []);
 
   // Focus trap + Esc handler while modal is open.
@@ -288,43 +282,16 @@ export default function MovementEdit({ movement, onUpdated }: Props) {
       )}
 
       {signInPrompt && (
-        <>
-          <div className="movement-edit-backdrop" onClick={closeSignInPrompt} aria-hidden="true" />
-          <div
-            className="movement-edit-modal movement-edit-signin"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="movement-signin-title"
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') closeSignInPrompt();
-            }}
-          >
-            <h2 id="movement-signin-title" className="movement-edit-title">
-              Sign in to edit
-            </h2>
-            <p className="movement-edit-signin-body">
+        <SignInPanel
+          onClose={closeSignInPrompt}
+          title="Sign in to edit"
+          body={
+            <>
               Movements are wiki-edit — any registered user can revise the name, tempo, key, or meter.
               Sign in or create an account to make your edit.
-            </p>
-            <div className="movement-edit-actions">
-              <button
-                type="button"
-                className="movement-edit-button movement-edit-button-ghost"
-                onClick={closeSignInPrompt}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="movement-edit-button movement-edit-button-primary"
-                onClick={handleSignIn}
-                autoFocus
-              >
-                Sign in / Register
-              </button>
-            </div>
-          </div>
-        </>
+            </>
+          }
+        />
       )}
     </>
   );

--- a/src/components/MovementsList.tsx
+++ b/src/components/MovementsList.tsx
@@ -14,9 +14,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import MovementEdit from './MovementEdit';
 import { CHANGELOG_REFRESH_EVENT } from './ChangeLog';
-import { supabase, hasSupabase } from '../lib/supabase';
+import { supabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
 import { fetchMovementsForPiece, type Movement } from '../lib/movements';
+import SignInPanel from './SignInPanel';
 
 export interface SeedMovement {
   name: string;
@@ -231,7 +232,18 @@ export default function MovementsList({ pieceId, initialMovements, seedMovements
         </div>
       )}
 
-      {signInOpen && <SignInPrompt onClose={() => setSignInOpen(false)} />}
+      {signInOpen && (
+        <SignInPanel
+          onClose={() => setSignInOpen(false)}
+          title="Sign in to edit"
+          body={
+            <>
+              Movements are wiki-edit — any registered user can add, revise, reorder, or remove them.
+              Sign in or create an account to make your change.
+            </>
+          }
+        />
+      )}
 
       {addOpen && (
         <AddMovementModal
@@ -243,61 +255,6 @@ export default function MovementsList({ pieceId, initialMovements, seedMovements
           }}
         />
       )}
-    </>
-  );
-}
-
-// ----------------------------------------------------------------------------
-// Shared sign-in prompt (used for anon interactions with any control).
-// ----------------------------------------------------------------------------
-
-function SignInPrompt({ onClose }: { onClose: () => void }) {
-  const handleSignIn = useCallback(async () => {
-    if (!hasSupabase) return;
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo: window.location.href },
-    });
-  }, []);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [onClose]);
-
-  return (
-    <>
-      <div className="movement-edit-backdrop" onClick={onClose} aria-hidden="true" />
-      <div
-        className="movement-edit-modal movement-edit-signin"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="movements-signin-title"
-      >
-        <h2 id="movements-signin-title" className="movement-edit-title">
-          Sign in to edit
-        </h2>
-        <p className="movement-edit-signin-body">
-          Movements are wiki-edit — any registered user can add, revise, reorder, or remove them.
-          Sign in or create an account to make your change.
-        </p>
-        <div className="movement-edit-actions">
-          <button type="button" className="movement-edit-button movement-edit-button-ghost" onClick={onClose}>
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="movement-edit-button movement-edit-button-primary"
-            onClick={handleSignIn}
-            autoFocus
-          >
-            Sign in / Register
-          </button>
-        </div>
-      </div>
     </>
   );
 }

--- a/src/components/PasswordSettings.tsx
+++ b/src/components/PasswordSettings.tsx
@@ -1,0 +1,154 @@
+// Settings-page section for setting or changing an account password.
+// Works for both kinds of users:
+//   - Email/password users: enter current + new → updateUser({ password }).
+//   - Google-signed-up users with no password yet: same updateUser call
+//     attaches an `email` identity to the existing auth.users row, so they
+//     can subsequently sign in with email + password too.
+//
+// Supabase's updateUser({ password }) does not require the current password,
+// but we collect it as a UX/security check and re-authenticate with
+// signInWithPassword before calling update. For users with no password on
+// file (pure Google signup), we skip the check.
+
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+import { useAuth } from '../lib/useAuth';
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'busy' }
+  | { kind: 'done'; message: string }
+  | { kind: 'error'; message: string };
+
+export default function PasswordSettings() {
+  const { user, loading } = useAuth();
+  const [hasPassword, setHasPassword] = useState<boolean | null>(null);
+  const [current, setCurrent] = useState('');
+  const [next, setNext] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+
+  useEffect(() => {
+    if (!user) { setHasPassword(null); return; }
+    // auth.users identities are not directly queryable from the anon client,
+    // but the user object exposes `identities` via getUser.
+    supabase.auth.getUser().then(({ data }) => {
+      const identities = data.user?.identities ?? [];
+      setHasPassword(identities.some((i) => i.provider === 'email'));
+    });
+  }, [user?.id]);
+
+  const submit = useCallback(async (e: FormEvent) => {
+    e.preventDefault();
+    if (!hasSupabase || !user?.email) return;
+    if (next.length < 6) {
+      setStatus({ kind: 'error', message: 'Password must be at least 6 characters.' });
+      return;
+    }
+    if (next !== confirm) {
+      setStatus({ kind: 'error', message: 'Passwords do not match.' });
+      return;
+    }
+    setStatus({ kind: 'busy' });
+
+    if (hasPassword) {
+      const { error: reauthErr } = await supabase.auth.signInWithPassword({
+        email: user.email,
+        password: current,
+      });
+      if (reauthErr) {
+        setStatus({ kind: 'error', message: 'Current password is incorrect.' });
+        return;
+      }
+    }
+
+    const { error } = await supabase.auth.updateUser({ password: next });
+    if (error) {
+      setStatus({ kind: 'error', message: error.message });
+      return;
+    }
+    setStatus({
+      kind: 'done',
+      message: hasPassword ? 'Password updated.' : 'Password set. You can now sign in with email and password.',
+    });
+    setCurrent('');
+    setNext('');
+    setConfirm('');
+    setHasPassword(true);
+  }, [current, next, confirm, hasPassword, user?.email]);
+
+  if (loading) return null;
+  if (!hasSupabase || !user) {
+    return (
+      <div className="text-center py-10 text-muted text-sm">
+        Sign in to manage your password.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-display text-xl">Password</h2>
+        {status.kind === 'done' && <span className="text-xs text-success">{status.message}</span>}
+      </div>
+
+      <p className="text-sm text-muted mb-5">
+        {hasPassword
+          ? 'Update your account password. You will need to re-enter your current password to confirm.'
+          : 'Your account was created via Google. Set a password to also sign in with email and password.'}
+      </p>
+
+      <form onSubmit={submit} className="flex flex-col gap-3 max-w-[420px]">
+        {hasPassword && (
+          <label className="ip-signin-field">
+            <span>Current password</span>
+            <input
+              type="password"
+              value={current}
+              onChange={(e) => setCurrent(e.target.value)}
+              autoComplete="current-password"
+              required
+            />
+          </label>
+        )}
+        <label className="ip-signin-field">
+          <span>New password</span>
+          <input
+            type="password"
+            value={next}
+            onChange={(e) => setNext(e.target.value)}
+            autoComplete="new-password"
+            minLength={6}
+            required
+          />
+        </label>
+        <label className="ip-signin-field">
+          <span>Confirm new password</span>
+          <input
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            autoComplete="new-password"
+            minLength={6}
+            required
+          />
+        </label>
+
+        {status.kind === 'error' && (
+          <div className="ip-signin-error" role="alert">{status.message}</div>
+        )}
+
+        <div className="ip-signin-actions">
+          <button
+            type="submit"
+            className="ip-signin-btn ip-signin-btn-primary"
+            disabled={status.kind === 'busy'}
+          >
+            {status.kind === 'busy' ? 'Saving…' : hasPassword ? 'Update password' : 'Set password'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/ResetPasswordForm.tsx
+++ b/src/components/ResetPasswordForm.tsx
@@ -1,0 +1,128 @@
+// Password-recovery landing page form. When Supabase sends the reset email,
+// the link brings the user here with a recovery token in the URL hash; the
+// JS client picks that up and raises an onAuthStateChange("PASSWORD_RECOVERY")
+// event with a valid session, at which point calling updateUser({ password })
+// sets a new password on that account (works for both email/password users
+// and Google-only users who had no password before).
+
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'waiting' }
+  | { kind: 'ready' }
+  | { kind: 'busy' }
+  | { kind: 'done' }
+  | { kind: 'error'; message: string };
+
+export default function ResetPasswordForm() {
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [status, setStatus] = useState<Status>({ kind: 'waiting' });
+
+  useEffect(() => {
+    if (!hasSupabase) {
+      setStatus({ kind: 'error', message: 'Supabase is not configured.' });
+      return;
+    }
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) setStatus({ kind: 'ready' });
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'PASSWORD_RECOVERY' && session) {
+        setStatus({ kind: 'ready' });
+      } else if (event === 'SIGNED_IN' && session) {
+        setStatus((s) => (s.kind === 'waiting' ? { kind: 'ready' } : s));
+      }
+    });
+
+    const timeout = window.setTimeout(() => {
+      setStatus((s) => s.kind === 'waiting'
+        ? { kind: 'error', message: 'Recovery link is missing or expired. Request a new one from the sign-in screen.' }
+        : s);
+    }, 4000);
+
+    return () => { sub.subscription.unsubscribe(); window.clearTimeout(timeout); };
+  }, []);
+
+  const submit = useCallback(async (e: FormEvent) => {
+    e.preventDefault();
+    if (password.length < 6) {
+      setStatus({ kind: 'error', message: 'Password must be at least 6 characters.' });
+      return;
+    }
+    if (password !== confirm) {
+      setStatus({ kind: 'error', message: 'Passwords do not match.' });
+      return;
+    }
+    setStatus({ kind: 'busy' });
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) {
+      setStatus({ kind: 'error', message: error.message });
+      return;
+    }
+    setStatus({ kind: 'done' });
+    setPassword('');
+    setConfirm('');
+    setTimeout(() => { window.location.href = '/'; }, 1800);
+  }, [password, confirm]);
+
+  if (status.kind === 'waiting') {
+    return <p className="text-sm text-muted">Validating recovery link…</p>;
+  }
+
+  if (status.kind === 'done') {
+    return (
+      <div className="ip-signin-info" role="status">
+        Password updated. Redirecting to the home page…
+      </div>
+    );
+  }
+
+  const disabled = status.kind === 'busy' || status.kind === 'error' && !password;
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3">
+      <label className="ip-signin-field">
+        <span>New password</span>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          minLength={6}
+          required
+          autoComplete="new-password"
+          autoFocus
+        />
+      </label>
+      <label className="ip-signin-field">
+        <span>Confirm password</span>
+        <input
+          type="password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          minLength={6}
+          required
+          autoComplete="new-password"
+        />
+      </label>
+
+      {status.kind === 'error' && (
+        <div className="ip-signin-error" role="alert">{status.message}</div>
+      )}
+
+      <div className="ip-signin-actions">
+        <button
+          type="submit"
+          className="ip-signin-btn ip-signin-btn-primary"
+          disabled={disabled}
+        >
+          {status.kind === 'busy' ? 'Saving…' : 'Set new password'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/SignInPanel.tsx
+++ b/src/components/SignInPanel.tsx
@@ -1,0 +1,361 @@
+// Shared sign-in / register / password-reset surface. Renders a centered
+// modal with three flows: choose-provider (Google + email), email-only
+// (sign in or create account), and forgot-password (request reset link).
+//
+// Used from the navbar AuthButton and from every anon "requires auth"
+// prompt (EditionsList, VoteThumbs, ExternalRefsList, MovementsList,
+// MovementEdit). Style primitives live in src/styles/global.css under the
+// .ip-signin-* namespace so the modal works on every page regardless of
+// which scoped stylesheets load.
+
+import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from 'react';
+import { supabase, hasSupabase } from '../lib/supabase';
+
+type Mode = 'choose' | 'signin' | 'signup' | 'forgot';
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'busy' }
+  | { kind: 'error'; message: string }
+  | { kind: 'unconfirmed'; email: string }
+  | { kind: 'info'; message: string };
+
+interface Props {
+  onClose: () => void;
+  title?: string;
+  body?: ReactNode;
+}
+
+export default function SignInPanel({ onClose, title = 'Sign in', body }: Props) {
+  const [mode, setMode] = useState<Mode>('choose');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const switchMode = useCallback((next: Mode) => {
+    setStatus({ kind: 'idle' });
+    setPassword('');
+    setMode(next);
+  }, []);
+
+  const signInWithGoogle = useCallback(async () => {
+    if (!hasSupabase) return;
+    setStatus({ kind: 'busy' });
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: window.location.href },
+    });
+    if (error) setStatus({ kind: 'error', message: prettyAuthError(error.message) });
+  }, []);
+
+  const submitSignIn = useCallback(async (e: FormEvent) => {
+    e.preventDefault();
+    if (!hasSupabase) return;
+    setStatus({ kind: 'busy' });
+    const trimmed = email.trim();
+    const { error } = await supabase.auth.signInWithPassword({
+      email: trimmed,
+      password,
+    });
+    if (error) {
+      if (/email not confirmed/i.test(error.message)) {
+        setStatus({ kind: 'unconfirmed', email: trimmed });
+        return;
+      }
+      setStatus({ kind: 'error', message: prettyAuthError(error.message) });
+      return;
+    }
+    onClose();
+  }, [email, password, onClose]);
+
+  const resendConfirmation = useCallback(async (addr: string) => {
+    if (!hasSupabase) return;
+    setStatus({ kind: 'busy' });
+    const { error } = await supabase.auth.resend({
+      type: 'signup',
+      email: addr,
+      options: { emailRedirectTo: `${window.location.origin}/auth/confirm` },
+    });
+    if (error) {
+      setStatus({ kind: 'error', message: prettyAuthError(error.message) });
+      return;
+    }
+    setStatus({
+      kind: 'info',
+      message: 'Confirmation email sent. Check your inbox.',
+    });
+  }, []);
+
+  const submitSignUp = useCallback(async (e: FormEvent) => {
+    e.preventDefault();
+    if (!hasSupabase) return;
+    setStatus({ kind: 'busy' });
+    const trimmed = email.trim();
+    const { data, error } = await supabase.auth.signUp({
+      email: trimmed,
+      password,
+      options: { emailRedirectTo: `${window.location.origin}/auth/confirm` },
+    });
+    if (error) {
+      setStatus({ kind: 'error', message: prettyAuthError(error.message) });
+      return;
+    }
+    if (data.session) {
+      onClose();
+      return;
+    }
+    window.location.href = `/auth/check-inbox?email=${encodeURIComponent(trimmed)}`;
+  }, [email, password, onClose]);
+
+  const submitForgot = useCallback(async (e: FormEvent) => {
+    e.preventDefault();
+    if (!hasSupabase) return;
+    setStatus({ kind: 'busy' });
+    const { error } = await supabase.auth.resetPasswordForEmail(email.trim(), {
+      redirectTo: `${window.location.origin}/auth/reset`,
+    });
+    if (error) {
+      setStatus({ kind: 'error', message: prettyAuthError(error.message) });
+      return;
+    }
+    setStatus({
+      kind: 'info',
+      message: 'If that email has an account, a reset link is on its way.',
+    });
+  }, [email]);
+
+  const busy = status.kind === 'busy';
+  const heading = mode === 'forgot' ? 'Reset your password'
+    : mode === 'signup' ? 'Create an account'
+    : title;
+
+  return (
+    <>
+      <div className="ip-signin-backdrop" onClick={onClose} aria-hidden="true" />
+      <div
+        className="ip-signin-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ip-signin-title"
+      >
+        <button
+          type="button"
+          className="ip-signin-close"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <h2 id="ip-signin-title" className="ip-signin-title">{heading}</h2>
+
+        {mode === 'choose' && body && <p className="ip-signin-body">{body}</p>}
+
+        {mode === 'choose' && (
+          <>
+            <button
+              type="button"
+              className="ip-signin-google"
+              onClick={signInWithGoogle}
+              disabled={busy}
+              autoFocus
+            >
+              <GoogleMark /> Continue with Google
+            </button>
+
+            <button
+              type="button"
+              className="ip-signin-alt"
+              onClick={() => switchMode('signin')}
+              disabled={busy}
+            >
+              Continue with email
+            </button>
+
+            <div className="ip-signin-sep" aria-hidden="true"><span>or</span></div>
+
+            <button
+              type="button"
+              className="ip-signin-create"
+              onClick={() => switchMode('signup')}
+              disabled={busy}
+            >
+              Create an account
+            </button>
+
+            {status.kind === 'error' && (
+              <div className="ip-signin-error" role="alert">{status.message}</div>
+            )}
+          </>
+        )}
+
+        {(mode === 'signin' || mode === 'signup') && (
+          <form onSubmit={mode === 'signin' ? submitSignIn : submitSignUp}>
+            <label className="ip-signin-field">
+              <span>Email</span>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
+                autoFocus
+              />
+            </label>
+            <label className="ip-signin-field">
+              <span>Password</span>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
+                minLength={6}
+                required
+              />
+            </label>
+
+            {status.kind === 'error' && (
+              <div className="ip-signin-error" role="alert">{status.message}</div>
+            )}
+            {status.kind === 'info' && (
+              <div className="ip-signin-info" role="status">{status.message}</div>
+            )}
+            {status.kind === 'unconfirmed' && (
+              <div className="ip-signin-error" role="alert">
+                This account&rsquo;s email isn&rsquo;t confirmed yet. Check your inbox for the confirmation link, or resend it.
+                <button
+                  type="button"
+                  className="ip-signin-link-btn"
+                  onClick={() => resendConfirmation(status.email)}
+                  disabled={busy}
+                >
+                  Resend confirmation email
+                </button>
+              </div>
+            )}
+
+            <div className="ip-signin-actions">
+              <button
+                type="button"
+                className="ip-signin-btn ip-signin-btn-ghost"
+                onClick={() => switchMode('choose')}
+                disabled={busy}
+              >
+                Back
+              </button>
+              <button
+                type="submit"
+                className="ip-signin-btn ip-signin-btn-primary"
+                disabled={busy}
+              >
+                {busy ? '…' : mode === 'signin' ? 'Sign in' : 'Create account'}
+              </button>
+            </div>
+
+            <div className="ip-signin-sublinks">
+              {mode === 'signin' ? (
+                <>
+                  <a href="#" onClick={(e) => { e.preventDefault(); switchMode('signup'); }}>
+                    Create an account
+                  </a>
+                  <a href="#" onClick={(e) => { e.preventDefault(); switchMode('forgot'); }}>
+                    Forgot password?
+                  </a>
+                </>
+              ) : (
+                <a href="#" onClick={(e) => { e.preventDefault(); switchMode('signin'); }}>
+                  Have an account? Sign in
+                </a>
+              )}
+            </div>
+          </form>
+        )}
+
+        {mode === 'forgot' && (
+          <form onSubmit={submitForgot}>
+            <p className="ip-signin-body">
+              Enter your email and we&rsquo;ll send a reset link.
+            </p>
+            <label className="ip-signin-field">
+              <span>Email</span>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
+                autoFocus
+              />
+            </label>
+
+            {status.kind === 'error' && (
+              <div className="ip-signin-error" role="alert">{status.message}</div>
+            )}
+            {status.kind === 'info' && (
+              <div className="ip-signin-info" role="status">{status.message}</div>
+            )}
+
+            <div className="ip-signin-actions">
+              <button
+                type="button"
+                className="ip-signin-btn ip-signin-btn-ghost"
+                onClick={() => switchMode('signin')}
+                disabled={busy}
+              >
+                Back
+              </button>
+              <button
+                type="submit"
+                className="ip-signin-btn ip-signin-btn-primary"
+                disabled={busy}
+              >
+                {busy ? '…' : 'Send reset link'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </>
+  );
+}
+
+function prettyAuthError(msg: string): string {
+  const m = msg.toLowerCase();
+  if (m.includes('invalid login') || m.includes('invalid credentials')) {
+    return 'Email or password is incorrect.';
+  }
+  if (m.includes('already registered') || m.includes('already exists') || m.includes('user already')) {
+    return 'That email already has an account. Try signing in instead.';
+  }
+  if (m.includes('rate') && m.includes('limit')) {
+    return 'Too many attempts — wait a minute and try again.';
+  }
+  if (m.includes('password') && (m.includes('6') || m.includes('short'))) {
+    return 'Password must be at least 6 characters.';
+  }
+  if (m.includes('email') && m.includes('valid')) {
+    return 'Please enter a valid email.';
+  }
+  if (m.includes('email not confirmed')) {
+    return 'Confirm your email first — check your inbox.';
+  }
+  return msg;
+}
+
+function GoogleMark() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 18 18" aria-hidden="true">
+      <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>
+      <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z"/>
+      <path fill="#FBBC05" d="M3.964 10.71A5.41 5.41 0 013.68 9c0-.593.102-1.17.284-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"/>
+      <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"/>
+    </svg>
+  );
+}

--- a/src/components/VoteThumbs.tsx
+++ b/src/components/VoteThumbs.tsx
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
+import SignInPanel from './SignInPanel';
 
 export type VoteSubjectTable =
   | 'performers_notes'
@@ -95,14 +96,6 @@ export default function VoteThumbs({ subjectTable, subjectId }: Props) {
     [user, vote, pending, subjectTable, subjectId],
   );
 
-  const handleSignIn = useCallback(async () => {
-    if (!hasSupabase) return;
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo: window.location.href },
-    });
-  }, []);
-
   const ariaUp = user
     ? vote === 1
       ? 'Remove upvote'
@@ -166,40 +159,16 @@ export default function VoteThumbs({ subjectTable, subjectId }: Props) {
       )}
 
       {signInOpen && (
-        <>
-          <div className="movement-edit-backdrop" onClick={() => setSignInOpen(false)} aria-hidden="true" />
-          <div
-            className="movement-edit-modal movement-edit-signin"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="vote-signin-title"
-          >
-            <h2 id="vote-signin-title" className="movement-edit-title">
-              Sign in to vote
-            </h2>
-            <p className="movement-edit-signin-body">
+        <SignInPanel
+          onClose={() => setSignInOpen(false)}
+          title="Sign in to vote"
+          body={
+            <>
               Voting helps the community surface the most trusted signed contributions.
               Sign in or create an account to cast your vote.
-            </p>
-            <div className="movement-edit-actions">
-              <button
-                type="button"
-                className="movement-edit-button movement-edit-button-ghost"
-                onClick={() => setSignInOpen(false)}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="movement-edit-button movement-edit-button-primary"
-                onClick={handleSignIn}
-                autoFocus
-              >
-                Sign in / Register
-              </button>
-            </div>
-          </div>
-        </>
+            </>
+          }
+        />
       )}
     </>
   );

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -81,7 +81,7 @@ const canonicalUrl = canonical || Astro.url.href;
     gtag('config', 'G-R3S9WT1EVV');
   </script>
 </head>
-<style>
+<style is:global>
   @import '../styles/global.css';
 </style>
 <body class="bg-bg text-ink min-h-screen font-body flex flex-col">

--- a/src/pages/auth/check-inbox.astro
+++ b/src/pages/auth/check-inbox.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Navbar from '../../components/Navbar.astro';
+import CheckInbox from '../../components/CheckInbox';
+---
+<Layout title="Check your inbox — Irregular Pearl" noindex={true}>
+  <Navbar />
+  <div class="max-w-[480px] mx-auto px-4 md:px-6 py-12 md:py-16">
+    <CheckInbox client:load />
+  </div>
+</Layout>

--- a/src/pages/auth/confirm.astro
+++ b/src/pages/auth/confirm.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Navbar from '../../components/Navbar.astro';
+import ConfirmEmail from '../../components/ConfirmEmail';
+---
+<Layout title="Email confirmed — Irregular Pearl" noindex={true}>
+  <Navbar />
+  <div class="max-w-[440px] mx-auto px-4 md:px-6 py-12">
+    <ConfirmEmail client:load />
+  </div>
+</Layout>

--- a/src/pages/auth/reset.astro
+++ b/src/pages/auth/reset.astro
@@ -1,0 +1,12 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Navbar from '../../components/Navbar.astro';
+import ResetPasswordForm from '../../components/ResetPasswordForm';
+---
+<Layout title="Reset password — Irregular Pearl" noindex={true}>
+  <Navbar />
+  <div class="max-w-[440px] mx-auto px-4 md:px-6 py-12">
+    <h1 class="font-display text-[26px] mb-6">Reset your password</h1>
+    <ResetPasswordForm client:load />
+  </div>
+</Layout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -11,7 +11,7 @@ import Navbar from '../components/Navbar.astro';
       <p><strong class="text-ink">Effective date:</strong> March 28, 2026</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">1. What we collect</h2>
-      <p>When you sign in with Google, we receive your name, email address, and profile picture. We store your display name and account identifier to attribute your contributions.</p>
+      <p>When you sign in with Google, we receive your name, email address, and profile picture. When you sign up with email and password, we store your email address. In either case we keep your display name and account identifier to attribute your contributions.</p>
       <p>When you use Irregular Pearl, we collect: edition ratings and which pieces you mark as "working on." This content is visible to other users.</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">2. What we do not collect</h2>
@@ -24,7 +24,7 @@ import Navbar from '../components/Navbar.astro';
       <ul class="list-disc pl-5 space-y-1">
         <li><strong class="text-ink">Supabase</strong> — authentication and database hosting</li>
         <li><strong class="text-ink">Cloudflare</strong> — website hosting and CDN</li>
-        <li><strong class="text-ink">Google</strong> — OAuth sign-in provider</li>
+        <li><strong class="text-ink">Google</strong> — optional OAuth sign-in provider</li>
         <li><strong class="text-ink">YouTube</strong> — embedded recordings (loaded only when you click play)</li>
       </ul>
       <p>Each service has its own privacy policy. We encourage you to review them.</p>

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import Navbar from '../components/Navbar.astro';
 import EmailPreferences from '../components/EmailPreferences';
+import PasswordSettings from '../components/PasswordSettings';
 ---
 <Layout title="Settings — Irregular Pearl">
   <Navbar />
@@ -9,8 +10,12 @@ import EmailPreferences from '../components/EmailPreferences';
   <div class="max-w-[600px] mx-auto px-4 md:px-6 py-8 md:py-10">
     <h1 class="font-display text-[28px] mb-8">Settings</h1>
 
-    <section id="email">
+    <section id="email" class="mb-10">
       <EmailPreferences client:load />
+    </section>
+
+    <section id="password" class="pt-8 border-t border-border">
+      <PasswordSettings client:load />
     </section>
   </div>
 </Layout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -17,7 +17,7 @@ import Navbar from '../components/Navbar.astro';
       <p>Irregular Pearl is a non-profit platform for classical music knowledge. We provide structured information about musical works, editions, and recordings.</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">3. User accounts</h2>
-      <p>You may browse Irregular Pearl without an account. To rate editions or mark pieces you're working on, you need to sign in via Google OAuth. You are responsible for your account activity.</p>
+      <p>You may browse Irregular Pearl without an account. To rate editions, contribute content, or mark pieces you're working on, you need an account — either by signing in with Google or by creating one with an email and password. You are responsible for your account activity.</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">4. User content</h2>
       <p>When you post reviews, you grant Irregular Pearl a non-exclusive, royalty-free license to display that content on the platform. You retain ownership of your content. You may delete your own posts at any time.</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -158,3 +158,220 @@ body {
     min-width: 44px;
   }
 }
+
+/* =========================================================================
+   SignInPanel — shared auth modal. Used from the navbar and every anon
+   "requires auth" prompt, so primitives live here (global) not in
+   piece-page.css.
+   ========================================================================= */
+
+.ip-signin-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 26, 26, 0.4);
+  z-index: 90;
+}
+.ip-signin-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(420px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  background: var(--bg);
+  border: 0.5px solid var(--border-strong);
+  border-radius: var(--r-card, 8px);
+  box-shadow: 0 12px 48px rgba(26, 26, 26, 0.18);
+  padding: 28px 28px 22px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.ip-signin-title {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  font-weight: 500;
+  margin: 0;
+  color: var(--ink);
+}
+.ip-signin-body {
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink);
+  margin: 0;
+}
+.ip-signin-google,
+.ip-signin-alt {
+  font: inherit;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  padding: 10px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border: 0.5px solid var(--border-strong);
+  background: var(--bg);
+  color: var(--ink);
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+.ip-signin-google:hover:not(:disabled),
+.ip-signin-alt:hover:not(:disabled) {
+  background: var(--bg-tint);
+  border-color: var(--ink);
+}
+.ip-signin-google:disabled,
+.ip-signin-alt:disabled { opacity: 0.55; cursor: default; }
+.ip-signin-sep {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+.ip-signin-sep::before,
+.ip-signin-sep::after {
+  content: "";
+  flex: 1;
+  height: 0;
+  border-top: 0.5px solid var(--border);
+}
+.ip-signin-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+.ip-signin-field + .ip-signin-field { margin-top: 6px; }
+.ip-signin-field > span {
+  color: var(--muted);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+.ip-signin-field input {
+  font: inherit;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  color: var(--ink);
+  padding: 8px 10px;
+  border: 0.5px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg);
+}
+.ip-signin-field input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  border-color: var(--accent);
+}
+.ip-signin-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 8px;
+}
+.ip-signin-btn {
+  font: inherit;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 0.5px solid transparent;
+}
+.ip-signin-btn:disabled { opacity: 0.55; cursor: default; }
+.ip-signin-btn-ghost {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--border-strong);
+}
+.ip-signin-btn-ghost:hover:not(:disabled) { color: var(--ink); }
+.ip-signin-btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+.ip-signin-btn-primary:hover:not(:disabled) { background: var(--accent-hover, #4C385C); }
+.ip-signin-error {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--danger);
+  background: var(--danger-soft);
+  padding: 10px 12px;
+  border-radius: 4px;
+}
+.ip-signin-info {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--success);
+  background: var(--success-soft);
+  padding: 10px 12px;
+  border-radius: 4px;
+}
+.ip-signin-sublinks {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 12px;
+  font-size: 12px;
+}
+.ip-signin-sublinks a {
+  color: var(--muted);
+  text-decoration: underline;
+  text-decoration-color: var(--border-strong);
+  text-underline-offset: 3px;
+}
+.ip-signin-sublinks a:hover { color: var(--accent); }
+.ip-signin-link-btn {
+  display: inline;
+  margin-left: 6px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--danger);
+  font: inherit;
+  font-size: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.ip-signin-link-btn:hover:not(:disabled) { color: var(--ink); }
+.ip-signin-link-btn:disabled { opacity: 0.55; cursor: default; }
+.ip-signin-close {
+  position: absolute;
+  top: 28px;
+  right: 22px;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+.ip-signin-close:hover { color: var(--ink); background: var(--bg-tint); }
+.ip-signin-close:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
+.ip-signin-create {
+  font: inherit;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  padding: 10px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  background: var(--accent);
+  color: #fff;
+  border: 0.5px solid var(--accent);
+  transition: background-color 120ms ease;
+}
+.ip-signin-create:hover:not(:disabled) { background: var(--accent-hover, #4C385C); }
+.ip-signin-create:disabled { opacity: 0.55; cursor: default; }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -153,7 +153,7 @@ enabled = true
 # in emails.
 site_url = "http://localhost:4321"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["http://localhost:4321", "http://localhost:4321/notifications", "http://127.0.0.1:4321"]
+additional_redirect_urls = ["http://localhost:4321", "http://localhost:4321/notifications", "http://localhost:4321/auth/reset", "http://localhost:4321/auth/confirm", "http://localhost:4321/auth/check-inbox", "http://127.0.0.1:4321", "http://127.0.0.1:4321/auth/reset", "http://127.0.0.1:4321/auth/confirm"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
@@ -206,7 +206,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.

--- a/supabase/migrations/20260511000000_gc_unconfirmed_users.sql
+++ b/supabase/migrations/20260511000000_gc_unconfirmed_users.sql
@@ -1,0 +1,53 @@
+-- Garbage-collect stale unconfirmed auth.users rows.
+--
+-- An email/password signup that never clicks the confirmation link leaves a
+-- row in auth.users with email_confirmed_at = null. It also creates a row in
+-- public.users via the handle_new_user trigger (display_name = email). These
+-- rows are unreachable — the user can't sign in — but they squat on the
+-- email and (more importantly) leak the email address through any public
+-- view that exposes display_name.
+--
+-- Mitigation: run daily at 03:00 UTC, delete every auth.users row with
+-- email_confirmed_at IS NULL older than 7 days. public.users cascades via FK
+-- (public.users.id references auth.users(id) on delete cascade, see initial
+-- schema migration). Cron job uses pg_cron which Supabase ships enabled on
+-- the postgres role.
+
+create extension if not exists pg_cron with schema extensions;
+
+create or replace function public.gc_unconfirmed_auth_users()
+returns integer
+language plpgsql
+security definer
+set search_path = public, auth, extensions
+as $$
+declare
+  deleted_count integer;
+begin
+  with victims as (
+    delete from auth.users
+    where email_confirmed_at is null
+      and created_at < now() - interval '7 days'
+    returning id
+  )
+  select count(*) into deleted_count from victims;
+  return deleted_count;
+end;
+$$;
+
+revoke all on function public.gc_unconfirmed_auth_users() from public, anon, authenticated;
+
+-- Schedule daily at 03:00 UTC. Unschedule first so re-running the migration
+-- is idempotent. cron.unschedule throws if the job doesn't exist, so wrap it.
+do $$
+begin
+  perform cron.unschedule('gc_unconfirmed_auth_users');
+exception when others then
+  null;
+end $$;
+
+select cron.schedule(
+  'gc_unconfirmed_auth_users',
+  '0 3 * * *',
+  $cron$ select public.gc_unconfirmed_auth_users() $cron$
+);


### PR DESCRIPTION
Adds a shared SignInPanel modal with three flows (chooser, email sign-in/sign-up, forgot password) and swaps the six existing Google-only SignInPrompt callsites to use it. Introduces a dedicated post-signup /auth/check-inbox page, a /auth/confirm landing for the confirmation email link, and /auth/reset for recovery. Adds a Password section to settings so Google-signed-up users can attach a password to the same account via supabase.auth.updateUser. Terms and privacy copy updated to cover both methods.

Backend: enables email confirmations in the local stack (matching prod), promotes Layout's scoped <style is:global> so the new signin CSS actually reaches React-rendered components, and adds a pg_cron migration that daily garbage-collects unconfirmed auth.users rows older than 7 days.