### PR TITLE
fix(qa): disable difficulty Publish on all-n/a draft

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -52,6 +52,18 @@ Tracked work for Irregular Pearl, organized by component and sorted by priority.
 
 ## Cleanup
 
+### `/settings` direct URL returns 404
+
+**What:** Navigating to `http://.../settings` returns 404. The canonical URL for the settings tab is `/profile/<uuid>?section=setting`, and the user-menu "Settings" link points there correctly. But a user who types `/settings` in the address bar or a bookmark that guessed the path lands on "Page Not Found".
+
+**Why:** Low-severity UX paper cut. The tab link works; only direct-URL users hit this. Easy fix: add a permanent redirect from `/settings` → `/profile/<current-user-uuid>?section=setting` (or a server-rendered 302 that resolves the current user).
+
+**Context:** Found by `/qa` on 2026-04-24. Report: `.gstack/qa-reports/qa-report-localhost-2026-04-24-signed.md` (ISSUE-002).
+
+**Effort:** S
+**Priority:** P3
+**Depends on:** None
+
 ### Fix `AddPieceForm` for `canonical_index_id` requirement
 
 **What:** [AddPieceForm.tsx](src/components/AddPieceForm.tsx) inserts into `pieces` without `canonical_index_id`, but migration `20260522000000` made the column NOT NULL. The v0.5.1 type-cleanup pass cast the insert payload `as any` with a TODO comment so `tsc --noEmit` passes, but the form would still fail at runtime on the FK constraint.

--- a/src/components/SignedPieceDifficulty.regression-001.test.ts
+++ b/src/components/SignedPieceDifficulty.regression-001.test.ts
@@ -1,0 +1,53 @@
+// Regression: ISSUE-001 — difficulty Publish was enabled with all axes at n/a
+// Found by /qa on 2026-04-24
+// Report: .gstack/qa-reports/qa-report-localhost-2026-04-24-signed.md
+
+import { describe, test, expect } from 'bun:test';
+import { hasRatedAxis, type Draft } from './SignedPieceDifficulty';
+
+const allNa: Draft = {
+  technical: { level: 0, note: '' },
+  stamina: { level: 0, note: '' },
+  interpretive: { level: 0, note: '' },
+  ensemble: { level: 0, note: '' },
+};
+
+describe('SignedPieceDifficulty / hasRatedAxis', () => {
+  test('returns false when every axis is 0 (all n/a)', () => {
+    expect(hasRatedAxis(allNa)).toBe(false);
+  });
+
+  test('returns false when every axis is 0 even if notes are filled', () => {
+    const notesOnly: Draft = {
+      technical: { level: 0, note: 'demanding bow control' },
+      stamina: { level: 0, note: 'long' },
+      interpretive: { level: 0, note: 'free' },
+      ensemble: { level: 0, note: '' },
+    };
+    expect(hasRatedAxis(notesOnly)).toBe(false);
+  });
+
+  test('returns true when technical is set', () => {
+    expect(hasRatedAxis({ ...allNa, technical: { level: 3, note: '' } })).toBe(true);
+  });
+
+  test('returns true when stamina is set', () => {
+    expect(hasRatedAxis({ ...allNa, stamina: { level: 1, note: '' } })).toBe(true);
+  });
+
+  test('returns true when interpretive is set', () => {
+    expect(hasRatedAxis({ ...allNa, interpretive: { level: 5, note: '' } })).toBe(true);
+  });
+
+  test('returns true when ensemble is set', () => {
+    expect(hasRatedAxis({ ...allNa, ensemble: { level: 2, note: '' } })).toBe(true);
+  });
+
+  test('returns true at boundary level 1', () => {
+    expect(hasRatedAxis({ ...allNa, technical: { level: 1, note: '' } })).toBe(true);
+  });
+
+  test('returns true at boundary level 5', () => {
+    expect(hasRatedAxis({ ...allNa, ensemble: { level: 5, note: '' } })).toBe(true);
+  });
+});

--- a/src/components/SignedPieceDifficulty.tsx
+++ b/src/components/SignedPieceDifficulty.tsx
@@ -67,7 +67,7 @@ interface AxisDraft {
   note: string;
 }
 
-type Draft = Record<AxisKey, AxisDraft>;
+export type Draft = Record<AxisKey, AxisDraft>;
 
 function emptyDraft(): Draft {
   return {
@@ -76,6 +76,10 @@ function emptyDraft(): Draft {
     interpretive: { level: 0, note: '' },
     ensemble: { level: 0, note: '' },
   };
+}
+
+export function hasRatedAxis(draft: Draft): boolean {
+  return AXIS_ORDER.some(({ key }) => draft[key].level > 0);
 }
 
 function draftFromRating(r: PublishedPieceDifficulty): Draft {
@@ -501,7 +505,7 @@ function DifficultyEditForm(props: {
   const setAxis = (key: AxisKey, patch: Partial<AxisDraft>) =>
     setDraft((d) => ({ ...d, [key]: { ...d[key], ...patch } }));
 
-  const canSubmit = AXIS_ORDER.some(({ key }) => draft[key].level > 0);
+  const canSubmit = hasRatedAxis(draft);
 
   return (
     <div>

--- a/src/components/SignedPieceDifficulty.tsx
+++ b/src/components/SignedPieceDifficulty.tsx
@@ -501,6 +501,8 @@ function DifficultyEditForm(props: {
   const setAxis = (key: AxisKey, patch: Partial<AxisDraft>) =>
     setDraft((d) => ({ ...d, [key]: { ...d[key], ...patch } }));
 
+  const canSubmit = AXIS_ORDER.some(({ key }) => draft[key].level > 0);
+
   return (
     <div>
       <div className="diff-edit-grid">
@@ -551,7 +553,7 @@ function DifficultyEditForm(props: {
         <button
           type="button"
           onClick={() => props.onSubmit(draft)}
-          disabled={props.submitting}
+          disabled={props.submitting || !canSubmit}
           className="diff-edit-primary"
         >
           {props.submitting ? submittingLabel : submitLabel}


### PR DESCRIPTION
## Summary

- **Fix:** `SignedPieceDifficulty`'s Publish button was enabled when every axis was at level 0 (n/a, the default from `emptyDraft()`). A signed-in user could submit a rating row with zero information on all four axes. Added `hasRatedAxis(draft)` helper, gated `disabled={submitting || !canSubmit}` on the button. Guard applies to both write and edit paths (both reuse `DifficultyEditForm`).
- **Test:** `SignedPieceDifficulty.regression-001.test.ts` — 8 cases covering every axis at levels 1 and 5, notes-only drafts (still blocked), all-n/a default. 132/132 in the full suite pass.
- **Deferred:** `/settings` direct URL 404s instead of redirecting to `/profile/<uuid>?section=setting`. Low severity; tracked in `TODOS.md` under Cleanup (P3).

## Why

Found by `/qa` signed-in run as user `haji` on 2026-04-24. The stack sorts user ratings ahead of the seed on `vote_tallies.net_score`, so an all-zero ratings row would land at the top of the stack with no meaningful difficulty signal. The fix is a three-line guard. Full report: `.gstack/qa-reports/qa-report-localhost-2026-04-24-signed.md`.

## Test plan

- [x] `bun test src/components/SignedPieceDifficulty.regression-001.test.ts` → 8 pass
- [x] Full suite `bun test src/lib src/data src/components src/tests` → 132 pass
- [x] Manual: open difficulty form signed-in, confirm Publish stays disabled on all n/a, enables when any axis > 0, disables again when axis returns to n/a. No console errors.
- [ ] Reviewer: eyeball the guard in SignedPieceDifficulty.tsx:501-556 and confirm the helper extraction looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)