### PR TITLE
feat(profile): sidebar shell + appearance (Light/System/Dark) + logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Irregular Pearl are recorded here. Format follows [Keep a
 
 ## [Unreleased]
 
+### Added (profile sidebar + appearance settings)
+
+- **Profile page now hosts a sidebar shell for signed-in owners.** Clicking the navbar avatar opens `/profile/:id`; for the owner, a new left vertical nav ([ProfileShell.tsx](src/components/ProfileShell.tsx)) — Profile / Setting / Logout — wraps the existing `ArtistProfile`. Anonymous or other-user views render the single-column profile unchanged (no sidebar leaks).
+- **Setting → Appearance** picks between Light / System / Dark ([AppearanceSettings.tsx](src/components/AppearanceSettings.tsx)) with three SVG preview cards (System shown as a diagonal split so both palettes are visible). Choice persists in `localStorage.theme`, and a pre-paint inline script in [Layout.astro](src/layouts/Layout.astro) applies `html[data-theme="dark"]` before render to avoid flash-of-wrong-theme.
+- **Logout** calls `supabase.auth.signOut()` (new `signOut` in [useAuth.ts](src/lib/useAuth.ts)) and redirects to `/`.
+- **Profile header matches the navbar.** Swapped the initials-in-cream-circle avatar stub for the same `GenerativeAvatar` the navbar uses, and derive the display name the same way (`email.split('@')[0]` when no full name is set).
+
+### Changed (design tokens + dark mode)
+
+- **Dark mode shipped as opt-in.** Supersedes the 2026-03-28 "no dark mode in Phase 1" decision recorded in DESIGN.md. Light stays the default; System follows `prefers-color-scheme`. Palette under `html[data-theme="dark"]` in [global.css](src/styles/global.css) is provisional — derived by inverting the light neutrals and lightening the purple accent; a proper dark kit pass is deferred.
+- **`accent-soft` softened** from `#F2EEF5` → `#F4F3F5`. Active sidebar items were reading as an obvious lavender pill; the new value keeps the accent family but sits close to neutral grey. Applied globally via the `--color-accent-soft` / `--color-accent-light` / `--accent-soft` tokens — every selected / soft-accent surface moves with it.
+- **Piece-page cards adapt to the theme.** `.diff-panel`, `.school`, `.ed` in [piece-page.css](src/styles/piece-page.css) moved from `background: #fff` to `background: var(--bg)` so the difficulty panel, interpretive schools, and editions list render on the dark surface instead of punching through as white cards. Other components still using hardcoded hex will need per-surface migration as they're touched.
+
 ### Changed (contributor pipeline — Slice C governance)
 
 - **Any registered user can now self-author signed content** on a piece: performer's notes, interpretive schools, and signed piece descriptions. Prior posture (Slice A → B) gated every self-publish and approval-queue RPC on a `users.is_contributor` flag granted out-of-band via `scripts/seed-contributor.ts` — in practice, exactly one user. Per PRD rev 2 and [PLAN-contributor-pipeline-slice-c.md](PLAN-contributor-pipeline-slice-c.md) §1.0, the flag is replaced by plain auth: if you have an account, you're an author. Draft-for-another-user (`create_*_draft`) stays admin/firstchair-only, but the draftee can now be any registered user. The `is_contributor` / `contributor_active` columns remain in the schema as an unused editorial marker — a follow-up cleanup will drop them once nothing else references them.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,7 +68,7 @@ The palette is small and mostly neutral. Add a color only if it encodes meaning.
 
 **Accent — one, used sparingly**
 - `#6B4E7C` — quiet purple, derived from the site's logomark palette. Used for kicker eyebrows, selected states, featured-card emphasis borders, focus rings, interactive chrome.
-- Accent soft: `#F2EEF5` — band backgrounds, hover fills.
+- Accent soft: `#F4F3F5` — band backgrounds, hover fills. Near-neutral grey with a trace of purple so selected states read as quiet rather than lavender.
 
 **Semantic — used only for meaning, never decoration**
 | Meaning | Foreground | Soft background |
@@ -80,7 +80,7 @@ The palette is small and mostly neutral. Add a color only if it encodes meaning.
 
 Never introduce a new color outside this palette without updating this document first. If a surface needs a color that isn't here, ask whether the surface really needs it — often the answer is typography or spacing would do the same work better.
 
-**Dark mode:** Deferred to Phase 2. Primary users are on iPads in well-lit practice rooms.
+**Dark mode:** Opt-in via Settings → Appearance (Light / System / Dark). Light remains the default. The dark palette is provisional — derived from inverting the light neutrals and lightening the purple accent — and still needs a proper pass. A few piece-page and profile surfaces use hardcoded hex literals that don't flip; migrate to CSS variables as they're touched.
 
 ## Spacing
 - **Base unit:** 4px
@@ -204,3 +204,6 @@ Claude is an executor of this system, not its author. When the system needs to c
 | 2026-04-20 | Signed notes pattern now shipping live on the piece page | First signed content on the site. Slice A of the contributor approval pipeline shipped: performer's notes render in the existing `.signed` pattern (2px accent left border, 18px padding, Source Serif 4 prose, byline in Inter medium with one-line bio). Contributor self-authored vs staff-drafted-and-approved both produce the same public output; the difference is the state machine behind the scenes. Multi-voice treatment (second voice uses `border-strong` instead of accent) already wired in markup even though v1 ships one contributor. |
 | 2026-04-20 | Secondary outline button pattern codified | Four surfaces had four different secondary-button looks during the Slice A build. Aligned all to one spec: transparent bg, 0.5px `border-strong`, `text-muted`, Inter 11px, padding `4px 10px`, 6px radius, darkens to `ink` on hover. Applies to Edit/Remove on signed notes, Refresh on the queue, Edit profile on the owner bar, and all filter chips. Enshrined in Buttons spec. |
 | 2026-04-20 | Popover spec added | Slice A's navbar bell introduced the site's first popover surface. Spec: 320px desktop / full-width narrow, `bg-surface`, 0.5px `border`, 12px radius, `shadow-md` (popovers float above the page so they get the shadow exception already granted to search inputs), 0.5px row dividers, Esc/outside-click/route-change dismiss. |
+| 2026-04-20 | Profile page now a sidebar shell for the signed-in owner | Clicking the navbar avatar opens `/profile/:id`. For the owner, the page renders a two-column shell (`ProfileShell.tsx`) with a left vertical nav — Profile / Setting / Logout — and the existing `ArtistProfile` inside. Anonymous or other-user views render the single-column profile unchanged. Active nav item uses `bg-accent-light` (the new subtler `#F4F3F5`), inactive items hover to `bg-bg-tint`. Logout calls `supabase.auth.signOut()` and redirects home. Profile header now uses the same `GenerativeAvatar` and `email.split('@')[0]` derivation as the navbar so the two stay consistent. |
+| 2026-04-20 | Dark mode shipped as opt-in via Settings → Appearance | Supersedes the 2026-03-28 "no dark mode in Phase 1" decision. Light remains the default; System follows `prefers-color-scheme`; Dark forces. Preference stored in `localStorage.theme` and applied by a pre-paint inline script in `Layout.astro` via `html[data-theme="dark"]` to avoid FOUC. Tokens for dark live in `global.css` under that selector; the palette is provisional and inherits all existing variable consumers. Theme picker (`AppearanceSettings.tsx`) shows three SVG preview cards (Light / split-diagonal System / Dark). Known gap: piece-page cards (`diff-panel`, `school`, `ed`) were migrated from `background: #fff` to `background: var(--bg)`; other surfaces still using hardcoded hex will need per-component migration. |
+| 2026-04-20 | `accent-soft` softened from `#F2EEF5` → `#F4F3F5` | The Profile sidebar's active state used `bg-accent-light` and read as an obvious lavender pill. Dropped the purple cast from RGB(+7B vs G) to RGB(+2B vs G) — still distinguishable as "accent family" but close enough to neutral grey that it no longer competes with the content. Applied globally; affects every selected/soft-accent surface. |

--- a/TODOS.md
+++ b/TODOS.md
@@ -148,6 +148,18 @@ Tracked work for Irregular Pearl, organized by component and sorted by priority.
 
 ## Completed
 
+### Profile sidebar + Settings (Appearance theme picker) + Logout
+
+**What:** Avatar click on the navbar now opens `/profile/:id` inside a new [ProfileShell.tsx](src/components/ProfileShell.tsx) — left vertical nav (Profile / Setting / Logout) plus the existing `ArtistProfile` on the right. Anonymous or other-user views bypass the shell and render the single-column profile unchanged. Setting → Appearance shows three SVG preview cards ([AppearanceSettings.tsx](src/components/AppearanceSettings.tsx)): Light / System (split-diagonal preview) / Dark. Choice persists in `localStorage.theme`; a pre-paint inline script in [Layout.astro](src/layouts/Layout.astro) applies `html[data-theme="dark"]` before render to avoid FOUC. Logout calls `supabase.auth.signOut()` (added to [useAuth.ts](src/lib/useAuth.ts)) and redirects home. Profile header swapped from initials-in-cream-circle to `GenerativeAvatar` + `email.split('@')[0]` display name so the page header matches the navbar avatar/tooltip.
+
+**Why:** User ask — a dedicated place to change appearance and sign out, without crowding the navbar.
+
+**Context:** Dark palette in [global.css](src/styles/global.css) is provisional (DESIGN.md called out Phase 2); `piece-page.css` `.diff-panel` / `.school` / `.ed` flipped from `background: #fff` to `var(--bg)` so they render on the dark surface. Other components using hardcoded hex will need per-surface migration as they're touched. `accent-soft` was dropped from `#F2EEF5` → `#F4F3F5` (near-neutral grey) so the active sidebar item reads quiet rather than lavender.
+
+**Effort:** S
+**Priority:** P1
+**Completed:** 2026-04-20
+
 ### Open self-authoring to any registered user (Slice C governance relaxation)
 
 **What:** Rewrote `_require_active_contributor()` to require only `auth.uid() is not null` — 19 self-publish + approval-queue RPCs inherited the relaxation automatically. The 3 staff-draft-for-other RPCs dropped their "target must be flagged contributor" check in favor of "target must exist in public.users". On the UI side, the `canWrite` gate in [PerformersNotes.tsx](src/components/PerformersNotes.tsx), [InterpretiveSchools.tsx](src/components/InterpretiveSchools.tsx), and [SignedPieceDescription.tsx](src/components/SignedPieceDescription.tsx) dropped the `isContributor` check; write entries render unconditionally; anon click opens `SignInPanel` (shared pattern with MovementsList / EditionsList / VoteThumbs).

--- a/src/components/AppearanceSettings.tsx
+++ b/src/components/AppearanceSettings.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react';
+import { getStoredTheme, setTheme, type ThemePreference } from '../lib/theme';
+
+const OPTIONS: { value: ThemePreference; label: string }[] = [
+  { value: 'light', label: 'Light' },
+  { value: 'system', label: 'System' },
+  { value: 'dark', label: 'Dark' },
+];
+
+export default function AppearanceSettings() {
+  const [current, setCurrent] = useState<ThemePreference>('system');
+
+  useEffect(() => {
+    setCurrent(getStoredTheme());
+  }, []);
+
+  const handleSelect = (value: ThemePreference) => {
+    setCurrent(value);
+    setTheme(value);
+  };
+
+  return (
+    <div>
+      <h2 className="text-sm font-medium text-ink mb-1">Appearance</h2>
+      <p className="text-xs text-muted mb-5">Choose how Irregular Pearl looks on this device.</p>
+
+      <div className="grid grid-cols-3 gap-3 md:gap-4 max-w-[520px]">
+        {OPTIONS.map((opt) => (
+          <ThemeOption
+            key={opt.value}
+            value={opt.value}
+            label={opt.label}
+            selected={current === opt.value}
+            onSelect={handleSelect}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ThemeOption({
+  value,
+  label,
+  selected,
+  onSelect,
+}: {
+  value: ThemePreference;
+  label: string;
+  selected: boolean;
+  onSelect: (v: ThemePreference) => void;
+}) {
+  return (
+    <a
+      href="#"
+      onClick={(e) => {
+        e.preventDefault();
+        onSelect(value);
+      }}
+      className="group block no-underline"
+      aria-pressed={selected}
+    >
+      <div
+        className={`rounded-lg overflow-hidden border transition-colors ${
+          selected
+            ? 'border-accent ring-1 ring-accent'
+            : 'border-border group-hover:border-border-strong'
+        }`}
+        style={{ borderWidth: '0.5px' }}
+      >
+        <ThemePreview variant={value} />
+      </div>
+      <div className="flex items-center gap-1.5 mt-2 text-xs">
+        <span
+          className={`inline-block w-3 h-3 rounded-full border ${
+            selected ? 'border-accent' : 'border-border-strong'
+          }`}
+          style={{ borderWidth: '0.5px' }}
+        >
+          {selected && (
+            <span className="block w-1.5 h-1.5 rounded-full bg-accent mx-auto mt-[3px]" />
+          )}
+        </span>
+        <span className={selected ? 'text-ink font-medium' : 'text-ink'}>{label}</span>
+      </div>
+    </a>
+  );
+}
+
+function ThemePreview({ variant }: { variant: ThemePreference }) {
+  if (variant === 'system') {
+    return (
+      <svg viewBox="0 0 160 100" className="w-full h-auto block" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <clipPath id="sys-left">
+            <polygon points="0,0 160,0 0,100" />
+          </clipPath>
+          <clipPath id="sys-right">
+            <polygon points="160,0 160,100 0,100" />
+          </clipPath>
+        </defs>
+        <g clipPath="url(#sys-left)">
+          <PreviewGraphic palette={LIGHT} />
+        </g>
+        <g clipPath="url(#sys-right)">
+          <PreviewGraphic palette={DARK} />
+        </g>
+        <line x1="160" y1="0" x2="0" y2="100" stroke="#CCC9C2" strokeWidth="0.5" />
+      </svg>
+    );
+  }
+
+  const palette = variant === 'dark' ? DARK : LIGHT;
+  return (
+    <svg viewBox="0 0 160 100" className="w-full h-auto block" xmlns="http://www.w3.org/2000/svg">
+      <PreviewGraphic palette={palette} />
+    </svg>
+  );
+}
+
+type Palette = {
+  bg: string;
+  surface: string;
+  ink: string;
+  muted: string;
+  border: string;
+  accent: string;
+};
+
+const LIGHT: Palette = {
+  bg: '#FFFFFF',
+  surface: '#F8F7F4',
+  ink: '#1A1A1A',
+  muted: '#9A9A9A',
+  border: '#E5E3DE',
+  accent: '#6B4E7C',
+};
+
+const DARK: Palette = {
+  bg: '#1A1A1A',
+  surface: '#242320',
+  ink: '#F0EFEC',
+  muted: '#77756F',
+  border: '#3A3732',
+  accent: '#B299C4',
+};
+
+function PreviewGraphic({ palette }: { palette: Palette }) {
+  return (
+    <g>
+      <rect width="160" height="100" fill={palette.bg} />
+      <rect x="0" y="0" width="160" height="16" fill={palette.surface} />
+      <line x1="0" y1="16" x2="160" y2="16" stroke={palette.border} strokeWidth="0.5" />
+      <text x="8" y="11" fontFamily="Georgia, serif" fontStyle="italic" fontSize="8" fill={palette.ink}>
+        IP
+      </text>
+      <circle cx="150" cy="8" r="3" fill={palette.accent} />
+      <rect x="10" y="28" width="70" height="5" rx="1" fill={palette.ink} opacity="0.85" />
+      <rect x="10" y="40" width="120" height="3" rx="1" fill={palette.muted} />
+      <rect x="10" y="48" width="100" height="3" rx="1" fill={palette.muted} />
+      <rect x="10" y="56" width="110" height="3" rx="1" fill={palette.muted} />
+      <rect x="10" y="72" width="28" height="10" rx="2" fill={palette.accent} />
+      <rect x="44" y="72" width="28" height="10" rx="2" fill="none" stroke={palette.border} strokeWidth="0.5" />
+    </g>
+  );
+}

--- a/src/components/ArtistProfile.tsx
+++ b/src/components/ArtistProfile.tsx
@@ -3,6 +3,7 @@ import { supabase, hasSupabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
 import { normalizeSocialUrl, getSocialIcon, normalizeWebsiteUrl } from '../lib/helpers';
 import UsernameEditor from './UsernameEditor';
+import GenerativeAvatar from './GenerativeAvatar';
 
 interface ProfileData {
   id: string;
@@ -72,14 +73,21 @@ export default function ArtistProfile({ userId }: { userId: string }) {
   if (loading) return <div className="max-w-[760px] mx-auto p-8 text-sm text-muted">Loading…</div>;
   if (!profile) return <div className="max-w-[760px] mx-auto p-8 text-sm text-muted">Profile not found.</div>;
 
+  const rawName = profile.display_name || '';
+  const displayName = rawName.includes('@') ? rawName.split('@')[0] : rawName;
+
   return (
     <main className="max-w-[760px] mx-auto px-4 md:px-8 py-8 md:py-12">
       <div className="flex items-start gap-5 mb-6">
-        <div className="w-20 h-20 md:w-24 md:h-24 rounded-full bg-gradient-to-br from-[#E8DDD3] to-[#F5E6D3] flex items-center justify-center font-display italic text-3xl md:text-4xl text-[#6F6F6F] flex-shrink-0">
-          {profile.display_name?.split(' ').map(n => n[0]).join('').slice(0, 2)}
+        <div className="flex-shrink-0">
+          {profile.avatar_url ? (
+            <img src={profile.avatar_url} alt={displayName} className="w-20 h-20 md:w-24 md:h-24 rounded-full object-cover" />
+          ) : (
+            <GenerativeAvatar userId={profile.id} size={96} />
+          )}
         </div>
         <div className="flex-1 min-w-0">
-          <h1 className="font-display italic text-2xl md:text-[28px] leading-tight mb-1">{profile.display_name}</h1>
+          <h1 className="font-display italic text-2xl md:text-[28px] leading-tight mb-1">{displayName}</h1>
           {isOwnProfile && <UsernameEditor currentUsername={profile.username} userId={profile.id} />}
           <div className="mt-2 flex flex-wrap gap-2 items-center">
             {profile.instrument && profile.instrument.split(',').map(i => i.trim()).filter(Boolean).map(inst => (

--- a/src/components/ProfileShell.tsx
+++ b/src/components/ProfileShell.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useAuth } from '../lib/useAuth';
+import ArtistProfile from './ArtistProfile';
+import AppearanceSettings from './AppearanceSettings';
+
+type Section = 'profile' | 'setting';
+
+export default function ProfileShell({ userId }: { userId: string }) {
+  const { user, signOut } = useAuth();
+  const isOwnProfile = user?.id === userId;
+  const [section, setSection] = useState<Section>('profile');
+
+  if (!isOwnProfile) {
+    return <ArtistProfile userId={userId} />;
+  }
+
+  return (
+    <div className="max-w-[1100px] mx-auto px-4 md:px-8 py-6 md:py-10 grid grid-cols-1 md:grid-cols-[200px_1fr] gap-8 md:gap-12">
+      <aside className="md:sticky md:top-20 md:self-start">
+        <nav className="flex md:flex-col gap-1 border-b md:border-b-0 md:border-r border-border pb-2 md:pb-0 md:pr-4">
+          <SidebarItem
+            label="Profile"
+            active={section === 'profile'}
+            onClick={() => setSection('profile')}
+          />
+          <SidebarItem
+            label="Setting"
+            active={section === 'setting'}
+            onClick={() => setSection('setting')}
+          />
+          <SidebarItem
+            label="Logout"
+            onClick={signOut}
+          />
+        </nav>
+      </aside>
+
+      <div className="min-w-0">
+        {section === 'profile' && <ArtistProfile userId={userId} />}
+        {section === 'setting' && <SettingsPanel />}
+      </div>
+    </div>
+  );
+}
+
+function SidebarItem({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <a
+      href="#"
+      onClick={(e) => {
+        e.preventDefault();
+        onClick();
+      }}
+      className={`text-sm no-underline px-3 py-2 rounded transition-colors ${
+        active
+          ? 'text-accent bg-accent-light font-medium'
+          : 'text-ink hover:text-accent hover:bg-bg-tint'
+      }`}
+    >
+      {label}
+    </a>
+  );
+}
+
+function SettingsPanel() {
+  return (
+    <section>
+      <h1 className="font-display italic text-2xl md:text-[28px] leading-tight mb-6">Setting</h1>
+      <AppearanceSettings />
+    </section>
+  );
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -72,6 +72,16 @@ const canonicalUrl = canonical || Astro.url.href;
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
+  <script is:inline>
+    (function () {
+      try {
+        var t = localStorage.getItem('theme') || 'system';
+        var dark = t === 'dark' || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (dark) document.documentElement.setAttribute('data-theme', 'dark');
+      } catch (e) {}
+    })();
+  </script>
+
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-R3S9WT1EVV"></script>
   <script is:inline>

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,41 @@
+export type ThemePreference = 'light' | 'system' | 'dark';
+
+const STORAGE_KEY = 'theme';
+
+export function getStoredTheme(): ThemePreference {
+  if (typeof localStorage === 'undefined') return 'system';
+  const v = localStorage.getItem(STORAGE_KEY);
+  return v === 'light' || v === 'dark' || v === 'system' ? v : 'system';
+}
+
+export function resolveTheme(pref: ThemePreference): 'light' | 'dark' {
+  if (pref === 'system') {
+    return typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  }
+  return pref;
+}
+
+export function applyTheme(pref: ThemePreference) {
+  const resolved = resolveTheme(pref);
+  const root = document.documentElement;
+  if (resolved === 'dark') root.setAttribute('data-theme', 'dark');
+  else root.removeAttribute('data-theme');
+}
+
+export function setTheme(pref: ThemePreference) {
+  localStorage.setItem(STORAGE_KEY, pref);
+  applyTheme(pref);
+  window.dispatchEvent(new CustomEvent('themechange', { detail: pref }));
+}
+
+export function watchSystemTheme(onChange: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const mq = window.matchMedia('(prefers-color-scheme: dark)');
+  const handler = () => {
+    if (getStoredTheme() === 'system') onChange();
+  };
+  mq.addEventListener('change', handler);
+  return () => mq.removeEventListener('change', handler);
+}

--- a/src/lib/useAuth.ts
+++ b/src/lib/useAuth.ts
@@ -37,5 +37,11 @@ export function useAuth() {
     });
   };
 
-  return { user, session, loading, signIn };
+  const signOut = async () => {
+    if (!hasSupabase) return;
+    await supabase.auth.signOut();
+    window.location.href = '/';
+  };
+
+  return { user, session, loading, signIn, signOut };
 }

--- a/src/pages/profile/[id].astro
+++ b/src/pages/profile/[id].astro
@@ -1,11 +1,11 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import Navbar from '../../components/Navbar.astro';
-import ArtistProfile from '../../components/ArtistProfile';
+import ProfileShell from '../../components/ProfileShell';
 
 const { id } = Astro.params;
 ---
 <Layout title="Artist Profile">
   <Navbar />
-  <ArtistProfile userId={id!} client:load />
+  <ProfileShell userId={id!} client:load />
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,11 +25,11 @@
 
   /* Accent — purple, used sparingly */
   --color-accent: #6B4E7C;
-  --color-accent-soft: #F2EEF5;
+  --color-accent-soft: #F4F3F5;
   /* Legacy tailwind class names kept as aliases so existing components
      that reference bg-accent-light / bg-accent-hover continue to resolve. */
   --color-accent-hover: #4C385C;
-  --color-accent-light: #F2EEF5;
+  --color-accent-light: #F4F3F5;
   --color-accent-border: #D9CCE1;
   --color-star: #6B4E7C;
 
@@ -67,7 +67,7 @@
 
   /* Accent */
   --accent: #6B4E7C;
-  --accent-soft: #F2EEF5;
+  --accent-soft: #F4F3F5;
 
   /* Semantic */
   --warning: #8B6914;
@@ -135,6 +135,55 @@
   /* Layout */
   --content-max-editorial: 960px;
   --content-max-catalog: 1100px;
+}
+
+/* =========================================================================
+   Dark theme — opt-in via html[data-theme="dark"]
+   Provisional palette derived from the light tokens; DESIGN.md defers dark
+   mode to Phase 2, so refine when the dark kit is authored.
+   ========================================================================= */
+
+html[data-theme="dark"] {
+  --color-bg: #1A1A1A;
+  --color-bg-tint: #242320;
+  --color-surface: #1F1F1F;
+  --color-ink: #F0EFEC;
+  --color-muted: #A8A6A0;
+  --color-tertiary: #77756F;
+  --color-border: #3A3732;
+  --color-border-strong: #524E47;
+  --color-accent: #B299C4;
+  --color-accent-soft: #2A2230;
+  --color-accent-hover: #D6C2E3;
+  --color-accent-light: #2A2230;
+  --color-accent-border: #4A3B56;
+  --color-star: #B299C4;
+  --color-success: #7FC592;
+  --color-success-bg: #1E2E22;
+  --color-error: #E38A8A;
+  --color-error-bg: #3A1F1F;
+  --color-warning: #D9B878;
+  --color-warning-bg: #332A18;
+  --color-info: #8FB0E0;
+  --color-info-bg: #1B2536;
+
+  --ink: #F0EFEC;
+  --muted: #A8A6A0;
+  --tertiary: #77756F;
+  --bg: #1A1A1A;
+  --bg-tint: #242320;
+  --border: #3A3732;
+  --border-strong: #524E47;
+  --accent: #B299C4;
+  --accent-soft: #2A2230;
+  --warning: #D9B878;
+  --warning-soft: #332A18;
+  --info: #8FB0E0;
+  --info-soft: #1B2536;
+  --success: #7FC592;
+  --success-soft: #1E2E22;
+  --danger: #E38A8A;
+  --danger-soft: #3A1F1F;
 }
 
 html {

--- a/src/styles/piece-page.css
+++ b/src/styles/piece-page.css
@@ -17,7 +17,7 @@ h1.piece .cat { font-family: var(--font-mono); font-size: 16px; color: var(--mut
 .pill { font-size: 12px; padding: 3px 10px; border-radius: var(--r-pill); background: var(--bg-tint); color: var(--muted); border: 0.5px solid var(--border); }
 
 /* ---------- Four-axis difficulty panel (PRD) ---------- */
-.diff-panel { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; border: 0.5px solid var(--border); border-radius: var(--r-card); padding: 20px 24px; margin-bottom: 48px; background: #fff; }
+.diff-panel { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; border: 0.5px solid var(--border); border-radius: var(--r-card); padding: 20px 24px; margin-bottom: 48px; background: var(--bg); }
 @media (max-width: 1024px) {
   .diff-panel { grid-template-columns: repeat(2, 1fr); gap: 20px 24px; }
 }
@@ -435,7 +435,7 @@ h2.section { font-family: var(--font-serif); font-size: 22px; font-weight: 500; 
 
 /* ---------- Interpretive schools (plural, signed) ---------- */
 .schools { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
-.school { background: #fff; border: 0.5px solid var(--border); border-radius: var(--r-card); padding: 20px 22px; }
+.school { background: var(--bg); border: 0.5px solid var(--border); border-radius: var(--r-card); padding: 20px 22px; }
 .school .name { font-family: var(--font-serif); font-size: 17px; font-weight: 500; margin-bottom: 8px; }
 .school .prose { font-family: var(--font-serif); font-size: 14px; line-height: 1.55; color: var(--ink); margin-bottom: 14px; }
 .school .tempi { font-family: var(--font-mono); font-size: 11px; color: var(--muted); line-height: 1.7; padding-top: 10px; border-top: 0.5px solid var(--border); margin-bottom: 12px; }
@@ -447,7 +447,7 @@ h2.section { font-family: var(--font-serif); font-size: 22px; font-weight: 500; 
 /* ---------- Editions — comparison-first ---------- */
 .editions-head { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 20px; }
 .ed-list { display: flex; flex-direction: column; gap: 12px; }
-.ed { background: #fff; border: 0.5px solid var(--border); border-radius: var(--r-card); padding: 18px 22px; display: grid; grid-template-columns: 1fr auto; gap: 20px; align-items: start; transition: border-color 100ms ease-out; }
+.ed { background: var(--bg); border: 0.5px solid var(--border); border-radius: var(--r-card); padding: 18px 22px; display: grid; grid-template-columns: 1fr auto; gap: 20px; align-items: start; transition: border-color 100ms ease-out; }
 .ed:hover { border-color: var(--accent); }
 .ed h3 { font-family: var(--font-serif); font-size: 17px; font-weight: 500; margin: 0 0 4px; }
 .ed .meta { font-size: 13px; color: var(--muted); margin-bottom: 8px; font-family: var(--font-mono); font-size: 12px; }


### PR DESCRIPTION
## Summary

- Avatar click on the navbar opens `/profile/:id` inside a two-column shell for the signed-in owner: left nav (Profile / Setting / Logout) wrapping the existing `ArtistProfile`. Anonymous + other-user views bypass the shell and render the single-column profile unchanged.
- Setting → Appearance picks between Light / System / Dark via three SVG preview cards. Choice persists in `localStorage.theme`; a pre-paint inline script in `Layout.astro` applies `html[data-theme="dark"]` before render to avoid flash-of-wrong-theme.
- Logout calls `supabase.auth.signOut()` (new `signOut` in `useAuth.ts`) and redirects home.
- Profile header aligned to the navbar — `GenerativeAvatar` + `email.split('@')[0]` — so the page header matches the avatar / tooltip you click to reach it.

## Design notes a reviewer should know

- **Supersedes DESIGN.md line 83** ("Dark mode: Deferred to Phase 2"). Now opt-in; light stays default.
- **Dark palette is provisional.** Derived by inverting the light neutrals and lightening the purple accent. A proper dark-kit pass is deferred — flagged in DESIGN.md and CHANGELOG.md.
- **Piece-page cards migrated.** `.diff-panel` / `.school` / `.ed` in `piece-page.css` moved from `background: #fff` to `background: var(--bg)` so the difficulty panel, interpretive schools, and editions list adapt in dark mode. Other components still using hardcoded hex (e.g. `text-[#57534E]`) will need per-surface migration as they're touched.
- **`accent-soft` softened** from `#F2EEF5` → `#F4F3F5`. Active sidebar item was reading as an obvious lavender pill; new value keeps the accent family but sits near neutral grey. Applied globally via `--color-accent-soft` / `--color-accent-light` / `--accent-soft` — every selected / soft-accent surface moves with it.

## Files

- Added: `src/components/ProfileShell.tsx`, `src/components/AppearanceSettings.tsx`, `src/lib/theme.ts`
- Modified: `src/components/ArtistProfile.tsx`, `src/layouts/Layout.astro`, `src/lib/useAuth.ts`, `src/pages/profile/[id].astro`, `src/styles/global.css`, `src/styles/piece-page.css`
- Docs: `CHANGELOG.md`, `DESIGN.md` (decision log + `accent-soft` value + dark-mode status), `TODOS.md`

## Test plan

- [ ] Sign in as an existing account. Click the navbar avatar → sidebar with Profile / Setting / Logout appears; Profile is active; ArtistProfile content matches the pre-PR layout.
- [ ] Click Setting → Appearance. Three preview cards render (Light shows light, System shows diagonal split, Dark shows dark). Clicking each applies the theme instantly and persists across reload.
- [ ] Reload with `localStorage.theme = "dark"` — no flash of light before dark applies.
- [ ] System mode follows OS `prefers-color-scheme` (toggle OS light/dark while on System).
- [ ] Click Logout → redirects to `/` and navbar shows Sign in.
- [ ] Visit someone else's profile URL while signed in — no sidebar, single-column profile renders.
- [ ] Piece page in dark mode: difficulty panel, interpretive schools, editions card all sit on dark background; text is legible.
- [ ] Active sidebar item reads as quiet grey, not lavender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)