### PR TITLE
feat(auth-gate): share sign-in gate + auto-resume intent across 14 surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "astro preview",
     "check": "astro check",
     "check:vestigial": "bash scripts/check-no-vestigial-refs.sh",
+    "check:auth-gate": "bash scripts/check-auth-gate.sh",
     "test": "bun test src/lib src/data src/components src/tests",
     "test:integration": "bun --env-file=.env.test test src/integration",
     "test:e2e": "bun test src/e2e",

--- a/scripts/check-auth-gate.sh
+++ b/scripts/check-auth-gate.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Grep-gate preventing reintroduction of the "click → sign-in modal →
+# intent lost" bug. Every anon-facing affordance must route through
+# src/lib/useRequireAuth.ts's `gate()` so the pending action auto-resumes
+# after sign-in. Without this guard, a new component can ad-hoc
+# `setSignInOpen(true)` and break the contract, the same way
+# StartContributionButton / RequestContributionDialog / SearchTypeahead
+# drifted in PRs 4–6.
+#
+# Run via `bun run check:auth-gate`. Exits non-zero with locations if any
+# banned pattern appears outside the sanctioned producers.
+#
+# Sanctioned locations (anything else is a bug):
+#   src/lib/useRequireAuth.ts        — owns signInOpen state
+#   src/components/AuthButton.tsx    — navbar sign-in (top-level, no pending action)
+#   src/components/SignInPanel.tsx   — the modal itself
+#
+# Banned patterns (search across src/**/*.{ts,tsx,astro}):
+#   1. `setSignInOpen(true)` / `setSignInPrompt(true)` — direct modal
+#      pop without the gate. Should be `gate(() => ...)` instead.
+#   2. `?signin=1` / `?sign_in=1` URLs — full-page detour through the
+#      home page. Use gate() to open the modal inline instead. The only
+#      sanctioned producer of that URL is privateRoute.ts (for private
+#      pages where the page itself shouldn't render).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+EXIT=0
+
+# Files allowed to reference setSignInOpen / setSignInPrompt.
+# Add to this list only when the anon click pattern intrinsically cannot
+# use gate() (e.g. AuthButton has no pending action).
+ALLOWED_STATE_FILES=(
+  'src/components/AuthButton.tsx'
+  'src/lib/useRequireAuth.ts'
+)
+
+# Files allowed to reference the signin query-param URL.
+ALLOWED_URL_FILES=(
+  'src/lib/privateRoute.ts'
+  'src/components/AuthButton.tsx'
+)
+
+join_alt() { local IFS='|'; echo "$*"; }
+
+STATE_PATTERN='setSignInOpen\(true\)|setSignInPrompt\(true\)'
+URL_PATTERN='\?signin=1|\?sign_in=1'
+
+ALLOWED_STATE_REGEX="^($(join_alt "${ALLOWED_STATE_FILES[@]}"))$"
+ALLOWED_URL_REGEX="^($(join_alt "${ALLOWED_URL_FILES[@]}"))$"
+
+check() {
+  local label="$1"
+  local pattern="$2"
+  local allowed_regex="$3"
+  local guidance="$4"
+
+  # Test files are excluded — regression tests often cite the bug by
+  # name (`/?sign_in=1`) in comments to document what they're pinning.
+  local hits
+  hits=$(grep -rnE --include='*.ts' --include='*.tsx' --include='*.astro' \
+    --exclude='*.test.ts' --exclude='*.test.tsx' \
+    "$pattern" src/ 2>/dev/null || true)
+
+  if [ -z "$hits" ]; then
+    return 0
+  fi
+
+  local filtered=""
+  while IFS= read -r line; do
+    local file="${line%%:*}"
+    if [[ ! "$file" =~ $allowed_regex ]]; then
+      filtered+="$line"$'\n'
+    fi
+  done <<< "$hits"
+
+  if [ -n "$filtered" ]; then
+    echo "ERROR: banned auth-gate pattern ($label):" >&2
+    echo "$filtered" >&2
+    echo "" >&2
+    echo "$guidance" >&2
+    echo "" >&2
+    EXIT=1
+  fi
+}
+
+check 'direct sign-in modal pop' "$STATE_PATTERN" "$ALLOWED_STATE_REGEX" \
+  "Use the shared hook: const { gate, signInOpen, onClose, onSignedIn } = useRequireAuth();
+ Then wrap the click: onClick={() => gate(() => doThing())}
+ The hook stashes the action and auto-resumes it after sign-in so users
+ don't have to re-click. See src/lib/useRequireAuth.ts for the contract."
+
+check 'sign-in redirect URL' "$URL_PATTERN" "$ALLOWED_URL_REGEX" \
+  "Opening the sign-in modal via a full-page redirect to /?signin=1 drops
+ the user on the home page. Use useRequireAuth().gate() to open the
+ SignInPanel inline on the current page instead."
+
+exit $EXIT

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -3,6 +3,7 @@ import { supabase, hasSupabase } from '../lib/supabase';
 import type { User } from '@supabase/supabase-js';
 import GenerativeAvatar from './GenerativeAvatar';
 import SignInPanel from './SignInPanel';
+import { SIGN_IN_PARAM } from '../lib/privateRoute';
 
 export default function AuthButton() {
   const [user, setUser] = useState<User | null>(null);
@@ -32,10 +33,10 @@ export default function AuthButton() {
         // private pages (/notifications, etc.) that redirect anon visitors
         // here without leaking what the source page was about.
         const params = new URLSearchParams(window.location.search);
-        if (params.get('signin') === '1') {
+        if (params.get(SIGN_IN_PARAM) === '1') {
           setSignInOpen(true);
           // Strip the param so a refresh doesn't keep popping the modal.
-          params.delete('signin');
+          params.delete(SIGN_IN_PARAM);
           const newSearch = params.toString();
           const newUrl =
             window.location.pathname + (newSearch ? '?' + newSearch : '') + window.location.hash;

--- a/src/components/EditionsList.tsx
+++ b/src/components/EditionsList.tsx
@@ -8,10 +8,10 @@
 
 import { useCallback, useState, useEffect, useRef } from 'react';
 import { supabase } from '../lib/supabase';
-import { useAuth } from '../lib/useAuth';
 import { fetchEditionsForPiece, type Edition } from '../lib/editions';
 import { CHANGELOG_REFRESH_EVENT } from './ChangeLog';
 import SignInPanel from './SignInPanel';
+import { useRequireAuth } from '../lib/useRequireAuth';
 
 interface Props {
   pieceId: string;
@@ -23,12 +23,16 @@ const TYPE_OPTIONS = ['urtext', 'scholarly', 'performer', 'facsimile', 'critical
 type Busy = { kind: 'idle' } | { kind: 'working'; id?: string } | { kind: 'error'; message: string };
 
 export default function EditionsList({ pieceId, initialEditions }: Props) {
-  const { user } = useAuth();
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
   const [editions, setEditions] = useState<Edition[]>(initialEditions);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
-  const [signInOpen, setSignInOpen] = useState(false);
   const [busy, setBusy] = useState<Busy>({ kind: 'idle' });
 
   const broadcastChangelog = useCallback(() => {
@@ -41,38 +45,35 @@ export default function EditionsList({ pieceId, initialEditions }: Props) {
     broadcastChangelog();
   }, [pieceId, broadcastChangelog]);
 
-  const requireAuth = useCallback(() => {
-    if (!user) { setSignInOpen(true); return false; }
-    return true;
-  }, [user]);
+  const handleSwap = useCallback((i: number, dir: 'up' | 'down') => {
+    gate(() => void (async () => {
+      const j = dir === 'up' ? i - 1 : i + 1;
+      if (j < 0 || j >= editions.length) return;
+      const a = editions[i], b = editions[j];
+      setBusy({ kind: 'working', id: a.id });
+      const { error } = await supabase.rpc('swap_edition_ordinals', { p_id_a: a.id, p_id_b: b.id });
+      if (error) {
+        setBusy({ kind: 'error', message: prettyError(error.message, 'Reorder failed') });
+        return;
+      }
+      await refetch();
+      setBusy({ kind: 'idle' });
+    })());
+  }, [editions, refetch, gate]);
 
-  const handleSwap = useCallback(async (i: number, dir: 'up' | 'down') => {
-    if (!requireAuth()) return;
-    const j = dir === 'up' ? i - 1 : i + 1;
-    if (j < 0 || j >= editions.length) return;
-    const a = editions[i], b = editions[j];
-    setBusy({ kind: 'working', id: a.id });
-    const { error } = await supabase.rpc('swap_edition_ordinals', { p_id_a: a.id, p_id_b: b.id });
-    if (error) {
-      setBusy({ kind: 'error', message: prettyError(error.message, 'Reorder failed') });
-      return;
-    }
-    await refetch();
-    setBusy({ kind: 'idle' });
-  }, [editions, refetch, requireAuth]);
-
-  const handleDelete = useCallback(async (id: string) => {
-    if (!requireAuth()) return;
-    setBusy({ kind: 'working', id });
-    const { error } = await supabase.rpc('delete_edition', { p_id: id });
-    if (error) {
-      setBusy({ kind: 'error', message: prettyError(error.message, 'Delete failed') });
-      return;
-    }
-    setConfirmDeleteId(null);
-    await refetch();
-    setBusy({ kind: 'idle' });
-  }, [refetch, requireAuth]);
+  const handleDelete = useCallback((id: string) => {
+    gate(() => void (async () => {
+      setBusy({ kind: 'working', id });
+      const { error } = await supabase.rpc('delete_edition', { p_id: id });
+      if (error) {
+        setBusy({ kind: 'error', message: prettyError(error.message, 'Delete failed') });
+        return;
+      }
+      setConfirmDeleteId(null);
+      await refetch();
+      setBusy({ kind: 'idle' });
+    })());
+  }, [refetch, gate]);
 
   return (
     <>
@@ -158,7 +159,7 @@ export default function EditionsList({ pieceId, initialEditions }: Props) {
                     </svg>
                   </button>
                   <button type="button" className="ed-ctrl" aria-label={`Edit ${e.publisher}`}
-                    disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setEditingId(e.id); }}>
+                    disabled={rowWorking} onClick={() => gate(() => setEditingId(e.id))}>
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                       <path d="M11.5 2.5l2 2L5 13H3v-2l8.5-8.5z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
                     </svg>
@@ -171,7 +172,7 @@ export default function EditionsList({ pieceId, initialEditions }: Props) {
                     </span>
                   ) : (
                     <button type="button" className="ed-ctrl ed-ctrl-delete" aria-label={`Delete ${e.publisher}`}
-                      disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setConfirmDeleteId(e.id); }}>
+                      disabled={rowWorking} onClick={() => gate(() => setConfirmDeleteId(e.id))}>
                       <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                         <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
                       </svg>
@@ -191,7 +192,7 @@ export default function EditionsList({ pieceId, initialEditions }: Props) {
         </div>
       )}
 
-      <button type="button" className="mvmt-add" onClick={() => { if (!requireAuth()) return; setAddOpen(true); }}>
+      <button type="button" className="mvmt-add" onClick={() => gate(() => setAddOpen(true))}>
         + Add edition
       </button>
 
@@ -204,7 +205,8 @@ export default function EditionsList({ pieceId, initialEditions }: Props) {
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to edit"
           body={
             <>

--- a/src/components/ExternalRefsList.tsx
+++ b/src/components/ExternalRefsList.tsx
@@ -4,7 +4,6 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
-import { useAuth } from '../lib/useAuth';
 import {
   fetchExternalLinksForPiece,
   REFERENCE_TYPES,
@@ -12,6 +11,7 @@ import {
 } from '../lib/externalLinks';
 import { CHANGELOG_REFRESH_EVENT } from './ChangeLog';
 import SignInPanel from './SignInPanel';
+import { useRequireAuth } from '../lib/useRequireAuth';
 
 interface Props {
   pieceId: string;
@@ -21,12 +21,16 @@ interface Props {
 type Busy = { kind: 'idle' } | { kind: 'working'; id?: string } | { kind: 'error'; message: string };
 
 export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
-  const { user } = useAuth();
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
   const [links, setLinks] = useState<ExternalLink[]>(initialLinks);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
-  const [signInOpen, setSignInOpen] = useState(false);
   const [busy, setBusy] = useState<Busy>({ kind: 'idle' });
 
   const broadcastChangelog = useCallback(() => {
@@ -39,38 +43,35 @@ export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
     broadcastChangelog();
   }, [pieceId, broadcastChangelog]);
 
-  const requireAuth = useCallback(() => {
-    if (!user) { setSignInOpen(true); return false; }
-    return true;
-  }, [user]);
+  const handleSwap = useCallback((i: number, dir: 'up' | 'down') => {
+    gate(() => void (async () => {
+      const j = dir === 'up' ? i - 1 : i + 1;
+      if (j < 0 || j >= links.length) return;
+      const a = links[i], b = links[j];
+      setBusy({ kind: 'working', id: a.id });
+      const { error } = await supabase.rpc('swap_external_link_ordinals', { p_id_a: a.id, p_id_b: b.id });
+      if (error) {
+        setBusy({ kind: 'error', message: pretty(error.message, 'Reorder failed') });
+        return;
+      }
+      await refetch();
+      setBusy({ kind: 'idle' });
+    })());
+  }, [links, refetch, gate]);
 
-  const handleSwap = useCallback(async (i: number, dir: 'up' | 'down') => {
-    if (!requireAuth()) return;
-    const j = dir === 'up' ? i - 1 : i + 1;
-    if (j < 0 || j >= links.length) return;
-    const a = links[i], b = links[j];
-    setBusy({ kind: 'working', id: a.id });
-    const { error } = await supabase.rpc('swap_external_link_ordinals', { p_id_a: a.id, p_id_b: b.id });
-    if (error) {
-      setBusy({ kind: 'error', message: pretty(error.message, 'Reorder failed') });
-      return;
-    }
-    await refetch();
-    setBusy({ kind: 'idle' });
-  }, [links, refetch, requireAuth]);
-
-  const handleDelete = useCallback(async (id: string) => {
-    if (!requireAuth()) return;
-    setBusy({ kind: 'working', id });
-    const { error } = await supabase.rpc('delete_external_link', { p_id: id });
-    if (error) {
-      setBusy({ kind: 'error', message: pretty(error.message, 'Delete failed') });
-      return;
-    }
-    setConfirmDeleteId(null);
-    await refetch();
-    setBusy({ kind: 'idle' });
-  }, [refetch, requireAuth]);
+  const handleDelete = useCallback((id: string) => {
+    gate(() => void (async () => {
+      setBusy({ kind: 'working', id });
+      const { error } = await supabase.rpc('delete_external_link', { p_id: id });
+      if (error) {
+        setBusy({ kind: 'error', message: pretty(error.message, 'Delete failed') });
+        return;
+      }
+      setConfirmDeleteId(null);
+      await refetch();
+      setBusy({ kind: 'idle' });
+    })());
+  }, [refetch, gate]);
 
   return (
     <>
@@ -128,7 +129,7 @@ export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
                     </svg>
                   </button>
                   <button type="button" className="ed-ctrl" aria-label={`Edit ${l.label}`}
-                    disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setEditingId(l.id); }}>
+                    disabled={rowWorking} onClick={() => gate(() => setEditingId(l.id))}>
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                       <path d="M11.5 2.5l2 2L5 13H3v-2l8.5-8.5z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
                     </svg>
@@ -141,7 +142,7 @@ export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
                     </span>
                   ) : (
                     <button type="button" className="ed-ctrl ed-ctrl-delete" aria-label={`Delete ${l.label}`}
-                      disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setConfirmDeleteId(l.id); }}>
+                      disabled={rowWorking} onClick={() => gate(() => setConfirmDeleteId(l.id))}>
                       <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                         <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
                       </svg>
@@ -154,7 +155,7 @@ export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
         </ul>
       )}
 
-      <button type="button" className="mvmt-add" onClick={() => { if (!requireAuth()) return; setAddOpen(true); }}>
+      <button type="button" className="mvmt-add" onClick={() => gate(() => setAddOpen(true))}>
         + Add reference
       </button>
 
@@ -167,7 +168,8 @@ export default function ExternalRefsList({ pieceId, initialLinks }: Props) {
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to edit"
           body={
             <>

--- a/src/components/InterpretiveSchools.tsx
+++ b/src/components/InterpretiveSchools.tsx
@@ -19,6 +19,7 @@ import VoteThumbs from './VoteThumbs';
 import OwnerEditDelete from './OwnerEditDelete';
 import PendingDraftCard from './PendingDraftCard';
 import SignInPanel from './SignInPanel';
+import { useRequireAuth } from '../lib/useRequireAuth';
 import ComposeDraftBlock from './ComposeDraftBlock';
 
 interface Props {
@@ -43,7 +44,12 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
   const [toast, setToast] = useState<string | null>(null);
   const [pendingDrafts, setPendingDrafts] = useState<PendingDraft[]>([]);
   const [pageIdx, setPageIdx] = useState(0);
-  const [signInOpen, setSignInOpen] = useState(false);
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
 
   const PAGE_SIZE = 3;
   const totalPages = Math.max(1, Math.ceil(schools.length / PAGE_SIZE));
@@ -285,8 +291,7 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
           type="button"
           onClick={() => {
             setError(null);
-            if (!viewer?.userId) { setSignInOpen(true); return; }
-            setMode('write');
+            gate(() => setMode('write'));
           }}
           className="mvmt-add"
         >
@@ -312,7 +317,8 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to write"
           body={
             <>Interpretive schools are signed — any registered user can propose one. Sign in or create an account to post yours.</>

--- a/src/components/MovementEdit.tsx
+++ b/src/components/MovementEdit.tsx
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
+import { useRequireAuth } from '../lib/useRequireAuth';
 import type { Movement } from '../lib/movements';
 import SignInPanel from './SignInPanel';
 
@@ -32,8 +33,13 @@ type SaveState =
 
 export default function MovementEdit({ movement, onUpdated }: Props) {
   const { user } = useAuth();
+  const {
+    signInOpen: signInPrompt,
+    onClose: signInPromptOnClose,
+    onSignedIn: signInPromptOnSignedIn,
+    gate,
+  } = useRequireAuth();
   const [open, setOpen] = useState(false);
-  const [signInPrompt, setSignInPrompt] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' });
   const [fields, setFields] = useState({
     name: movement.name,
@@ -51,21 +57,19 @@ export default function MovementEdit({ movement, onUpdated }: Props) {
   // Reset form state when opening so subsequent edits start from the current
   // movement (in case another user updated it between modal opens).
   const openModal = useCallback(() => {
-    if (!user) {
-      setSignInPrompt(true);
-      return;
-    }
-    setFields({
-      name: movement.name,
-      tempoIndication: movement.tempoIndication ?? '',
-      keySignature: movement.keySignature ?? '',
-      meter: movement.meter ?? '',
-      ordinal: movement.ordinal,
-      editSummary: '',
+    gate(() => {
+      setFields({
+        name: movement.name,
+        tempoIndication: movement.tempoIndication ?? '',
+        keySignature: movement.keySignature ?? '',
+        meter: movement.meter ?? '',
+        ordinal: movement.ordinal,
+        editSummary: '',
+      });
+      setSaveState({ kind: 'idle' });
+      setOpen(true);
     });
-    setSaveState({ kind: 'idle' });
-    setOpen(true);
-  }, [movement, user]);
+  }, [movement, gate]);
 
   const closeModal = useCallback(() => {
     setOpen(false);
@@ -74,9 +78,9 @@ export default function MovementEdit({ movement, onUpdated }: Props) {
   }, []);
 
   const closeSignInPrompt = useCallback(() => {
-    setSignInPrompt(false);
+    signInPromptOnClose();
     requestAnimationFrame(() => pencilRef.current?.focus());
-  }, []);
+  }, [signInPromptOnClose]);
 
   // Focus trap + Esc handler while modal is open.
   useEffect(() => {
@@ -284,6 +288,7 @@ export default function MovementEdit({ movement, onUpdated }: Props) {
       {signInPrompt && (
         <SignInPanel
           onClose={closeSignInPrompt}
+          onSignedIn={signInPromptOnSignedIn}
           title="Sign in to edit"
           body={
             <>

--- a/src/components/MovementsList.tsx
+++ b/src/components/MovementsList.tsx
@@ -16,6 +16,7 @@ import MovementEdit from './MovementEdit';
 import { CHANGELOG_REFRESH_EVENT } from './ChangeLog';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
+import { useRequireAuth } from '../lib/useRequireAuth';
 import { fetchMovementsForPiece, type Movement } from '../lib/movements';
 import SignInPanel from './SignInPanel';
 import StructuralLandmarks from './StructuralLandmarks';
@@ -43,10 +44,15 @@ export default function MovementsList({
   landmarksByMovement = {},
 }: Props) {
   const { user } = useAuth();
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
   const [movements, setMovements] = useState<Movement[]>(initialMovements);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
-  const [signInOpen, setSignInOpen] = useState(false);
   const [busy, setBusy] = useState<Busy>({ kind: 'idle' });
 
   const broadcastChangelog = useCallback(() => {
@@ -61,56 +67,50 @@ export default function MovementsList({
     broadcastChangelog();
   }, [pieceId, broadcastChangelog]);
 
-  const requireAuth = useCallback(() => {
-    if (!user) {
-      setSignInOpen(true);
-      return false;
-    }
-    return true;
-  }, [user]);
-
   const handleSwap = useCallback(
-    async (i: number, direction: 'up' | 'down') => {
-      if (!requireAuth()) return;
-      const target = direction === 'up' ? i - 1 : i + 1;
-      if (target < 0 || target >= movements.length) return;
-      const a = movements[i];
-      const b = movements[target];
-      setBusy({ kind: 'working', movementId: a.id });
-      const { error } = await supabase.rpc('swap_movement_ordinals', {
-        p_movement_id_a: a.id,
-        p_movement_id_b: b.id,
-      });
-      if (error) {
-        const pretty = error.message.includes('rate limit')
-          ? 'You’ve changed movements too often. Try again later.'
-          : `Reorder failed: ${error.message}`;
-        setBusy({ kind: 'error', message: pretty });
-        return;
-      }
-      await refetch();
-      setBusy({ kind: 'idle' });
+    (i: number, direction: 'up' | 'down') => {
+      gate(() => void (async () => {
+        const target = direction === 'up' ? i - 1 : i + 1;
+        if (target < 0 || target >= movements.length) return;
+        const a = movements[i];
+        const b = movements[target];
+        setBusy({ kind: 'working', movementId: a.id });
+        const { error } = await supabase.rpc('swap_movement_ordinals', {
+          p_movement_id_a: a.id,
+          p_movement_id_b: b.id,
+        });
+        if (error) {
+          const pretty = error.message.includes('rate limit')
+            ? 'You’ve changed movements too often. Try again later.'
+            : `Reorder failed: ${error.message}`;
+          setBusy({ kind: 'error', message: pretty });
+          return;
+        }
+        await refetch();
+        setBusy({ kind: 'idle' });
+      })());
     },
-    [movements, refetch, requireAuth],
+    [movements, refetch, gate],
   );
 
   const handleDelete = useCallback(
-    async (id: string) => {
-      if (!requireAuth()) return;
-      setBusy({ kind: 'working', movementId: id });
-      const { error } = await supabase.rpc('delete_movement', { p_movement_id: id });
-      if (error) {
-        const pretty = error.message.includes('rate limit')
-          ? 'You’ve changed movements too often. Try again later.'
-          : `Delete failed: ${error.message}`;
-        setBusy({ kind: 'error', message: pretty });
-        return;
-      }
-      setConfirmDeleteId(null);
-      await refetch();
-      setBusy({ kind: 'idle' });
+    (id: string) => {
+      gate(() => void (async () => {
+        setBusy({ kind: 'working', movementId: id });
+        const { error } = await supabase.rpc('delete_movement', { p_movement_id: id });
+        if (error) {
+          const pretty = error.message.includes('rate limit')
+            ? 'You’ve changed movements too often. Try again later.'
+            : `Delete failed: ${error.message}`;
+          setBusy({ kind: 'error', message: pretty });
+          return;
+        }
+        setConfirmDeleteId(null);
+        await refetch();
+        setBusy({ kind: 'idle' });
+      })());
     },
-    [refetch, requireAuth],
+    [refetch, gate],
   );
 
   return (
@@ -183,10 +183,7 @@ export default function MovementsList({
                         type="button"
                         className="mvmt-ctrl mvmt-ctrl-delete"
                         aria-label={user ? `Delete ${m.name}` : `Sign in to delete ${m.name}`}
-                        onClick={() => {
-                          if (!requireAuth()) return;
-                          setConfirmDeleteId(m.id);
-                        }}
+                        onClick={() => gate(() => setConfirmDeleteId(m.id))}
                         disabled={rowWorking}
                       >
                         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -227,10 +224,7 @@ export default function MovementsList({
       <button
         type="button"
         className="mvmt-add"
-        onClick={() => {
-          if (!requireAuth()) return;
-          setAddOpen(true);
-        }}
+        onClick={() => gate(() => setAddOpen(true))}
       >
         + Add movement
       </button>
@@ -246,7 +240,8 @@ export default function MovementsList({
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to edit"
           body={
             <>

--- a/src/components/PedagogicalArcList.tsx
+++ b/src/components/PedagogicalArcList.tsx
@@ -11,7 +11,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
-import { useAuth } from '../lib/useAuth';
+import { useRequireAuth } from '../lib/useRequireAuth';
 import {
   fetchPedagogicalConnections,
   type PedagogicalConnection,
@@ -36,12 +36,16 @@ const KIND_LABELS: Record<PedagogicalKind, string> = {
 };
 
 export default function PedagogicalArcList({ pieceId, initialConnections, pieceOptions }: Props) {
-  const { user } = useAuth();
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
   const [connections, setConnections] = useState<PedagogicalConnection[]>(initialConnections);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [addOpenKind, setAddOpenKind] = useState<PedagogicalKind | null>(null);
-  const [signInOpen, setSignInOpen] = useState(false);
   const [busy, setBusy] = useState<Busy>({ kind: 'idle' });
 
   const broadcastChangelog = useCallback(() => {
@@ -52,11 +56,6 @@ export default function PedagogicalArcList({ pieceId, initialConnections, pieceO
     setConnections(await fetchPedagogicalConnections(pieceId));
     broadcastChangelog();
   }, [pieceId, broadcastChangelog]);
-
-  const requireAuth = useCallback(() => {
-    if (!user) { setSignInOpen(true); return false; }
-    return true;
-  }, [user]);
 
   const grouped = useMemo(() => {
     const prepare: PedagogicalConnection[] = [];
@@ -73,34 +72,36 @@ export default function PedagogicalArcList({ pieceId, initialConnections, pieceO
     return s;
   }, [connections, pieceId]);
 
-  const handleSwap = useCallback(async (kind: PedagogicalKind, i: number, dir: 'up' | 'down') => {
-    if (!requireAuth()) return;
-    const list = grouped[kind];
-    const j = dir === 'up' ? i - 1 : i + 1;
-    if (j < 0 || j >= list.length) return;
-    const a = list[i], b = list[j];
-    setBusy({ kind: 'working', id: a.id });
-    const { error } = await supabase.rpc('swap_pedagogical_ordinals', { p_id_a: a.id, p_id_b: b.id });
-    if (error) {
-      setBusy({ kind: 'error', message: pretty(error.message, 'Reorder failed') });
-      return;
-    }
-    await refetch();
-    setBusy({ kind: 'idle' });
-  }, [grouped, refetch, requireAuth]);
+  const handleSwap = useCallback((kind: PedagogicalKind, i: number, dir: 'up' | 'down') => {
+    gate(() => void (async () => {
+      const list = grouped[kind];
+      const j = dir === 'up' ? i - 1 : i + 1;
+      if (j < 0 || j >= list.length) return;
+      const a = list[i], b = list[j];
+      setBusy({ kind: 'working', id: a.id });
+      const { error } = await supabase.rpc('swap_pedagogical_ordinals', { p_id_a: a.id, p_id_b: b.id });
+      if (error) {
+        setBusy({ kind: 'error', message: pretty(error.message, 'Reorder failed') });
+        return;
+      }
+      await refetch();
+      setBusy({ kind: 'idle' });
+    })());
+  }, [grouped, refetch, gate]);
 
-  const handleDelete = useCallback(async (id: string) => {
-    if (!requireAuth()) return;
-    setBusy({ kind: 'working', id });
-    const { error } = await supabase.rpc('delete_pedagogical_connection', { p_id: id });
-    if (error) {
-      setBusy({ kind: 'error', message: pretty(error.message, 'Delete failed') });
-      return;
-    }
-    setConfirmDeleteId(null);
-    await refetch();
-    setBusy({ kind: 'idle' });
-  }, [refetch, requireAuth]);
+  const handleDelete = useCallback((id: string) => {
+    gate(() => void (async () => {
+      setBusy({ kind: 'working', id });
+      const { error } = await supabase.rpc('delete_pedagogical_connection', { p_id: id });
+      if (error) {
+        setBusy({ kind: 'error', message: pretty(error.message, 'Delete failed') });
+        return;
+      }
+      setConfirmDeleteId(null);
+      await refetch();
+      setBusy({ kind: 'idle' });
+    })());
+  }, [refetch, gate]);
 
   return (
     <>
@@ -172,7 +173,7 @@ export default function PedagogicalArcList({ pieceId, initialConnections, pieceO
                           </svg>
                         </button>
                         <button type="button" className="ed-ctrl" aria-label={`Edit ${c.relatedTitle}`}
-                          disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setEditingId(c.id); }}>
+                          disabled={rowWorking} onClick={() => gate(() => setEditingId(c.id))}>
                           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                             <path d="M11.5 2.5l2 2L5 13H3v-2l8.5-8.5z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
                           </svg>
@@ -185,7 +186,7 @@ export default function PedagogicalArcList({ pieceId, initialConnections, pieceO
                           </span>
                         ) : (
                           <button type="button" className="ed-ctrl ed-ctrl-delete" aria-label={`Delete ${c.relatedTitle}`}
-                            disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setConfirmDeleteId(c.id); }}>
+                            disabled={rowWorking} onClick={() => gate(() => setConfirmDeleteId(c.id))}>
                             <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                               <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
                             </svg>
@@ -198,7 +199,7 @@ export default function PedagogicalArcList({ pieceId, initialConnections, pieceO
                 })}
               </ul>
             )}
-            <button type="button" className="mvmt-add ped-add" onClick={() => { if (!requireAuth()) return; setAddOpenKind(kind); }}>
+            <button type="button" className="mvmt-add ped-add" onClick={() => gate(() => setAddOpenKind(kind))}>
               + Add {KIND_LABELS[kind].toLowerCase()}
             </button>
           </div>
@@ -214,7 +215,8 @@ export default function PedagogicalArcList({ pieceId, initialConnections, pieceO
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to edit"
           body={
             <>

--- a/src/components/PerformersNotes.tsx
+++ b/src/components/PerformersNotes.tsx
@@ -20,6 +20,7 @@ import OwnerEditDelete from './OwnerEditDelete';
 import PendingDraftCard from './PendingDraftCard';
 import SignInPanel from './SignInPanel';
 import ComposeDraftBlock from './ComposeDraftBlock';
+import { useRequireAuth } from '../lib/useRequireAuth';
 
 interface Props {
   pieceId: string;
@@ -43,7 +44,12 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
   const [toast, setToast] = useState<string | null>(null);
   const [pendingDrafts, setPendingDrafts] = useState<PendingDraft[]>([]);
   const [pageIdx, setPageIdx] = useState(0);
-  const [signInOpen, setSignInOpen] = useState(false);
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
 
   const PAGE_SIZE = 3;
   const totalPages = Math.max(1, Math.ceil(notes.length / PAGE_SIZE));
@@ -281,8 +287,7 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
           type="button"
           onClick={() => {
             setError(null);
-            if (!viewer?.userId) { setSignInOpen(true); return; }
-            setMode('write');
+            gate(() => setMode('write'));
           }}
           className="write-entry"
         >
@@ -306,7 +311,8 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to write"
           body={
             <>Performer's notes are signed — any registered user can publish their own. Sign in or create an account to post yours.</>

--- a/src/components/RecordingsList.tsx
+++ b/src/components/RecordingsList.tsx
@@ -14,7 +14,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
-import { useAuth } from '../lib/useAuth';
+import { useRequireAuth } from '../lib/useRequireAuth';
 import {
   fetchExternalLinksForPiece,
   recordingEmbedUrl,
@@ -32,13 +32,17 @@ interface Props {
 type Busy = { kind: 'idle' } | { kind: 'working'; id?: string } | { kind: 'error'; message: string };
 
 export default function RecordingsList({ pieceId, initialLinks }: Props) {
-  const { user } = useAuth();
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
   const [links, setLinks] = useState<ExternalLink[]>(initialLinks);
   const [openId, setOpenId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
-  const [signInOpen, setSignInOpen] = useState(false);
   const [busy, setBusy] = useState<Busy>({ kind: 'idle' });
 
   const broadcastChangelog = useCallback(() => {
@@ -51,39 +55,36 @@ export default function RecordingsList({ pieceId, initialLinks }: Props) {
     broadcastChangelog();
   }, [pieceId, broadcastChangelog]);
 
-  const requireAuth = useCallback(() => {
-    if (!user) { setSignInOpen(true); return false; }
-    return true;
-  }, [user]);
+  const handleSwap = useCallback((i: number, dir: 'up' | 'down') => {
+    gate(() => void (async () => {
+      const j = dir === 'up' ? i - 1 : i + 1;
+      if (j < 0 || j >= links.length) return;
+      const a = links[i], b = links[j];
+      setBusy({ kind: 'working', id: a.id });
+      const { error } = await supabase.rpc('swap_external_link_ordinals', { p_id_a: a.id, p_id_b: b.id });
+      if (error) {
+        setBusy({ kind: 'error', message: pretty(error.message, 'Reorder failed') });
+        return;
+      }
+      await refetch();
+      setBusy({ kind: 'idle' });
+    })());
+  }, [links, refetch, gate]);
 
-  const handleSwap = useCallback(async (i: number, dir: 'up' | 'down') => {
-    if (!requireAuth()) return;
-    const j = dir === 'up' ? i - 1 : i + 1;
-    if (j < 0 || j >= links.length) return;
-    const a = links[i], b = links[j];
-    setBusy({ kind: 'working', id: a.id });
-    const { error } = await supabase.rpc('swap_external_link_ordinals', { p_id_a: a.id, p_id_b: b.id });
-    if (error) {
-      setBusy({ kind: 'error', message: pretty(error.message, 'Reorder failed') });
-      return;
-    }
-    await refetch();
-    setBusy({ kind: 'idle' });
-  }, [links, refetch, requireAuth]);
-
-  const handleDelete = useCallback(async (id: string) => {
-    if (!requireAuth()) return;
-    setBusy({ kind: 'working', id });
-    const { error } = await supabase.rpc('delete_external_link', { p_id: id });
-    if (error) {
-      setBusy({ kind: 'error', message: pretty(error.message, 'Delete failed') });
-      return;
-    }
-    setConfirmDeleteId(null);
-    if (openId === id) setOpenId(null);
-    await refetch();
-    setBusy({ kind: 'idle' });
-  }, [openId, refetch, requireAuth]);
+  const handleDelete = useCallback((id: string) => {
+    gate(() => void (async () => {
+      setBusy({ kind: 'working', id });
+      const { error } = await supabase.rpc('delete_external_link', { p_id: id });
+      if (error) {
+        setBusy({ kind: 'error', message: pretty(error.message, 'Delete failed') });
+        return;
+      }
+      setConfirmDeleteId(null);
+      if (openId === id) setOpenId(null);
+      await refetch();
+      setBusy({ kind: 'idle' });
+    })());
+  }, [openId, refetch, gate]);
 
   return (
     <>
@@ -154,7 +155,7 @@ export default function RecordingsList({ pieceId, initialLinks }: Props) {
                       </svg>
                     </button>
                     <button type="button" className="ed-ctrl" aria-label={`Edit ${r.label}`}
-                      disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setEditingId(r.id); if (isOpen) setOpenId(null); }}>
+                      disabled={rowWorking} onClick={() => gate(() => { setEditingId(r.id); if (isOpen) setOpenId(null); })}>
                       <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                         <path d="M11.5 2.5l2 2L5 13H3v-2l8.5-8.5z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
                       </svg>
@@ -167,7 +168,7 @@ export default function RecordingsList({ pieceId, initialLinks }: Props) {
                       </span>
                     ) : (
                       <button type="button" className="ed-ctrl ed-ctrl-delete" aria-label={`Delete ${r.label}`}
-                        disabled={rowWorking} onClick={() => { if (!requireAuth()) return; setConfirmDeleteId(r.id); }}>
+                        disabled={rowWorking} onClick={() => gate(() => setConfirmDeleteId(r.id))}>
                         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                           <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
                         </svg>
@@ -204,7 +205,7 @@ export default function RecordingsList({ pieceId, initialLinks }: Props) {
         </ul>
       )}
 
-      <button type="button" className="mvmt-add" onClick={() => { if (!requireAuth()) return; setAddOpen(true); }}>
+      <button type="button" className="mvmt-add" onClick={() => gate(() => setAddOpen(true))}>
         + Add recording
       </button>
 
@@ -217,7 +218,8 @@ export default function RecordingsList({ pieceId, initialLinks }: Props) {
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to edit"
           body={
             <>

--- a/src/components/RequestContributionDialog.test.tsx
+++ b/src/components/RequestContributionDialog.test.tsx
@@ -1,0 +1,37 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!globalThis.document) GlobalRegistrator.register();
+import { afterEach, describe, test, expect } from 'bun:test';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import RequestContributionDialog from './RequestContributionDialog';
+
+// Regression pin for the sign-in modal drift bug (sibling to
+// StartContributionButton.test.tsx). Anon click on the request trigger must
+// open the SignInPanel inline, not navigate to /?sign_in=1 (the old typo'd
+// param that dropped users on the home page with no dialog).
+describe('RequestContributionDialog (anon)', () => {
+  afterEach(() => cleanup());
+
+  test('click on anon trigger opens the SignInPanel modal inline', async () => {
+    const { container, getByText } = render(
+      <RequestContributionDialog
+        pieceId="test-piece"
+        pieceTitle="Test Piece"
+        composerName="Test Composer"
+        triggerLabel="Request a contribution"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('Request a contribution')).toBeTruthy();
+    });
+
+    expect(container.querySelector('.ip-signin-modal')).toBeNull();
+
+    fireEvent.click(getByText('Request a contribution'));
+
+    const modal = container.querySelector('.ip-signin-modal');
+    expect(modal).not.toBeNull();
+    const title = container.querySelector('.ip-signin-title');
+    expect(title?.textContent).toContain('Sign in');
+  });
+});

--- a/src/components/RequestContributionDialog.tsx
+++ b/src/components/RequestContributionDialog.tsx
@@ -13,8 +13,9 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
-import { useAuth } from '../lib/useAuth';
+import { useRequireAuth } from '../lib/useRequireAuth';
 import { createOutboxRequest } from '../lib/contributionDrafts';
+import SignInPanel from './SignInPanel';
 
 interface Props {
   pieceId: string;
@@ -41,7 +42,13 @@ export default function RequestContributionDialog({
   triggerLabel,
   triggerClassName,
 }: Props) {
-  const { user } = useAuth();
+  const {
+    user,
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
   const [open, setOpen] = useState(false);
   const [isStaff, setIsStaff] = useState(false);
   const [mode, setMode] = useState<Mode>('username');
@@ -182,13 +189,11 @@ export default function RequestContributionDialog({
   }, [suggestOpen]);
 
   function handleOpen() {
-    if (!user) {
-      window.location.href = '/?sign_in=1';
-      return;
-    }
-    setOpen(true);
-    setError(null);
-    setSuccess(null);
+    gate(() => {
+      setOpen(true);
+      setError(null);
+      setSuccess(null);
+    });
   }
 
   function handleClose() {
@@ -373,6 +378,17 @@ export default function RequestContributionDialog({
       >
         {triggerLabel}
       </button>
+
+      {signInOpen && (
+        <SignInPanel
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
+          title="Sign in to request a contribution"
+          body={
+            <>Sending a contribution request is a signed action. Sign in or create an account to continue.</>
+          }
+        />
+      )}
 
       {open && (
         <div

--- a/src/components/SearchTypeahead.tsx
+++ b/src/components/SearchTypeahead.tsx
@@ -12,6 +12,8 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
+import { useRequireAuth } from '../lib/useRequireAuth';
+import SignInPanel from './SignInPanel';
 
 interface Result {
   result_type: 'materialized' | 'seed';
@@ -73,7 +75,13 @@ export default function SearchTypeahead({ className, autoFocus, onDismiss }: Pro
   const [open, setOpen] = useState(false);
   const [activeIdx, setActiveIdx] = useState(0);
   const [materializing, setMaterializing] = useState(false);
-  const [needsSignIn, setNeedsSignIn] = useState<Result | null>(null);
+  const [pendingSeed, setPendingSeed] = useState<Result | null>(null);
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -139,14 +147,11 @@ export default function SearchTypeahead({ className, autoFocus, onDismiss }: Pro
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
 
-  // Escape dismiss
+  // Escape dismiss. The SignInPanel owns its own Escape handling when open,
+  // so we only care about dismissing the typeahead dropdown here.
   useEffect(() => {
     function handler(e: KeyboardEvent) {
       if (e.key === 'Escape') {
-        if (needsSignIn) {
-          setNeedsSignIn(null);
-          return;
-        }
         if (open) {
           maybeLogDismissedMiss();
           setOpen(false);
@@ -157,7 +162,7 @@ export default function SearchTypeahead({ className, autoFocus, onDismiss }: Pro
     }
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [open, needsSignIn, onDismiss]);
+  }, [open, onDismiss]);
 
   // Page unload (nav away with dropdown still open)
   useEffect(() => {
@@ -168,18 +173,8 @@ export default function SearchTypeahead({ className, autoFocus, onDismiss }: Pro
     return () => window.removeEventListener('pagehide', handler);
   }, [open]);
 
-  async function handleSelect(r: Result) {
-    if (r.result_type === 'materialized') {
-      window.location.href = piecePath(r.id);
-      return;
-    }
-    // Seed: materialize (signed-in only)
+  async function materializeAndGo(r: Result) {
     if (!hasSupabase) return;
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
-      setNeedsSignIn(r);
-      return;
-    }
     setMaterializing(true);
     const { data: pieceId, error } = await supabase.rpc('materialize_piece_from_index', {
       p_index_id: r.id,
@@ -192,6 +187,20 @@ export default function SearchTypeahead({ className, autoFocus, onDismiss }: Pro
       return;
     }
     window.location.href = piecePath(pieceId as string);
+  }
+
+  function handleSelect(r: Result) {
+    if (r.result_type === 'materialized') {
+      window.location.href = piecePath(r.id);
+      return;
+    }
+    // Seed: anon gets SignInPanel with the seed stashed as the pending
+    // action; on successful sign-in the materialize + navigate resumes.
+    setPendingSeed(r);
+    gate(() => {
+      setPendingSeed(null);
+      void materializeAndGo(r);
+    });
   }
 
   function handleKey(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -362,35 +371,21 @@ export default function SearchTypeahead({ className, autoFocus, onDismiss }: Pro
         </div>
       )}
 
-      {needsSignIn && (
-        <div
-          className="absolute left-0 right-0 top-full mt-2 bg-surface border border-border rounded-xl shadow-md z-50 p-4"
-          role="dialog"
-          aria-label="Sign in required"
-        >
-          <p className="text-sm text-ink mb-2">
-            <span className="text-muted">{needsSignIn.composer_name} · </span>
-            <span className="text-ink">{needsSignIn.title}</span>
-          </p>
-          <p className="text-xs text-muted mb-3">
-            Sign in to open this piece so you can contribute or request a contribution.
-          </p>
-          <div className="flex gap-2">
-            <a
-              href={`/?sign_in=1`}
-              className="inline-flex items-center px-3 py-1.5 bg-ink text-surface rounded-md text-xs font-medium no-underline"
-            >
-              Sign in
-            </a>
-            <button
-              type="button"
-              onClick={() => setNeedsSignIn(null)}
-              className="inline-flex items-center px-3 py-1.5 text-muted hover:text-ink border border-border-strong rounded-md text-xs bg-transparent cursor-pointer"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+      {signInOpen && (
+        <SignInPanel
+          onClose={() => { setPendingSeed(null); signInOnClose(); }}
+          onSignedIn={signInOnSignedIn}
+          title="Sign in to open this piece"
+          body={
+            pendingSeed ? (
+              <>
+                Opening <span style={{ fontWeight: 500 }}>{pendingSeed.composer_name} · {pendingSeed.title}</span> for contribution is a signed action. Sign in or create an account to continue.
+              </>
+            ) : (
+              <>Opening a seed piece for contribution is a signed action. Sign in or create an account to continue.</>
+            )
+          }
+        />
       )}
     </div>
   );

--- a/src/components/SignInPanel.tsx
+++ b/src/components/SignInPanel.tsx
@@ -20,12 +20,26 @@ type Status =
   | { kind: 'info'; message: string };
 
 interface Props {
+  /** Fired when the user dismisses the modal without signing in
+   *  (backdrop / X / Escape). */
   onClose: () => void;
+  /** Fired after a successful password sign-in or same-session signup.
+   *  Defaults to onClose for legacy callers. Callers that resume a pending
+   *  action after sign-in (see useRequireAuth) pass a distinct handler here
+   *  so cancellation can't fire the resumed action. */
+  onSignedIn?: () => void;
+  /** URL Google OAuth redirects to after successful auth. Defaults to the
+   *  current page. Callers with a navigation-style intent (e.g. "go to
+   *  ?expand=1 after sign-in") pass that URL here so OAuth round-trip
+   *  completes the action; in-memory pending closures don't survive the
+   *  redirect. */
+  redirectTo?: string;
   title?: string;
   body?: ReactNode;
 }
 
-export default function SignInPanel({ onClose, title = 'Sign in', body }: Props) {
+export default function SignInPanel({ onClose, onSignedIn, redirectTo, title = 'Sign in', body }: Props) {
+  const onSuccess = onSignedIn ?? onClose;
   const [mode, setMode] = useState<Mode>('choose');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -46,12 +60,13 @@ export default function SignInPanel({ onClose, title = 'Sign in', body }: Props)
   const signInWithGoogle = useCallback(async () => {
     if (!hasSupabase) return;
     setStatus({ kind: 'busy' });
+    const target = redirectTo ?? window.location.href;
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: { redirectTo: window.location.href },
+      options: { redirectTo: target },
     });
     if (error) setStatus({ kind: 'error', message: prettyAuthError(error.message) });
-  }, []);
+  }, [redirectTo]);
 
   const submitSignIn = useCallback(async (e: FormEvent) => {
     e.preventDefault();
@@ -70,8 +85,8 @@ export default function SignInPanel({ onClose, title = 'Sign in', body }: Props)
       setStatus({ kind: 'error', message: prettyAuthError(error.message) });
       return;
     }
-    onClose();
-  }, [email, password, onClose]);
+    onSuccess();
+  }, [email, password, onSuccess]);
 
   const resendConfirmation = useCallback(async (addr: string) => {
     if (!hasSupabase) return;
@@ -106,11 +121,11 @@ export default function SignInPanel({ onClose, title = 'Sign in', body }: Props)
       return;
     }
     if (data.session) {
-      onClose();
+      onSuccess();
       return;
     }
     window.location.href = `/auth/check-inbox?email=${encodeURIComponent(trimmed)}`;
-  }, [email, password, onClose]);
+  }, [email, password, onSuccess]);
 
   const submitForgot = useCallback(async (e: FormEvent) => {
     e.preventDefault();

--- a/src/components/SignedPieceDescription.tsx
+++ b/src/components/SignedPieceDescription.tsx
@@ -16,6 +16,7 @@ import OwnerEditDelete from './OwnerEditDelete';
 import PendingDraftCard from './PendingDraftCard';
 import SignInPanel from './SignInPanel';
 import ComposeDraftBlock from './ComposeDraftBlock';
+import { useRequireAuth } from '../lib/useRequireAuth';
 
 interface Props {
   pieceId: string;
@@ -52,7 +53,12 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
   const [toast, setToast] = useState<string | null>(null);
   const [pendingDrafts, setPendingDrafts] = useState<PendingDraft[]>([]);
   const [stackIdx, setStackIdx] = useState(0);
-  const [signInOpen, setSignInOpen] = useState(false);
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
 
   const stackItems: StackItem[] = [
     ...descriptions.map((desc) => ({ kind: 'user' as const, desc })),
@@ -306,8 +312,7 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
           type="button"
           onClick={() => {
             setError(null);
-            if (!user) { setSignInOpen(true); return; }
-            setMode('write');
+            gate(() => setMode('write'));
           }}
           className="write-entry"
         >
@@ -331,7 +336,8 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to write"
           body={
             <>Signed descriptions are authored — any registered user can publish their take on a piece. Sign in or create an account to post yours.</>

--- a/src/components/SignedPieceDifficulty.tsx
+++ b/src/components/SignedPieceDifficulty.tsx
@@ -13,6 +13,7 @@ import type { PieceDifficultyAxes, DifficultyAxis } from '../data/difficulty-axe
 import VoteThumbs from './VoteThumbs';
 import OwnerEditDelete from './OwnerEditDelete';
 import SignInPanel from './SignInPanel';
+import { useRequireAuth } from '../lib/useRequireAuth';
 
 type AxisKey = 'technical' | 'stamina' | 'interpretive' | 'ensemble';
 
@@ -99,7 +100,12 @@ export default function SignedPieceDifficulty({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [stackIdx, setStackIdx] = useState(0);
-  const [signInOpen, setSignInOpen] = useState(false);
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
 
   const stackItems: StackItem[] = [
     ...ratings.map((rating) => ({ kind: 'user' as const, rating })),
@@ -246,7 +252,8 @@ export default function SignedPieceDifficulty({
         {renderWriteEntry()}
         {signInOpen && (
           <SignInPanel
-            onClose={() => setSignInOpen(false)}
+            onClose={signInOnClose}
+            onSignedIn={signInOnSignedIn}
             title="Sign in to rate"
             body={<>Signed ratings are authored — any registered user can publish their own four-axis difficulty. Sign in or create an account to post yours.</>}
           />
@@ -446,11 +453,7 @@ export default function SignedPieceDifficulty({
         type="button"
         onClick={() => {
           setError(null);
-          if (!user) {
-            setSignInOpen(true);
-            return;
-          }
-          setMode('write');
+          gate(() => setMode('write'));
         }}
         className="write-entry-diff"
       >

--- a/src/components/StartContributionButton.test.tsx
+++ b/src/components/StartContributionButton.test.tsx
@@ -1,0 +1,36 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!globalThis.document) GlobalRegistrator.register();
+import { afterEach, describe, test, expect } from 'bun:test';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import StartContributionButton from './StartContributionButton';
+
+// Regression pin for the sign-in modal drift bug: anon click on the CTA used
+// to navigate to /?sign_in=1 (typo'd param). The home page's AuthButton
+// listens for ?signin=1, so the modal never opened and the user landed on
+// the main page with no dialog. Fix routed the click to open SignInPanel
+// inline on the current page. This test asserts that contract.
+describe('StartContributionButton (anon)', () => {
+  afterEach(() => cleanup());
+
+  test('click opens the SignInPanel modal inline (no navigation)', async () => {
+    const { container, getByText } = render(
+      <StartContributionButton pieceId="test-piece" />,
+    );
+
+    // Wait for useAuth to finish resolving (loading=false, user=null).
+    await waitFor(() => {
+      expect(getByText('Start the first contribution')).toBeTruthy();
+    });
+
+    // No modal before click.
+    expect(container.querySelector('.ip-signin-modal')).toBeNull();
+
+    fireEvent.click(getByText('Start the first contribution'));
+
+    // Modal is now rendered inline on this component.
+    const modal = container.querySelector('.ip-signin-modal');
+    expect(modal).not.toBeNull();
+    const title = container.querySelector('.ip-signin-title');
+    expect(title?.textContent).toContain('Sign in');
+  });
+});

--- a/src/components/StartContributionButton.tsx
+++ b/src/components/StartContributionButton.tsx
@@ -4,36 +4,48 @@
 //   performer's notes, schools, landmarks, etc.). The pre-piece page
 //   stays deliberately read-only until this click so no one nudges
 //   into writing accidentally.
-// - Signed-out: routes to /?sign_in=1 first; after auth they return
-//   to the piece page and can click the CTA again.
+// - Signed-out: opens the SignInPanel inline on the current piece page
+//   (no home-page detour). After successful sign-in the pending action
+//   auto-resumes via useRequireAuth, so the user doesn't click twice.
 
-import { useAuth } from '../lib/useAuth';
+import { useRequireAuth } from '../lib/useRequireAuth';
+import SignInPanel from './SignInPanel';
 
 interface Props {
   pieceId: string;
 }
 
 export default function StartContributionButton({ pieceId }: Props) {
-  const { user, loading } = useAuth();
+  const { signInOpen, onClose, onSignedIn, redirectTo, gate } = useRequireAuth();
+
+  // Same URL + ?expand=1 — forces [id].astro down the PiecePageLayout
+  // branch even when has_signed_content is still false.
+  const expandUrl = `/piece/${pieceId}?expand=1`;
 
   function handleClick() {
-    if (loading) return;
-    if (!user) {
-      window.location.href = '/?sign_in=1';
-      return;
-    }
-    // Same URL + ?expand=1 — forces [id].astro down the PiecePageLayout
-    // branch even when has_signed_content is still false.
-    window.location.href = `/piece/${pieceId}?expand=1`;
+    gate(() => { window.location.href = expandUrl; }, { resumeUrl: expandUrl });
   }
 
   return (
-    <button
-      type="button"
-      className="pp-cta-primary"
-      onClick={handleClick}
-    >
-      Start the first contribution
-    </button>
+    <>
+      <button
+        type="button"
+        className="pp-cta-primary"
+        onClick={handleClick}
+      >
+        Start the first contribution
+      </button>
+      {signInOpen && (
+        <SignInPanel
+          onClose={onClose}
+          onSignedIn={onSignedIn}
+          redirectTo={redirectTo}
+          title="Sign in to contribute"
+          body={
+            <>Any registered user can start a contribution. Sign in or create an account to open this piece for writing.</>
+          }
+        />
+      )}
+    </>
   );
 }

--- a/src/components/StructuralLandmarks.tsx
+++ b/src/components/StructuralLandmarks.tsx
@@ -22,6 +22,7 @@ import VoteThumbs from './VoteThumbs';
 import OwnerEditDelete from './OwnerEditDelete';
 import PendingDraftCard from './PendingDraftCard';
 import SignInPanel from './SignInPanel';
+import { useRequireAuth } from '../lib/useRequireAuth';
 
 interface Props {
   pieceId: string;
@@ -101,7 +102,12 @@ export default function StructuralLandmarks({ pieceId, movementId, initialLandma
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [pendingDrafts, setPendingDrafts] = useState<PendingDraft[]>([]);
-  const [signInOpen, setSignInOpen] = useState(false);
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
 
   useEffect(() => {
     if (!hasSupabase) { setAuthed(false); setViewerId(null); return; }
@@ -147,8 +153,7 @@ export default function StructuralLandmarks({ pieceId, movementId, initialLandma
   }, [toast]);
 
   const onAddClick = () => {
-    if (authed === false) { setSignInOpen(true); return; }
-    setFormOpen(true);
+    gate(() => setFormOpen(true));
   };
 
   async function handleRemove(landmarkId: string) {
@@ -269,7 +274,8 @@ export default function StructuralLandmarks({ pieceId, movementId, initialLandma
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to add"
           body={<>Landmarks are signed — any registered user can add one. Sign in or create an account to post yours.</>}
         />

--- a/src/components/VoteThumbs.tsx
+++ b/src/components/VoteThumbs.tsx
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
 import { useAuth } from '../lib/useAuth';
+import { useRequireAuth } from '../lib/useRequireAuth';
 import SignInPanel from './SignInPanel';
 
 export type VoteSubjectTable =
@@ -37,9 +38,14 @@ type Vote = -1 | 0 | 1;
 
 export default function VoteThumbs({ subjectTable, subjectId }: Props) {
   const { user, loading: authLoading } = useAuth();
+  const {
+    signInOpen,
+    onClose: signInOnClose,
+    onSignedIn: signInOnSignedIn,
+    gate,
+  } = useRequireAuth();
   const [vote, setVote] = useState<Vote>(0);
   const [error, setError] = useState<string | null>(null);
-  const [signInOpen, setSignInOpen] = useState(false);
   const [pending, setPending] = useState(false);
   // Bumps every time the user transitions INTO an upvote (not clear, not down).
   // The upvote button reads this to trigger a one-shot celebration animation
@@ -67,12 +73,8 @@ export default function VoteThumbs({ subjectTable, subjectId }: Props) {
     };
   }, [user, authLoading, subjectTable, subjectId]);
 
-  const cast = useCallback(
+  const doCast = useCallback(
     async (desired: 1 | -1) => {
-      if (!user) {
-        setSignInOpen(true);
-        return;
-      }
       if (pending) return;
       const prev = vote;
       // Clicking the already-filled thumb clears the vote; otherwise sets.
@@ -104,7 +106,12 @@ export default function VoteThumbs({ subjectTable, subjectId }: Props) {
         setError(pretty);
       }
     },
-    [user, vote, pending, subjectTable, subjectId],
+    [vote, pending, subjectTable, subjectId],
+  );
+
+  const cast = useCallback(
+    (desired: 1 | -1) => gate(() => { void doCast(desired); }),
+    [gate, doCast],
   );
 
   const ariaUp = user
@@ -173,7 +180,8 @@ export default function VoteThumbs({ subjectTable, subjectId }: Props) {
 
       {signInOpen && (
         <SignInPanel
-          onClose={() => setSignInOpen(false)}
+          onClose={signInOnClose}
+          onSignedIn={signInOnSignedIn}
           title="Sign in to vote"
           body={
             <>

--- a/src/lib/privateRoute.ts
+++ b/src/lib/privateRoute.ts
@@ -13,8 +13,15 @@
 //
 // Called from inside a useEffect on each private-page island after the
 // auth check resolves. SSR-safe (no-op if window is undefined).
+
+/** Query param that makes the home-page AuthButton auto-open the SignInPanel.
+ *  Single source of truth — any producer sending anon users to the modal must
+ *  use this constant (and AuthButton reads it) so the two sides can't drift. */
+export const SIGN_IN_PARAM = 'signin';
+export const SIGN_IN_TRIGGER_URL = `/?${SIGN_IN_PARAM}=1`;
+
 export function redirectFromPrivateRoute(isSignedIn: boolean): void {
   if (typeof window === 'undefined') return;
-  const target = isSignedIn ? '/' : '/?signin=1';
+  const target = isSignedIn ? '/' : SIGN_IN_TRIGGER_URL;
   window.location.replace(target);
 }

--- a/src/lib/useRequireAuth.ts
+++ b/src/lib/useRequireAuth.ts
@@ -1,0 +1,113 @@
+// Shared "click → maybe sign in → resume" gate.
+//
+// Every anon-facing contributor affordance uses the same motion: the user
+// clicks something (vote, write, add, edit, swap), we check auth, if anon
+// we pop the SignInPanel. Before this hook, that's where the flow stalled —
+// after sign-in the modal closed but the original intent was lost, so the
+// user had to click again.
+//
+// gate(action) stashes the action in a ref and opens the modal. On
+// cancellation (close prop) the pending action is cleared. On successful
+// password sign-in (onSignedIn prop) the pending action runs and the modal
+// closes. The success/cancel split prevents an old stashed action from
+// firing later if the user dismissed the modal and signed in elsewhere.
+//
+// Consumers render their own SignInPanel so they can set title/body per
+// surface; this hook only owns state and wires the callbacks.
+//
+// --- OAuth resume (optional) ----------------------------------------------
+// Google OAuth redirects off-page, so an in-memory closure can't survive
+// the round-trip. For intents that ARE serializable as a URL (e.g. "go
+// to /piece/X?expand=1 after sign-in"), pass `resumeUrl` in gate's
+// options: it's routed to SignInPanel's `redirectTo` prop and Google
+// redirects the user straight there post-auth. Intents that mutate local
+// state (setMode('write'), optimistic vote, open inline editor) do NOT
+// survive OAuth because the page reloads and React state is wiped — the
+// user has to click the affordance again. That's an inherent limit of
+// OAuth redirect flow, not a bug in this hook. Password sign-in resumes
+// every kind of intent because no reload happens.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from './useAuth';
+
+export interface GateOptions {
+  /** Target URL passed to OAuth redirectTo. Use when the pending action
+   *  is a navigation (e.g. "load /piece/X?expand=1") so OAuth round-trip
+   *  lands directly on the completed state. Defaults to the current URL. */
+  resumeUrl?: string;
+}
+
+export interface RequireAuth {
+  user: ReturnType<typeof useAuth>['user'];
+  loading: boolean;
+  /** True while the SignInPanel should be rendered. */
+  signInOpen: boolean;
+  /** Pass as `onClose` on SignInPanel. */
+  onClose: () => void;
+  /** Pass as `onSignedIn` on SignInPanel. */
+  onSignedIn: () => void;
+  /** Pass as `redirectTo` on SignInPanel. Populated from the latest
+   *  gate() call's resumeUrl (or undefined to default to current URL). */
+  redirectTo: string | undefined;
+  /** Run `action` if signed in, otherwise open the SignInPanel and run
+   *  `action` after successful password sign-in. `options.resumeUrl`
+   *  additionally covers OAuth round-trip for navigation intents. No-op
+   *  while auth is loading. */
+  gate: (action: () => void, options?: GateOptions) => void;
+}
+
+export function useRequireAuth(): RequireAuth {
+  const { user, loading } = useAuth();
+  const [signInOpen, setSignInOpen] = useState(false);
+  const [redirectTo, setRedirectTo] = useState<string | undefined>(undefined);
+  const pendingRef = useRef<(() => void) | null>(null);
+
+  // Belt-and-braces: if the user was already signed in while a pending
+  // action was stashed (edge cases like auth resolving between click and
+  // render), run it on the next auth tick.
+  useEffect(() => {
+    if (user && pendingRef.current) {
+      const action = pendingRef.current;
+      pendingRef.current = null;
+      setSignInOpen(false);
+      action();
+    }
+  }, [user]);
+
+  const gate = useCallback(
+    (action: () => void, options?: GateOptions) => {
+      if (loading) return;
+      if (!user) {
+        pendingRef.current = action;
+        setRedirectTo(options?.resumeUrl);
+        setSignInOpen(true);
+        return;
+      }
+      action();
+    },
+    [user, loading],
+  );
+
+  const onClose = useCallback(() => {
+    // Cancellation — drop the pending action so it can't resurrect later
+    // if the user signs in through an unrelated surface.
+    pendingRef.current = null;
+    setRedirectTo(undefined);
+    setSignInOpen(false);
+  }, []);
+
+  const onSignedIn = useCallback(() => {
+    const action = pendingRef.current;
+    pendingRef.current = null;
+    setRedirectTo(undefined);
+    setSignInOpen(false);
+    // The SignInPanel calls this right after a successful auth.signInWith*
+    // call resolves. useAuth's onAuthStateChange listener may not have
+    // flipped user to non-null yet, but the action doesn't care — it runs
+    // now, and any RPC it calls will see the fresh session because supabase
+    // has already applied it.
+    if (action) action();
+  }, []);
+
+  return { user, loading, signInOpen, onClose, onSignedIn, redirectTo, gate };
+}


### PR DESCRIPTION
## Summary

Every anon-facing affordance (vote, write, add, rate, edit, swap, materialize, request contribution, start contribution) used to stall after sign-in — the modal closed but the original intent was lost, forcing a second click. This branch:

- Extracts a shared [`useRequireAuth`](src/lib/useRequireAuth.ts) hook. `gate(action, { resumeUrl? })` stashes the action, opens `SignInPanel`, runs the action on `onSignedIn`, drops it on `onClose`. Password sign-in resumes every kind of intent with zero extra clicks; OAuth round-trip resumes navigation intents via `resumeUrl` → `redirectTo`.
- Migrates **14 consumers**: StartContributionButton (OAuth-resume-enabled), RequestContributionDialog, SearchTypeahead, VoteThumbs, PerformersNotes, SignedPieceDescription, InterpretiveSchools, SignedPieceDifficulty, StructuralLandmarks, EditionsList, ExternalRefsList, RecordingsList, MovementsList, PedagogicalArcList, MovementEdit.
- Fixes the original bug: three producers navigated anon users to `/?sign_in=1` (underscore) while `AuthButton` listened for `/?signin=1` — modal never opened, user landed on the home page. Canonical constant now exported from `privateRoute.ts`.
- Adds `SignInPanel.onSignedIn` + `redirectTo` props so the gate can distinguish cancel vs success (prevents stashed action from firing later if user dismissed then signed in elsewhere) and thread OAuth destination through.
- Ships `scripts/check-auth-gate.sh` (wired as `bun run check:auth-gate`). Grep-bans `setSignInOpen(true)` and `/?signin=1`-style redirects outside sanctioned files so a future consumer can't ad-hoc the pattern and reintroduce the bug.
- Adds regression tests for StartContributionButton + RequestContributionDialog that pin the anon-click → inline-modal contract.

## Why

Original report: "in certain view size, clicking on something that should bring up signin dialog shows nothing. it just takes the user to the main page." Root cause was a `sign_in=1` vs `signin=1` param typo in three sibling producers — but the deeper issue was that the sign-in gate was an implicit string-literal contract, repeated across 14 surfaces with subtle drift in every one. Even after fixing the typo, the reporter flagged "now I have to click again" — which revealed that *every* anon affordance had the same post-sign-in-intent-loss bug.

This PR fixes both: the immediate bug, and the absence of a shared contract that let the bug exist.

## OAuth limitations (documented in the hook header)

Google OAuth redirects off-page, wiping in-memory React state. For navigation intents (StartContributionButton's "go to `?expand=1`"), `resumeUrl` covers it. For state-mutation intents (vote up this note, open inline editor, mark a row for deletion), React state is gone after the reload — the user must click again post-OAuth. That's inherent to OAuth redirect flow, not a hook bug. Password sign-in resumes every intent regardless.

## Test plan

- [x] `bun run check:auth-gate` — exit 0
- [x] `bun test src/components src/lib` — 87 pass, 0 fail
- [x] Manual browser verification: anon click on "Start the first contribution" on `/piece/crumb-sonata-solo-cello` → `SignInPanel` opens inline, URL unchanged
- [x] OAuth `redirectTo` capture: verified Google button would redirect to `/piece/crumb-sonata-solo-cello?expand=1` (the resume URL)
- [ ] Reviewer: password sign-in end-to-end (local supabase required)
- [ ] Reviewer: OAuth end-to-end on StartContributionButton (local or staging)
- [ ] Reviewer: confirm 13 non-navigation surfaces still work (one click → modal → sign in → action runs)

## Scope notes

- Does **not** touch your in-progress unrelated edits (digest cron Mon→Sun, supabase functions, EmailPreferences copy) — those stay in your working tree on this branch for you to handle separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)