### PR TITLE
v0.4.1 — UX polish: horizontal profile nav, navbar slim, dark-mode contrast, PWA fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Irregular Pearl are recorded here. Format follows [Keep a
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-23
+
+### Changed
+
+- **Profile became a single horizontal nav at every viewport.** The vertical sidebar at md+ collapsed into the same horizontal tab bar mobile already had: `Profile | Setting | [Maestro/Admin/Moderator if applicable]   ……   Logout`, with Logout flushed right via `ml-auto`. Role links (Maestro / Admin / Moderator) moved out of the navbar and into this row, sitting immediately after Setting so they're discoverable from the avatar instead of crowding the top chrome. [ProfileShell.tsx](src/components/ProfileShell.tsx).
+- **Navbar slimmed.** Removed the Maestro / Admin / Moderator badges and the "About" link from the top nav. About now lives in the footer (before Terms / Privacy on desktop and mobile rows). The right side of the nav is just the bell + avatar. [Navbar.astro](src/components/Navbar.astro), [AuthButton.tsx](src/components/AuthButton.tsx), [Layout.astro](src/layouts/Layout.astro).
+- **Mobile search promoted from overlay to a second navbar row.** Below 640px, the search input now renders as a full-width second row inside the sticky nav (with `px-2 pb-2` for minimal margin) instead of an icon that opens an overlay. Removed the search-open / search-close buttons and the overlay div + script. [Navbar.astro](src/components/Navbar.astro).
+
+### Fixed
+
+- **Navbar icons aligned at every viewport.** Below 1025px the global touch-target rule (`@media (max-width: 1024px) { button, a { min-height: 44px; min-width: 44px } }`) was inflating the bell button + avatar anchor + IrregularPearl logo into 44×44 boxes with their content top-left aligned, throwing both vertical and horizontal alignment off. Each is now `inline-flex items-center justify-center` and exempts itself from the min-width via `min-w-0!` (Tailwind v4 important suffix — beats the unlayered global rule that otherwise wins over layered utilities regardless of specificity). The 44px vertical hit area is preserved. [Navbar.astro](src/components/Navbar.astro), [NavbarBell.tsx](src/components/NavbarBell.tsx), [AuthButton.tsx](src/components/AuthButton.tsx).
+- **Dark mode text uses pure white.** `--color-ink` / `--ink` in `html[data-theme="dark"]` switched from `#F0EFEC` (a warm off-white) to `#FFFFFF` for maximum contrast against the `#1A1A1A` background. Contrast ratio against the page bg climbed from ~15.6:1 to ~17.4:1. [global.css](src/styles/global.css).
+- **`.pending-draft-btn` (Edit & accept / Decline) visible in dark mode.** Two compounding bugs: the rule had `background: #fff` hardcoded, and once the ink color went white in dark mode that rendered as white-on-white. Base background switched to `var(--color-surface)` and an explicit `html[data-theme="dark"] .pending-draft-btn { background: var(--bg); color: var(--ink); border-color: var(--border-strong); }` block was added so the buttons stand out against the dark purple draft card. The primary variant (`Accept as-is`) flips its label to `var(--bg)` in dark mode so the dark text reads cleanly on the lavender accent fill. [global.css](src/styles/global.css).
+- **Username slug + actions wrap as a unit.** On the profile header, `irregularpearl.org/@<username>` would line-break independently from `View · Change username` at narrow widths, leaving "View" stranded on its own line and "Change username" wrapped to two lines. The actions are now in an `inline-flex items-center gap-2 shrink-0 whitespace-nowrap` group so they always travel together; `min-w-0! min-h-0!` on the View / Change `<a>`+`<button>` opts them out of the global touch-target rule that was inflating them. The outer container is `flex flex-wrap items-center gap-x-2 gap-y-1`, so when there's not enough room for the slug and the action group on one line, the action group drops below the slug as a single block. [UsernameEditor.tsx](src/components/UsernameEditor.tsx).
+- **PWA manifest no longer 404s on icons.** `public/manifest.json` was pointing at `/icon-192.png` and `/icon-512.png` which never shipped, breaking the install banner and triggering a console error on every load. Manifest now references the existing `favicon.svg` with `sizes: "any"` so a single scalable asset covers every install slot. [manifest.json](public/manifest.json).
+- **Deprecated PWA meta tag complemented.** Added `<meta name="mobile-web-app-capable" content="yes">` alongside the legacy `apple-mobile-web-app-capable`, clearing the Chrome console deprecation warning. Apple's variant is kept for older iOS Safari. [Layout.astro](src/layouts/Layout.astro).
+
 ## [0.4.0] - 2026-04-22
 
 ### Added

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Version
 
-Current: **0.4.0** (2026-04-22)
+Current: **0.4.1** (2026-04-23)
 
 The version number lives in three places that must stay in sync:
 
@@ -36,6 +36,7 @@ Pre-1.0, this project follows a relaxed semver:
 
 | Version | Date | Tag | GitHub release | Anchor commit | One-line summary |
 |---------|------|-----|----------------|---------------|------------------|
+| 0.4.1 | 2026-04-23 | `v0.4.1` | [v0.4.1](https://github.com/jspkm/irregular-pearl/releases/tag/v0.4.1) | release commit | UX polish: profile horizontal nav + slim navbar (About → footer, role links → profile), mobile search second row, navbar icon alignment under 1025px, dark-mode contrast (white ink + visible draft buttons), username slug + actions wrap as unit, PWA manifest icon + mobile-web-app-capable meta |
 | 0.4.0 | 2026-04-22 | `v0.4.0` | [v0.4.0](https://github.com/jspkm/irregular-pearl/releases/tag/v0.4.0) | release commit | Request a contribution end-to-end: canonical piece index, pre-piece surface with NOT YET CURATED search, materialize-on-CTA, recipient ribbon, unified Messages page, LLM-drafted notes (staff-only), editorial signals dashboard (unmatched queries + most-viewed-no-contribution), Recent Curation admin tile |
 | 0.3.0 | 2026-04-21 | `v0.3.0` | [v0.3.0](https://github.com/jspkm/irregular-pearl/releases/tag/v0.3.0) | release commit | Wiki-edit for recordings + pedagogical arc (with piece picker), seed-description voting, piece-page UI polish across every wiki-edit surface, thumbs-up celebration animation, seed.ts ordinal fix |
 | 0.2.0 | 2026-04-21 | `v0.2.0` | [v0.2.0](https://github.com/jspkm/irregular-pearl/releases/tag/v0.2.0) | release commit | Slice C: structural landmarks + silent voting + stacking + wiki-edit movements + page change log + email/password auth + profile sidebar + dark mode |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irregular-pearl",
   "type": "module",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,14 +8,10 @@
   "theme_color": "#ffffff",
   "icons": [
     {
-      "src": "/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png"
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
     }
   ]
 }

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -7,8 +7,6 @@ import SignInPanel from './SignInPanel';
 export default function AuthButton() {
   const [user, setUser] = useState<User | null>(null);
   const [dbAvatarUrl, setDbAvatarUrl] = useState<string | null | undefined>(undefined);
-  const [userRole, setUserRole] = useState<string>('user');
-  const [isMaestro, setIsMaestro] = useState(false);
   const [loading, setLoading] = useState(true);
   const [signInOpen, setSignInOpen] = useState(false);
 
@@ -25,11 +23,9 @@ export default function AuthButton() {
         // Fetch avatar_url from public.users (respects user's choice).
         // Don't block the navbar on this — if the row is missing or the
         // query fails, we still render the avatar via GenerativeAvatar.
-        supabase.from('users').select('avatar_url, role, is_maestro').eq('id', session.user.id).single()
+        supabase.from('users').select('avatar_url').eq('id', session.user.id).single()
           .then(({ data }) => {
             setDbAvatarUrl(data?.avatar_url ?? null);
-            setUserRole((data as any)?.role || 'user');
-            setIsMaestro((data as any)?.is_maestro === true);
           });
       } else if (typeof window !== 'undefined') {
         // Auto-open sign-in modal when arriving with ?signin=1. Used by
@@ -64,22 +60,11 @@ export default function AuthButton() {
 
     return (
       <div className="flex items-center gap-3">
-        {isMaestro && (
-          <a href="/maestro" className="text-xs font-medium text-[#6B4E7C] hover:text-[#4C385C] no-underline transition-colors">
-            Maestro
-          </a>
-        )}
-        {userRole === 'admin' && (
-          <a href="/admin" className="text-xs font-medium text-[#6B4E7C] hover:text-[#4C385C] no-underline transition-colors">
-            Admin
-          </a>
-        )}
-        {userRole === 'moderator' && (
-          <a href="/moderator/reports" className="text-xs font-medium text-[#6B4E7C] hover:text-[#4C385C] no-underline transition-colors">
-            Moderator
-          </a>
-        )}
-        <a href={`/profile/${user.id}`} className="block no-underline" title={displayName}>
+        <a
+          href={`/profile/${user.id}`}
+          className="inline-flex items-center justify-center no-underline min-w-0!"
+          title={displayName}
+        >
           {dbAvatarUrl ? (
             <img src={dbAvatarUrl} alt={displayName} className="w-7 h-7 rounded-full object-cover" />
           ) : (

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,71 +3,23 @@ import AuthButton from './AuthButton';
 import NavbarBell from './NavbarBell';
 import SearchTypeahead from './SearchTypeahead';
 ---
-<nav class="relative flex items-center gap-4 md:gap-6 px-4 md:px-6 py-4 border-b border-border bg-surface sticky top-0 z-50">
-  <a href="/" class="no-underline shrink-0 text-ink font-medium tracking-tight text-base md:text-lg">
-    IrregularPearl
-  </a>
+<div class="sticky top-0 z-50 bg-surface border-b border-border">
+  <nav class="relative flex items-center gap-4 md:gap-6 px-4 md:px-6 py-4">
+    <a href="/" class="no-underline shrink-0 text-ink font-medium tracking-tight text-base md:text-lg inline-flex items-center min-w-0!">
+      IrregularPearl
+    </a>
 
-  <div class="hidden sm:block absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-1/2 min-w-[260px] max-w-xl">
+    <div class="hidden sm:block absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-1/2 min-w-[260px] max-w-xl">
+      <SearchTypeahead client:load />
+    </div>
+
+    <div class="flex items-center gap-4 md:gap-5 text-sm text-ink ml-auto">
+      <NavbarBell client:load />
+      <AuthButton client:load />
+    </div>
+  </nav>
+
+  <div class="sm:hidden px-2 pb-2">
     <SearchTypeahead client:load />
   </div>
-
-  <div class="flex items-center gap-4 md:gap-5 text-sm text-ink ml-auto">
-    <button
-      type="button"
-      id="nav-search-open"
-      class="sm:hidden bg-transparent border-0 p-0 text-ink hover:text-accent transition-colors cursor-pointer inline-flex items-center"
-      aria-label="Search"
-    >
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <circle cx="11" cy="11" r="7"></circle>
-        <path d="m21 21-4.3-4.3"></path>
-      </svg>
-    </button>
-    <a href="/about" class="no-underline text-ink hover:text-accent transition-colors">About</a>
-    <NavbarBell client:load />
-    <AuthButton client:load />
-  </div>
-
-  <div
-    id="nav-search-overlay"
-    class="hidden absolute inset-0 bg-surface items-center gap-2 px-4 py-3 z-10"
-  >
-    <div class="flex-1">
-      <SearchTypeahead client:visible />
-    </div>
-    <button
-      type="button"
-      id="nav-search-close"
-      class="bg-transparent border-0 p-0 text-ink hover:text-accent transition-colors cursor-pointer inline-flex items-center shrink-0"
-      aria-label="Close search"
-    >
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M18 6 6 18"></path>
-        <path d="m6 6 12 12"></path>
-      </svg>
-    </button>
-  </div>
-</nav>
-
-<script>
-  const open = document.getElementById('nav-search-open');
-  const close = document.getElementById('nav-search-close');
-  const overlay = document.getElementById('nav-search-overlay');
-  if (open && close && overlay) {
-    const show = () => {
-      overlay.classList.remove('hidden');
-      overlay.classList.add('flex');
-      overlay.querySelector('input')?.focus();
-    };
-    const hide = () => {
-      overlay.classList.add('hidden');
-      overlay.classList.remove('flex');
-    };
-    open.addEventListener('click', show);
-    close.addEventListener('click', hide);
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && !overlay.classList.contains('hidden')) hide();
-    });
-  }
-</script>
+</div>

--- a/src/components/NavbarBell.tsx
+++ b/src/components/NavbarBell.tsx
@@ -222,7 +222,7 @@ export default function NavbarBell() {
         type="button"
         aria-label={badgeText ? `Notifications (${badgeText})` : 'Notifications'}
         onClick={() => setOpen((o) => !o)}
-        className="bg-transparent border-0 p-0 text-ink hover:text-accent transition-colors cursor-pointer inline-flex items-center relative"
+        className="bg-transparent border-0 p-0 text-ink hover:text-accent transition-colors cursor-pointer inline-flex items-center relative min-w-0!"
       >
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />

--- a/src/components/ProfileShell.tsx
+++ b/src/components/ProfileShell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../lib/useAuth';
+import { supabase, hasSupabase } from '../lib/supabase';
 import ArtistProfile from './ArtistProfile';
 import AppearanceSettings from './AppearanceSettings';
 
@@ -10,6 +11,8 @@ export default function ProfileShell({ userId }: { userId: string }) {
   const isOwnProfile = user?.id === userId;
   const [section, setSection] = useState<Section>('profile');
   const [confirmLogout, setConfirmLogout] = useState(false);
+  const [userRole, setUserRole] = useState<string>('user');
+  const [isMaestro, setIsMaestro] = useState(false);
 
   useEffect(() => {
     if (!confirmLogout) return;
@@ -17,54 +20,76 @@ export default function ProfileShell({ userId }: { userId: string }) {
     return () => clearTimeout(t);
   }, [confirmLogout]);
 
+  useEffect(() => {
+    if (!isOwnProfile || !hasSupabase || !user) return;
+    supabase
+      .from('users')
+      .select('role, is_maestro')
+      .eq('id', user.id)
+      .single()
+      .then(({ data }) => {
+        setUserRole((data as any)?.role || 'user');
+        setIsMaestro((data as any)?.is_maestro === true);
+      });
+  }, [isOwnProfile, user]);
+
   if (!isOwnProfile) {
     return <ArtistProfile userId={userId} />;
   }
 
+  const roleLinks: { href: string; label: string }[] = [];
+  if (isMaestro) roleLinks.push({ href: '/maestro', label: 'Maestro' });
+  if (userRole === 'admin') roleLinks.push({ href: '/admin', label: 'Admin' });
+  if (userRole === 'moderator') roleLinks.push({ href: '/moderator/reports', label: 'Moderator' });
+
   return (
-    <div className="max-w-[1100px] mx-auto px-4 md:px-8 py-6 md:py-10 grid grid-cols-1 md:grid-cols-[200px_1fr] gap-8 md:gap-12">
-      <aside className="md:sticky md:top-20 md:self-start">
-        <nav className="flex md:flex-col gap-1 border-b md:border-b-0 md:border-r border-border pb-2 md:pb-0 md:pr-4">
-          <SidebarItem
-            label="Profile"
-            active={section === 'profile'}
-            onClick={() => setSection('profile')}
-          />
-          <SidebarItem
-            label="Setting"
-            active={section === 'setting'}
-            onClick={() => setSection('setting')}
-          />
-          {confirmLogout ? (
-            <span
-              role="alertdialog"
-              className="text-sm px-3 py-2 rounded border border-border flex items-center gap-2"
+    <div className="max-w-[1100px] mx-auto px-4 md:px-8 py-6 md:py-10">
+      <nav className="flex items-center gap-1 border-b border-border pb-2 mb-6 md:mb-8">
+        <SidebarItem
+          label="Profile"
+          active={section === 'profile'}
+          onClick={() => setSection('profile')}
+        />
+        <SidebarItem
+          label="Setting"
+          active={section === 'setting'}
+          onClick={() => setSection('setting')}
+        />
+
+        {roleLinks.map((link) => (
+          <SidebarItem key={link.href} label={link.label} href={link.href} />
+        ))}
+
+        {confirmLogout ? (
+          <span
+            role="alertdialog"
+            className="ml-auto text-sm px-3 py-2 rounded border border-border flex items-center gap-2"
+          >
+            <span className="text-ink">Log out?</span>
+            <button
+              type="button"
+              onClick={signOut}
+              className="text-accent underline underline-offset-2 hover:text-accent-dark"
             >
-              <span className="text-ink">Log out?</span>
-              <button
-                type="button"
-                onClick={signOut}
-                className="text-accent underline underline-offset-2 hover:text-accent-dark"
-              >
-                Yes
-              </button>
-              <span className="text-muted">/</span>
-              <button
-                type="button"
-                onClick={() => setConfirmLogout(false)}
-                className="text-muted underline underline-offset-2 hover:text-ink"
-              >
-                No
-              </button>
-            </span>
-          ) : (
-            <SidebarItem
-              label="Logout"
-              onClick={() => setConfirmLogout(true)}
-            />
-          )}
-        </nav>
-      </aside>
+              Yes
+            </button>
+            <span className="text-muted">/</span>
+            <button
+              type="button"
+              onClick={() => setConfirmLogout(false)}
+              className="text-muted underline underline-offset-2 hover:text-ink"
+            >
+              No
+            </button>
+          </span>
+        ) : (
+          <SidebarItem
+            label="Logout"
+            onClick={() => setConfirmLogout(true)}
+            className="ml-auto"
+          />
+        )}
+      </nav>
 
       <div className="min-w-0">
         {section === 'profile' && <ArtistProfile userId={userId} />}
@@ -78,23 +103,37 @@ function SidebarItem({
   label,
   active,
   onClick,
+  href,
+  className,
 }: {
   label: string;
   active?: boolean;
-  onClick: () => void;
+  onClick?: () => void;
+  href?: string;
+  className?: string;
 }) {
+  const base = `text-sm no-underline px-3 py-2 rounded transition-colors ${
+    active
+      ? 'text-accent bg-accent-light font-medium'
+      : 'text-ink hover:text-accent hover:bg-bg-tint'
+  } ${className ?? ''}`;
+
+  if (href) {
+    return (
+      <a href={href} className={base}>
+        {label}
+      </a>
+    );
+  }
+
   return (
     <a
       href="#"
       onClick={(e) => {
         e.preventDefault();
-        onClick();
+        onClick?.();
       }}
-      className={`text-sm no-underline px-3 py-2 rounded transition-colors ${
-        active
-          ? 'text-accent bg-accent-light font-medium'
-          : 'text-ink hover:text-accent hover:bg-bg-tint'
-      }`}
+      className={base}
     >
       {label}
     </a>

--- a/src/components/UsernameEditor.tsx
+++ b/src/components/UsernameEditor.tsx
@@ -58,26 +58,28 @@ export default function UsernameEditor({ userId, currentUsername, onUsernameChan
 
   if (!editing) {
     return (
-      <div className="flex items-center gap-2 mb-4">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mb-4">
         {currentUsername ? (
           <>
-            <span className="font-mono text-xs text-[#A8A29E]">
+            <span className="font-mono text-xs text-[#A8A29E] leading-none">
               irregularpearl.org/@{currentUsername}
             </span>
-            <a
-              href={`/@${currentUsername}`}
-              className="text-[11px] text-accent hover:underline no-underline"
-            >
-              View
-            </a>
-            <span className="text-[11px] text-[#E5E3DE]">·</span>
-            <button
-              onClick={() => { setEditing(true); setUsername(currentUsername); }}
-              className="text-[11px] text-accent hover:underline bg-transparent border-none cursor-pointer p-0"
-            >
-              Change username
-            </button>
-            {saved && <span className="text-[11px] text-green-600">Saved</span>}
+            <span className="inline-flex items-center gap-2 leading-none shrink-0 whitespace-nowrap">
+              <a
+                href={`/@${currentUsername}`}
+                className="text-[11px] text-accent hover:underline no-underline min-w-0! min-h-0!"
+              >
+                View
+              </a>
+              <span className="text-[11px] text-[#E5E3DE]">·</span>
+              <button
+                onClick={() => { setEditing(true); setUsername(currentUsername); }}
+                className="text-[11px] text-accent hover:underline bg-transparent border-none cursor-pointer p-0 min-w-0! min-h-0!"
+              >
+                Change username
+              </button>
+              {saved && <span className="text-[11px] text-green-600">Saved</span>}
+            </span>
           </>
         ) : (
           <button

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,6 +69,7 @@ const canonicalUrl = canonical || Astro.url.href;
   <!-- PWA -->
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#faf8f5" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
@@ -102,6 +103,7 @@ const canonicalUrl = canonical || Astro.url.href;
     <footer class="border-t border-border py-5 px-4 md:px-6 text-xs text-muted mt-auto">
       <div class="hidden md:flex justify-between items-center">
         <div class="flex gap-4">
+          <a href="/about" class="text-muted no-underline">About</a>
           <a href="/terms" class="text-muted no-underline">Terms</a>
           <a href="/privacy" class="text-muted no-underline">Privacy</a>
         </div>
@@ -109,6 +111,7 @@ const canonicalUrl = canonical || Astro.url.href;
       </div>
       <div class="flex flex-col items-center gap-2 md:hidden text-center">
         <a href="/" class="text-ink no-underline font-medium tracking-tight">IrregularPearl</a>
+        <a href="/about" class="text-muted no-underline">About</a>
         <a href="/terms" class="text-muted no-underline">Terms</a>
         <a href="/privacy" class="text-muted no-underline">Privacy</a>
         <span>© {currentYear} Irregular Pearl — a non-profit for classical music knowledge</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -147,7 +147,7 @@ html[data-theme="dark"] {
   --color-bg: #1A1A1A;
   --color-bg-tint: #242320;
   --color-surface: #1F1F1F;
-  --color-ink: #F0EFEC;
+  --color-ink: #FFFFFF;
   --color-muted: #A8A6A0;
   --color-tertiary: #77756F;
   --color-border: #3A3732;
@@ -167,7 +167,7 @@ html[data-theme="dark"] {
   --color-info: #8FB0E0;
   --color-info-bg: #1B2536;
 
-  --ink: #F0EFEC;
+  --ink: #FFFFFF;
   --muted: #A8A6A0;
   --tertiary: #77756F;
   --bg: #1A1A1A;
@@ -648,7 +648,7 @@ body {
   padding: 6px 12px;
   border-radius: 4px;
   border: 0.5px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   color: var(--ink);
   cursor: pointer;
   transition: background 0.12s, border-color 0.12s;
@@ -666,6 +666,16 @@ body {
   filter: brightness(1.05);
 }
 .pending-draft-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+html[data-theme="dark"] .pending-draft-btn {
+  background: var(--bg);
+  color: var(--ink);
+  border-color: var(--border-strong);
+}
+html[data-theme="dark"] .pending-draft-btn.primary {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
 .pending-draft-toast {
   font-family: var(--font-sans);
   font-size: 12px;


### PR DESCRIPTION
## Summary

UX polish across the navbar, profile, dark mode, and PWA chrome. No new features; no schema or data changes.

**Profile + navbar restructure**
- Profile sidebar collapses to a single horizontal nav at every viewport: `Profile | Setting | [role links] | … | Logout` (Logout flushed right via `ml-auto`). Vertical sidebar at md+ removed.
- Maestro / Admin / Moderator role links moved out of the navbar into the profile row, sitting immediately right of Setting.
- "About" moved from the navbar into the footer (before Terms / Privacy on both desktop and mobile rows).
- Below 640px, search renders as a full-width second row inside the sticky nav. Removed the search-open icon and overlay.

**Alignment fixes**
- Navbar bell + avatar + IrregularPearl logo align vertically and horizontally at every viewport. Below 1025px the global touch-target rule (`min-h:44 min-w:44` on `a/button`) was top-left-aligning their content inside inflated boxes. Each is now `inline-flex items-center justify-center` with `min-w-0!` (Tailwind v4 important suffix beats the unlayered global rule). 44px vertical hit area preserved.
- Username slug + `View · Change username` actions wrap as one unit when the row narrows. Inner action group is `inline-flex shrink-0 whitespace-nowrap`; outer is `flex flex-wrap`.

**Dark mode contrast**
- `--color-ink` / `--ink` in dark mode: `#F0EFEC` → `#FFFFFF` (~15.6:1 → ~17.4:1 against `#1A1A1A`).
- `.pending-draft-btn` (Edit & accept / Decline) now visible in dark mode. Hardcoded `background: #fff` → `var(--color-surface)`, plus explicit `html[data-theme="dark"] .pending-draft-btn` block. Primary variant flips its label to `var(--bg)` so dark text reads on the lavender accent fill.

**PWA cleanup**
- `public/manifest.json` no longer 404s on `/icon-192.png` and `/icon-512.png` — manifest now uses `favicon.svg` (`sizes: "any"`).
- Added `<meta name="mobile-web-app-capable" content="yes">` alongside the legacy Apple variant.

## Test Coverage

No new code paths — diff is CSS, JSX layout, and config. 122/122 unit tests pass on final HEAD.

## Pre-Landing Review

No checklist findings. No SQL, auth, LLM trust boundary, migrations, or data writes touched.

## Documentation

CHANGELOG.md `## [0.4.1] - 2026-04-23` (3 Changed + 5 Fixed). VERSION.md bumped + history row. README / CLAUDE.md / DESIGN.md / PRD.md unchanged.

## Test plan

- [x] `bun run test` — 122 pass, 0 fail
- [ ] Visual sanity at < 640px, 640–1024px, ≥ 1025px (light + dark)
- [ ] Chrome devtools: PWA icons load + no `apple-mobile-web-app-capable` deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
