### PR TITLE
feat(slice-c): open self-authoring to any registered user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Irregular Pearl are recorded here. Format follows [Keep a
 
 ## [Unreleased]
 
+### Changed (contributor pipeline — Slice C governance)
+
+- **Any registered user can now self-author signed content** on a piece: performer's notes, interpretive schools, and signed piece descriptions. Prior posture (Slice A → B) gated every self-publish and approval-queue RPC on a `users.is_contributor` flag granted out-of-band via `scripts/seed-contributor.ts` — in practice, exactly one user. Per PRD rev 2 and [PLAN-contributor-pipeline-slice-c.md](PLAN-contributor-pipeline-slice-c.md) §1.0, the flag is replaced by plain auth: if you have an account, you're an author. Draft-for-another-user (`create_*_draft`) stays admin/firstchair-only, but the draftee can now be any registered user. The `is_contributor` / `contributor_active` columns remain in the schema as an unused editorial marker — a follow-up cleanup will drop them once nothing else references them.
+- **Write entries are always visible.** `Write a performer's note →` / `Write a school →` / `Write a signed description →` render for every viewer — signed-in, signed-out, whoever. Anon click opens the shared sign-in panel (same pattern MovementsList + EditionsList + VoteThumbs use) rather than hiding the affordance. Matches the "anon click opens sign-in prompt, never hidden" rule.
+- Ownership guards on edit / remove paths are untouched. User A still cannot edit or remove User B's row — the `where contributor_id = auth.uid()` inside each mutation RPC does the enforcement, not the caller gate.
+
 ### Fixed
 
 - **Movement wiki-edit was invisible on every piece page** — Slice C Step 2 shipped the `movements` table as schema-only, with row population deferred to `bun run supabase/seed.ts`. CI only applies migrations, not seed.ts, so production's `movements` table stayed empty across all 18 pieces. [MovementsList.tsx](src/components/MovementsList.tsx) correctly fell back to read-only rows from `src/data/seed.ts`, which by design render no edit affordances — pencil, ↑/↓, × were absent everywhere. New migration [20260512000000_backfill_seed_movements.sql](supabase/migrations/20260512000000_backfill_seed_movements.sql) inserts the 69 seed movements across 18 pieces plus their version-1 rows (authored_by null, marked "initial seed from src/data/seed.ts"). Idempotent via `NOT EXISTS (piece_id, ordinal)` guards — safe to re-run and won't overwrite any movement a user edited between ship and apply.

--- a/src/components/InterpretiveSchools.tsx
+++ b/src/components/InterpretiveSchools.tsx
@@ -16,6 +16,7 @@ import { supabase, hasSupabase } from '../lib/supabase';
 import type { PublishedInterpretiveSchool } from '../lib/interpretiveSchools';
 import VoteThumbs from './VoteThumbs';
 import OwnerEditDelete from './OwnerEditDelete';
+import SignInPanel from './SignInPanel';
 
 interface Props {
   pieceId: string;
@@ -24,7 +25,6 @@ interface Props {
 
 interface Viewer {
   userId: string | null;
-  isContributor: boolean;
   displayName: string | null;
   bioShort: string | null;
 }
@@ -38,6 +38,7 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pageIdx, setPageIdx] = useState(0);
+  const [signInOpen, setSignInOpen] = useState(false);
 
   const PAGE_SIZE = 3;
   const totalPages = Math.max(1, Math.ceil(schools.length / PAGE_SIZE));
@@ -48,23 +49,22 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
   const nextPage = () => setPageIdx((i) => (totalPages === 0 ? 0 : (i + 1) % totalPages));
 
   const loadViewer = useCallback(async () => {
-    if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
+    if (!hasSupabase) { setViewer({ userId: null, displayName: null, bioShort: null }); return; }
 
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.user) {
-      setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null });
+      setViewer({ userId: null, displayName: null, bioShort: null });
       return;
     }
 
     const { data } = await supabase
       .from('users')
-      .select('display_name, is_contributor, contributor_active, contributor_bio_short')
+      .select('display_name, contributor_bio_short')
       .eq('id', session.user.id)
       .single();
 
     setViewer({
       userId: session.user.id,
-      isContributor: Boolean(data?.is_contributor && data?.contributor_active),
       displayName: data?.display_name ?? null,
       bioShort: data?.contributor_bio_short ?? null,
     });
@@ -148,8 +148,9 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
     if (typeof window !== 'undefined') window.dispatchEvent(new Event('notifications:changed'));
   }
 
-  // CM5: always visible for eligible contributors. Label adapts.
-  const canWrite = Boolean(viewer?.isContributor);
+  // CM5: always visible. Any authed user can propose a school; anon sees
+  // the entry and gets a sign-in panel on click.
+  const canWrite = true;
   const writeLabel = schools.length === 0 ? 'Write a school' : 'Add another school';
 
   return (
@@ -243,13 +244,17 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
       {mode !== 'write' && canWrite && (
         <button
           type="button"
-          onClick={() => { setMode('write'); setError(null); }}
+          onClick={() => {
+            setError(null);
+            if (!viewer?.userId) { setSignInOpen(true); return; }
+            setMode('write');
+          }}
           className="write-entry"
         >
           {writeLabel} &rarr;
         </button>
       )}
-      {mode === 'write' && viewer && (
+      {mode === 'write' && viewer?.userId && (
         <div className="mt-6 school-card">
           <EditForm
             initialName=""
@@ -264,6 +269,16 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
             submittingLabel="Publishing…"
           />
         </div>
+      )}
+
+      {signInOpen && (
+        <SignInPanel
+          onClose={() => setSignInOpen(false)}
+          title="Sign in to write"
+          body={
+            <>Interpretive schools are signed — any registered user can propose one. Sign in or create an account to post yours.</>
+          }
+        />
       )}
 
       <style>{`

--- a/src/components/PerformersNotes.tsx
+++ b/src/components/PerformersNotes.tsx
@@ -16,6 +16,7 @@ import { supabase, hasSupabase } from '../lib/supabase';
 import type { PublishedPerformersNote } from '../lib/performersNotes';
 import VoteThumbs from './VoteThumbs';
 import OwnerEditDelete from './OwnerEditDelete';
+import SignInPanel from './SignInPanel';
 
 interface Props {
   pieceId: string;
@@ -24,7 +25,6 @@ interface Props {
 
 interface Viewer {
   userId: string | null;
-  isContributor: boolean;
   displayName: string | null;
   bioShort: string | null;
 }
@@ -38,6 +38,7 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pageIdx, setPageIdx] = useState(0);
+  const [signInOpen, setSignInOpen] = useState(false);
 
   const PAGE_SIZE = 3;
   const totalPages = Math.max(1, Math.ceil(notes.length / PAGE_SIZE));
@@ -48,23 +49,22 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
   const nextPage = () => setPageIdx((i) => (totalPages === 0 ? 0 : (i + 1) % totalPages));
 
   const loadViewer = useCallback(async () => {
-    if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
+    if (!hasSupabase) { setViewer({ userId: null, displayName: null, bioShort: null }); return; }
 
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.user) {
-      setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null });
+      setViewer({ userId: null, displayName: null, bioShort: null });
       return;
     }
 
     const { data } = await supabase
       .from('users')
-      .select('display_name, is_contributor, contributor_active, contributor_bio_short')
+      .select('display_name, contributor_bio_short')
       .eq('id', session.user.id)
       .single();
 
     setViewer({
       userId: session.user.id,
-      isContributor: Boolean(data?.is_contributor && data?.contributor_active),
       displayName: data?.display_name ?? null,
       bioShort: data?.contributor_bio_short ?? null,
     });
@@ -139,12 +139,14 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
     if (typeof window !== 'undefined') window.dispatchEvent(new Event('notifications:changed'));
   }
 
-  // Can the viewer write a brand-new note? Only if they're an active
-  // contributor AND they don't already have a published note on this piece.
+  // Can the viewer write a brand-new note? Any authed user who doesn't
+  // already have a published note on this piece. Anon users see the entry
+  // too; clicking opens the sign-in panel (never hidden, per the "anon
+  // click opens sign-in prompt" pattern).
   const viewerHasNote = Boolean(
     viewer?.userId && notes.some((n) => n.contributor.id === viewer.userId),
   );
-  const canWrite = Boolean(viewer?.isContributor && !viewerHasNote);
+  const canWrite = !viewerHasNote;
 
   return (
     <div>
@@ -226,17 +228,22 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
         </div>
       )}
 
-      {/* Write-a-note entry (only for contributors without a published note here) */}
+      {/* Write-a-note entry — any authed user without an existing note.
+          Anon click opens the sign-in panel. */}
       {mode !== 'write' && canWrite && (
         <button
           type="button"
-          onClick={() => { setMode('write'); setError(null); }}
+          onClick={() => {
+            setError(null);
+            if (!viewer?.userId) { setSignInOpen(true); return; }
+            setMode('write');
+          }}
           className="write-entry"
         >
           Write a performer's note &rarr;
         </button>
       )}
-      {mode === 'write' && viewer && (
+      {mode === 'write' && viewer?.userId && (
         <div className="mt-6 signed">
           <EditForm
             initial=""
@@ -249,6 +256,16 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
             submittingLabel="Publishing…"
           />
         </div>
+      )}
+
+      {signInOpen && (
+        <SignInPanel
+          onClose={() => setSignInOpen(false)}
+          title="Sign in to write"
+          body={
+            <>Performer's notes are signed — any registered user can publish their own. Sign in or create an account to post yours.</>
+          }
+        />
       )}
 
       <style>{`

--- a/src/components/SignedPieceDescription.tsx
+++ b/src/components/SignedPieceDescription.tsx
@@ -11,6 +11,7 @@ import { supabase, hasSupabase } from '../lib/supabase';
 import type { PublishedPieceDescription } from '../lib/pieceDescriptions';
 import VoteThumbs from './VoteThumbs';
 import OwnerEditDelete from './OwnerEditDelete';
+import SignInPanel from './SignInPanel';
 
 interface Props {
   pieceId: string;
@@ -27,7 +28,6 @@ type StackItem =
 
 interface Viewer {
   userId: string | null;
-  isContributor: boolean;
   displayName: string | null;
   bioShort: string | null;
 }
@@ -41,6 +41,7 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [stackIdx, setStackIdx] = useState(0);
+  const [signInOpen, setSignInOpen] = useState(false);
 
   const stackItems: StackItem[] = [
     ...descriptions.map((desc) => ({ kind: 'user' as const, desc })),
@@ -54,23 +55,22 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
   const next = () => setStackIdx((i) => (stackItems.length === 0 ? 0 : (i + 1) % stackItems.length));
 
   const loadViewer = useCallback(async () => {
-    if (!hasSupabase) { setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null }); return; }
+    if (!hasSupabase) { setViewer({ userId: null, displayName: null, bioShort: null }); return; }
 
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.user) {
-      setViewer({ userId: null, isContributor: false, displayName: null, bioShort: null });
+      setViewer({ userId: null, displayName: null, bioShort: null });
       return;
     }
 
     const { data } = await supabase
       .from('users')
-      .select('display_name, is_contributor, contributor_active, contributor_bio_short')
+      .select('display_name, contributor_bio_short')
       .eq('id', session.user.id)
       .single();
 
     setViewer({
       userId: session.user.id,
-      isContributor: Boolean(data?.is_contributor && data?.contributor_active),
       displayName: data?.display_name ?? null,
       bioShort: data?.contributor_bio_short ?? null,
     });
@@ -150,7 +150,9 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
     if (typeof window !== 'undefined') window.dispatchEvent(new Event('notifications:changed'));
   }
 
-  const canWrite = Boolean(viewer?.isContributor);
+  // Any authed user can write. Anon sees the entry and gets a sign-in
+  // panel on click.
+  const canWrite = true;
   const writeLabel = descriptions.length === 0 ? 'Write a signed description' : 'Add another description';
 
   return (
@@ -246,13 +248,17 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
       {mode !== 'write' && canWrite && (
         <button
           type="button"
-          onClick={() => { setMode('write'); setError(null); }}
+          onClick={() => {
+            setError(null);
+            if (!viewer?.userId) { setSignInOpen(true); return; }
+            setMode('write');
+          }}
           className="write-entry"
         >
           {writeLabel} &rarr;
         </button>
       )}
-      {mode === 'write' && viewer && (
+      {mode === 'write' && viewer?.userId && (
         <div className="mt-6 description-essay">
           <EssayEditForm
             initial=""
@@ -265,6 +271,16 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
             submittingLabel="Publishing…"
           />
         </div>
+      )}
+
+      {signInOpen && (
+        <SignInPanel
+          onClose={() => setSignInOpen(false)}
+          title="Sign in to write"
+          body={
+            <>Signed descriptions are authored — any registered user can publish their take on a piece. Sign in or create an account to post yours.</>
+          }
+        />
       )}
 
       <style>{`

--- a/src/integration/contributorPipeline.test.ts
+++ b/src/integration/contributorPipeline.test.ts
@@ -276,13 +276,23 @@ describe('staff-drafted path', () => {
 });
 
 describe('forbidden transitions', () => {
-  test('non-contributor cannot call publish_contributor_note', async () => {
-    const { error } = await normalUser.client.rpc('publish_contributor_note', {
-      p_piece_id: PIECE,
-      p_body: 'should fail',
-    });
-    expect(error).not.toBeNull();
-    expect(error!.message).toContain('not an active contributor');
+  test('any registered user can publish_contributor_note', async () => {
+    // Post-Slice-C governance (20260513000000_open_self_authoring.sql):
+    // the is_contributor flag is no longer a gate; auth is all that's
+    // required. Ownership guards still prevent user A editing user B's row.
+    const { data: noteId, error } = await normalUser.client.rpc(
+      'publish_contributor_note',
+      { p_piece_id: PIECE, p_body: 'self-authored by non-flagged user' },
+    );
+    expect(error).toBeNull();
+    expect(noteId).toBeTruthy();
+    const { data: row } = await admin
+      .from('performers_notes')
+      .select('contributor_id, status')
+      .eq('id', noteId as string)
+      .single();
+    expect(row?.contributor_id).toBe(normalUser.id);
+    expect(row?.status).toBe('published');
   });
 
   test('non-staff cannot call create_performers_note_draft', async () => {

--- a/src/integration/interpretiveSchools.test.ts
+++ b/src/integration/interpretiveSchools.test.ts
@@ -423,14 +423,23 @@ describe('staff-drafted schools — approval flow', () => {
 });
 
 describe('authorization guards', () => {
-  test('normal user cannot publish_contributor_interpretive_school', async () => {
-    const { error } = await normalUser.client.rpc('publish_contributor_interpretive_school', {
-      p_piece_id: PIECE,
-      p_name: 'Should fail',
-      p_body: 'body',
-    });
-    expect(error).not.toBeNull();
-    expect(error!.message).toMatch(/not an active contributor/i);
+  test('any registered user can publish_contributor_interpretive_school', async () => {
+    // Post-Slice-C governance (20260513000000_open_self_authoring.sql):
+    // the is_contributor flag is no longer a gate; auth is all that's
+    // required. Ownership guards still prevent user A editing user B's row.
+    const { data: schoolId, error } = await normalUser.client.rpc(
+      'publish_contributor_interpretive_school',
+      { p_piece_id: PIECE, p_name: 'Self-authored by non-flagged user', p_body: 'body' },
+    );
+    expect(error).toBeNull();
+    expect(schoolId).toBeTruthy();
+    const { data: row } = await admin
+      .from('interpretive_schools')
+      .select('contributor_id, status')
+      .eq('id', schoolId as string)
+      .single();
+    expect(row?.contributor_id).toBe(normalUser.id);
+    expect(row?.status).toBe('published');
   });
 
   test('normal user cannot create_interpretive_school_draft', async () => {

--- a/src/integration/pieceDescriptions.test.ts
+++ b/src/integration/pieceDescriptions.test.ts
@@ -280,13 +280,24 @@ describe('staff-drafted descriptions — approval flow', () => {
 });
 
 describe('authorization guards', () => {
-  test('normal user cannot publish_contributor_piece_description', async () => {
-    const { error } = await normalUser.client.rpc('publish_contributor_piece_description', {
-      p_piece_id: PIECE,
-      p_body: 'body',
-    });
-    expect(error).not.toBeNull();
-    expect(error!.message).toMatch(/not an active contributor/i);
+  test('any registered user can publish_contributor_piece_description', async () => {
+    // Post-Slice-C governance (20260513000000_open_self_authoring.sql):
+    // the is_contributor flag is no longer a gate; auth is all that's
+    // required. Ownership guards still prevent user A editing user B's row.
+    const { data: descriptionId, error } = await normalUser.client.rpc(
+      'publish_contributor_piece_description',
+      { p_piece_id: PIECE, p_body: 'a non-flagged user publishing a signed description' },
+    );
+    expect(error).toBeNull();
+    expect(descriptionId).toBeTruthy();
+    // Byline resolves to the authed user, not a flagged contributor.
+    const { data: row } = await admin
+      .from('piece_descriptions')
+      .select('contributor_id, status')
+      .eq('id', descriptionId as string)
+      .single();
+    expect(row?.contributor_id).toBe(normalUser.id);
+    expect(row?.status).toBe('published');
   });
 
   test('normal user cannot create_piece_description_draft', async () => {

--- a/supabase/migrations/20260513000000_open_self_authoring.sql
+++ b/supabase/migrations/20260513000000_open_self_authoring.sql
@@ -1,0 +1,191 @@
+-- Slice C governance relaxation: any registered user can self-author
+-- signed content (performer's notes, interpretive schools, signed piece
+-- descriptions).
+--
+-- Per PLAN-contributor-pipeline-slice-c.md §1.0 rev 2: the original Slice A
+-- "flagged contributor" gate (users.is_contributor + contributor_active,
+-- granted out-of-band via scripts/seed-contributor.ts) was CEO/eng-review
+-- reframed to "any registered user === contributor". Step 1 (#48) dropped
+-- the vestigial notifications.performers_note_id but never shipped the
+-- governance half. This migration does.
+--
+-- Two surgical moves, both inside SECURITY DEFINER RPCs — RLS policies
+-- never referenced is_contributor (they check contributor_id = auth.uid()
+-- and is_staff() only), and all mutations go through RPCs anyway.
+--
+-- 1. Rewrite _require_active_contributor() to require only authentication.
+--    19 self-publish / approve-queue RPCs inherit the relaxation with zero
+--    further changes: publish_contributor_note / _edit / remove +
+--    approve_performers_note / approve_and_edit / reject + the matching
+--    interpretive_schools and piece_descriptions families + the
+--    update_interpretive_school_metadata one-off. Ownership is still
+--    guaranteed inside each RPC by `where contributor_id = auth.uid()`
+--    clauses — relaxing the helper does not let user A edit user B's row.
+--
+-- 2. Rewrite the 3 create-*-draft RPCs (staff drafts content on behalf of
+--    a target user) to require the target user exist, not be flagged.
+--    The caller gate stays _require_staff() — only admin/firstchair can
+--    draft for others; the draftee can be any registered user.
+--
+-- `is_contributor` / `contributor_active` columns on public.users remain
+-- in the schema as an unused editorial flag. Dropping them is follow-up
+-- cleanup once we confirm no scripts, seeds, or scheduled tasks still
+-- depend on them.
+
+begin;
+
+-- ============================================
+-- 1. Relax the caller gate across all self-publish + approval RPCs.
+-- ============================================
+
+create or replace function public._require_active_contributor()
+  returns void
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+begin
+  -- Governance: any registered user is a first-class author. The helper
+  -- name is kept for caller compatibility (19 RPCs call it); rename is
+  -- deferred to a later refactor pass.
+  if auth.uid() is null then
+    raise exception 'unauthenticated';
+  end if;
+end;
+$$;
+
+-- ============================================
+-- 2. Relax the target-user gate on the 3 create-draft RPCs.
+--     The caller is still _require_staff(); only the target check shifts
+--     from "is an active contributor" to "exists in public.users".
+-- ============================================
+
+create or replace function public.create_performers_note_draft(
+  p_piece_id text,
+  p_contributor_id uuid,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_note_id uuid;
+  v_staff_id uuid := auth.uid();
+begin
+  perform public._require_staff();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found';
+  end if;
+  if not exists (select 1 from public.users where id = p_contributor_id) then
+    raise exception 'target user not found';
+  end if;
+
+  v_note_id := gen_random_uuid();
+  insert into public.performers_notes (
+    id, piece_id, contributor_id, status, drafted_by
+  )
+  values (v_note_id, p_piece_id, p_contributor_id, 'draft', v_staff_id);
+
+  perform public._insert_performers_note_version(
+    v_note_id, p_piece_id, p_contributor_id,
+    p_body, v_staff_id, false
+  );
+
+  return v_note_id;
+end;
+$$;
+
+create or replace function public.create_interpretive_school_draft(
+  p_piece_id text,
+  p_contributor_id uuid,
+  p_name text,
+  p_body text,
+  p_tempo_cues jsonb default null
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_school_id uuid;
+  v_staff_id uuid := auth.uid();
+begin
+  perform public._require_staff();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+  if p_name is null or length(trim(p_name)) = 0 then
+    raise exception 'name required';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found';
+  end if;
+  if not exists (select 1 from public.users where id = p_contributor_id) then
+    raise exception 'target user not found';
+  end if;
+
+  v_school_id := gen_random_uuid();
+  insert into public.interpretive_schools (
+    id, piece_id, contributor_id, name, tempo_cues, status, drafted_by
+  )
+  values (v_school_id, p_piece_id, p_contributor_id, trim(p_name), p_tempo_cues, 'draft', v_staff_id);
+
+  perform public._insert_interpretive_school_version(
+    v_school_id, p_piece_id, p_contributor_id,
+    p_body, v_staff_id, false
+  );
+
+  return v_school_id;
+end;
+$$;
+
+create or replace function public.create_piece_description_draft(
+  p_piece_id text,
+  p_contributor_id uuid,
+  p_body text
+)
+  returns uuid
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_description_id uuid;
+  v_staff_id uuid := auth.uid();
+begin
+  perform public._require_staff();
+
+  if p_body is null or length(trim(p_body)) = 0 then
+    raise exception 'body required';
+  end if;
+  if not exists (select 1 from public.pieces where id = p_piece_id) then
+    raise exception 'piece not found';
+  end if;
+  if not exists (select 1 from public.users where id = p_contributor_id) then
+    raise exception 'target user not found';
+  end if;
+
+  v_description_id := gen_random_uuid();
+  insert into public.piece_descriptions (
+    id, piece_id, contributor_id, status, drafted_by
+  )
+  values (v_description_id, p_piece_id, p_contributor_id, 'draft', v_staff_id);
+
+  perform public._insert_piece_description_version(
+    v_description_id, p_piece_id, p_contributor_id,
+    p_body, v_staff_id, false
+  );
+
+  return v_description_id;
+end;
+$$;
+
+commit;


### PR DESCRIPTION
## Summary

Slice C governance relaxation. Three user-facing changes, one data-layer change, one minor schema implication.

**Before.** Only users flagged `is_contributor = true AND contributor_active = true` (granted out-of-band via `scripts/seed-contributor.ts`, in practice one person: Haji Kim) could publish a performer's note, interpretive school, or signed piece description. A regular registered user saw no write entry at all. The backing RPCs rejected the call with `"caller is not an active contributor"`.

**After.** Any registered user can self-author. The write entry (`Write a performer's note →` / `Write a school →` / `Write a signed description →`) is always visible, including for anon viewers. Clicking as anon opens the shared `SignInPanel` (same pattern [MovementsList](src/components/MovementsList.tsx:236), [EditionsList](src/components/EditionsList.tsx), [VoteThumbs](src/components/VoteThumbs.tsx) use). Clicking as authed opens the composer.

Per PRD rev 2 and [PLAN-contributor-pipeline-slice-c.md §1.0](PLAN-contributor-pipeline-slice-c.md). Slice C Step 1 (#48) already dropped the vestigial `notifications.performers_note_id` column — this PR does the governance half that never shipped.

## Data layer

[supabase/migrations/20260513000000_open_self_authoring.sql](supabase/migrations/20260513000000_open_self_authoring.sql) does two surgical moves:

1. **Rewrites `_require_active_contributor()`** to require only `auth.uid() is not null`. 19 self-publish + approval RPCs call this helper (`publish_contributor_note` / `_edit` / `remove_performers_note`, `approve_performers_note`, `approve_and_edit_performers_note`, `reject_performers_note`, and the matching `interpretive_schools` + `piece_descriptions` families, plus `update_interpretive_school_metadata`). All 19 inherit the relaxation with zero per-caller changes. Helper name is kept for caller compat; rename is follow-up.

2. **Rewrites the 3 `create_*_draft` RPCs** (staff drafts on behalf of a target user) so the target check is `exists in public.users`, not `is_contributor = true`. The caller gate stays `_require_staff()` — only admin/firstchair can draft for others, but the draftee can be anyone with an account.

RLS on `performers_notes`, `interpretive_schools`, `piece_descriptions` never referenced `is_contributor` (only `contributor_id = auth.uid()` and `is_staff()`), so no policy edits. All mutations go through SECURITY DEFINER RPCs anyway.

**Ownership is still enforced.** Each edit/remove RPC has `where contributor_id = auth.uid()` clauses. Relaxing the caller gate doesn't let user A edit user B's row — if User A tries, they get `"note not found or not owned by caller"`.

**Schema.** The `users.is_contributor` + `contributor_active` columns remain but are now unused as a gate. Follow-up cleanup can drop them once nothing else references them.

## UI layer

Three components: [PerformersNotes.tsx](src/components/PerformersNotes.tsx), [InterpretiveSchools.tsx](src/components/InterpretiveSchools.tsx), [SignedPieceDescription.tsx](src/components/SignedPieceDescription.tsx). Identical diff shape across all three:

- Drop `isContributor` from the viewer state interface and from the `users` SELECT (only `display_name` + `contributor_bio_short` still need fetching).
- `canWrite` no longer ANDs in `isContributor`. For performer's notes it's still gated on `!viewerHasNote` (one-note-per-piece data invariant, not governance). For schools and descriptions it's unconditional (plural-contributions-allowed design).
- Render the write-entry button unconditionally. On click: if `!viewer?.userId`, open `SignInPanel`; else set compose mode.
- Add the `SignInPanel` instance at the bottom with a subject-specific title + body.

## Bio fallback

`users.contributor_bio_short` is already nullable, and [lib/performersNotes.ts:78](src/lib/performersNotes.ts:78) / [lib/interpretiveSchools.ts:78](src/lib/interpretiveSchools.ts:78) / [lib/pieceDescriptions.ts:70](src/lib/pieceDescriptions.ts:70) all map it null-safely. Render sites conditional-render the bio span (`{contributor.bioShort && <>…</>}`). Non-flagged users publish under their `display_name` alone, bio absent. Zero visual regression for existing flagged contributors (Haji's bio still shows).

## Test Coverage

Three existing tests asserted the old posture (`normal user cannot publish_contributor_*` → expect `"not an active contributor"` error). Those assertions contradicted the new posture by definition, so I flipped them:

- [contributorPipeline.test.ts:279](src/integration/contributorPipeline.test.ts:279) — `any registered user can publish_contributor_note`: asserts the call succeeds, then verifies `performers_notes.contributor_id = normalUser.id` and `status = 'published'`.
- [interpretiveSchools.test.ts:426](src/integration/interpretiveSchools.test.ts:426) — same shape for schools.
- [pieceDescriptions.test.ts:283](src/integration/pieceDescriptions.test.ts:283) — same shape for descriptions.

Ownership tests elsewhere in the suite (`other contributor cannot approve someone else's draft`, `contributor cannot approve another contributor's draft`) keep running against the original flagged-contributor user to prove the ownership guard still fires post-relaxation.

Tests: 162/162 integration, 118/118 unit.

## Pre-Landing Review

Scope: 8 files — one migration, three React components, three test files, one CHANGELOG entry.

- SQL safety: `CREATE OR REPLACE FUNCTION` within a single `BEGIN`/`COMMIT`. No destructive ops, no DDL beyond function bodies.
- Blast radius: the one helper rewrite intentionally propagates to 19 RPCs. Every one of those RPCs was manually inventoried against the PR description to confirm the relaxation is desired (self-publish + approval-queue paths, not staff-drafts-for-other).
- Authentication still enforced: `auth.uid() is null → raise` remains the first check in the helper.
- Ownership still enforced: every edit/remove RPC has independent `where contributor_id = auth.uid()` clauses.
- Staff-drafts-for-other still restricted: the three create-draft RPCs keep their `_require_staff()` caller gate untouched.
- UI change: SSR output verified — `Write a performer's note`, `Write a school`, `Write a signed description` all render in the anon HTML.

No issues found.

## TODOS

No TODO items tracked this work. Plan reference is [PLAN-contributor-pipeline-slice-c.md](PLAN-contributor-pipeline-slice-c.md) §1.0 (governance model clarification, 2026-04-20).

## Test plan

- [x] `bun run test:integration` — 162/162 pass (+9 new expect() calls from the flipped tests)
- [x] `bun run test` — 118/118 pass
- [x] Migration applies cleanly against local supabase
- [x] SSR output confirms all three write entries render for anon viewers
- [x] Ownership guards preserved (existing owner-only tests still pass against the relaxed helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)