### PR TITLE
refactor(roles): rename firstchair role to moderator

### DIFF
--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -60,9 +60,9 @@ export default function AuthButton() {
             Admin
           </a>
         )}
-        {userRole === 'firstchair' && (
-          <a href="/firstchair/reports" className="text-xs font-medium text-[#6B4E7C] hover:text-[#4C385C] no-underline transition-colors">
-            First Chair
+        {userRole === 'moderator' && (
+          <a href="/moderator/reports" className="text-xs font-medium text-[#6B4E7C] hover:text-[#4C385C] no-underline transition-colors">
+            Moderator
           </a>
         )}
         <a href={`/profile/${user.id}`} className="block no-underline" title={displayName}>

--- a/src/components/admin/AdminPage.tsx
+++ b/src/components/admin/AdminPage.tsx
@@ -39,7 +39,7 @@ export default function AdminPage({ initialTab }: Props) {
 
       if (!data) { setDenied(true); setLoading(false); return; }
 
-      const isStaff = data.role === 'admin' || data.role === 'firstchair' || data.is_maestro;
+      const isStaff = data.role === 'admin' || data.role === 'moderator' || data.is_maestro;
       if (!isStaff) { setDenied(true); setLoading(false); return; }
 
       setProfile(data as StaffProfile);
@@ -60,7 +60,7 @@ export default function AdminPage({ initialTab }: Props) {
 
   const isAdmin = profile.role === 'admin';
   const isMaestro = profile.is_maestro || isAdmin;
-  const headerLabel = isAdmin ? 'Admin' : profile.role === 'firstchair' ? 'First Chair' : isMaestro ? 'Maestro' : 'Admin';
+  const headerLabel = isAdmin ? 'Admin' : profile.role === 'moderator' ? 'Moderator' : isMaestro ? 'Maestro' : 'Admin';
 
   const tabs = [
     { id: 'dashboard' as Tab, label: 'Dashboard', show: isAdmin },

--- a/src/components/admin/AdminUserList.tsx
+++ b/src/components/admin/AdminUserList.tsx
@@ -60,7 +60,7 @@ export default function AdminUserList() {
   };
 
   const handleRoleChange = async (userId: string, newRole: string) => {
-    if (newRole === 'firstchair') {
+    if (newRole === 'moderator') {
       setEditingSections(userId);
       setTempSections([]);
       return;
@@ -69,7 +69,7 @@ export default function AdminUserList() {
   };
 
   const saveSections = async (userId: string) => {
-    await updateUser(userId, { role: 'firstchair', managed_sections: tempSections });
+    await updateUser(userId, { role: 'moderator', managed_sections: tempSections });
     setEditingSections(null);
   };
 
@@ -91,7 +91,7 @@ export default function AdminUserList() {
         >
           <option value="all">All roles</option>
           <option value="admin">Admin</option>
-          <option value="firstchair">First Chair</option>
+          <option value="moderator">Moderator</option>
           <option value="user">User</option>
         </select>
       </div>
@@ -125,7 +125,7 @@ export default function AdminUserList() {
                     className="text-xs border border-border rounded px-2 py-1 bg-white"
                   >
                     <option value="user">User</option>
-                    <option value="firstchair">First Chair</option>
+                    <option value="moderator">Moderator</option>
                     <option value="admin">Admin</option>
                   </select>
                 </td>
@@ -138,7 +138,7 @@ export default function AdminUserList() {
                   </button>
                 </td>
                 <td className="px-4 py-2 hidden md:table-cell">
-                  {u.role === 'firstchair' && u.managed_sections?.length > 0 ? (
+                  {u.role === 'moderator' && u.managed_sections?.length > 0 ? (
                     <div className="flex flex-wrap gap-1">
                       {u.managed_sections.map(s => (
                         <span key={s} className="text-[10px] bg-[#F2EEF5] text-[#6B4E7C] px-1.5 py-0.5 rounded-full">{s}</span>

--- a/supabase/migrations/20260518000000_rename_firstchair_to_moderator.sql
+++ b/supabase/migrations/20260518000000_rename_firstchair_to_moderator.sql
@@ -1,0 +1,10 @@
+-- Rename 'firstchair' role to 'moderator'
+-- Mirror of 20260331100000 which renamed 'manager' to 'firstchair'.
+ALTER TABLE public.users DROP CONSTRAINT IF EXISTS users_role_check;
+UPDATE public.users SET role = 'moderator' WHERE role = 'firstchair';
+ALTER TABLE public.users ADD CONSTRAINT users_role_check CHECK (role IN ('user', 'moderator', 'admin'));
+
+CREATE OR REPLACE FUNCTION public.is_staff()
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE AS $$
+  SELECT EXISTS (SELECT 1 FROM public.users WHERE id = auth.uid() AND (role IN ('admin', 'moderator') OR is_maestro = true));
+$$;


### PR DESCRIPTION
## Summary
- Renames the `firstchair` user role to `moderator` across schema and UI, mirroring the earlier `manager → firstchair` rename ([20260331100000](supabase/migrations/20260331100000_rename_manager_to_firstchair.sql)).
- New migration [20260518000000_rename_firstchair_to_moderator.sql](supabase/migrations/20260518000000_rename_firstchair_to_moderator.sql): drops `users_role_check`, updates existing rows, re-adds `CHECK (role IN ('user', 'moderator', 'admin'))`, rewrites `is_staff()`.
- UI: enum values + labels updated in `AuthButton.tsx`, `AdminPage.tsx`, `AdminUserList.tsx`. Dead nav reference `/firstchair/reports` renamed to `/moderator/reports` (no file exists at either path — pre-existing).

## Why
User ask. "Moderator" reads clearer to new users than the orchestra metaphor, and matches the governance role the column actually plays now (drafter-role gate for `create_*_draft` / `submit_*` / approval surfaces).

## Scope notes
- Historical migrations (20260331/20260428/20260513/20260515) still reference `firstchair` in comments — left alone as write-once history.
- Plan doc PLAN-contributor-pipeline-slice-c.md and CHANGELOG also reference `firstchair` in their design narrative — left as historical record.
- No test referenced `firstchair` by string. Integration tests exercise the gate via the `admin` path, which is unchanged.

## Test plan
- [ ] CI applies the migration on merge.
- [ ] Verify in prod that any existing `firstchair` row migrated to `moderator` and the CHECK accepts `moderator`.
- [ ] Sign-in as an admin, open `/admin` → Users, confirm the role dropdown shows "Moderator" (not "First Chair") and saving a user to `moderator` persists.
- [ ] Confirm typecheck + local test suite still clean (301 pass; the 23 E2E failures against irregularpearl.org are pre-existing CORS issues, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)