### PR TITLE
feat(email): preview override + noreply@ sender for digests

### DIFF
--- a/supabase/functions/send-notification-digest/index.ts
+++ b/supabase/functions/send-notification-digest/index.ts
@@ -49,11 +49,116 @@ const SUBJECT_TABLES = [
   'piece_descriptions',
 ] as const;
 
-async function fetchAndSendDigests(): Promise<{ sent: number; skipped: number; errors: string[] }> {
+async function fetchAndSendDigests(previewTo?: string, previewName?: string): Promise<{ sent: number; skipped: number; errors: string[] }> {
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const errors: string[] = [];
   let sent = 0;
   let skipped = 0;
+
+  // Preview mode: pull the most recent notifications (regardless of cleared /
+  // digest-sent state) so the preview always has content, render ONE digest
+  // grouping them, send only to previewTo, and skip the last_digest_sent_at
+  // stamp so prod state is untouched.
+  if (previewTo) {
+    const { data: sampleRows } = await supabase
+      .from("notifications")
+      .select("id, recipient_id, subject_table, subject_id, body, link_path, created_at")
+      .order("created_at", { ascending: false })
+      .limit(3);
+
+    // If prod has no notifications (early-stage catalog), synthesize preview
+    // items against real pieces so the review still shows the shipping layout.
+    let effectiveRows: NotificationRow[];
+    let syntheticPieceById = new Map<string, PieceRef>();
+    if (!sampleRows || sampleRows.length === 0) {
+      const { data: somePieces } = await supabase
+        .from("pieces")
+        .select("id, title, catalog_number, composer_name")
+        .order("created_at", { ascending: false })
+        .limit(2);
+      if (!somePieces || somePieces.length === 0) {
+        return { sent: 0, skipped: 0, errors: ["No notifications and no pieces in prod — nothing to preview against"] };
+      }
+      const synthetic: NotificationRow[] = [];
+      for (const p of somePieces as PieceRef[]) {
+        syntheticPieceById.set(p.id, p);
+        synthetic.push({
+          id: `preview-${p.id}`,
+          recipient_id: "preview",
+          subject_table: "__preview__",
+          subject_id: p.id,
+          body: "Sample draft body: a contributor submitted a performer's note for this piece. Approve, request a revision, or let it sit for another reviewer.",
+          link_path: `/piece/${p.id}#performers-notes`,
+          created_at: new Date().toISOString(),
+        });
+      }
+      effectiveRows = synthetic;
+    } else {
+      effectiveRows = sampleRows as NotificationRow[];
+    }
+
+    // Enrich subject → piece for pretty rendering.
+    const sampleSubjectToPiece = new Map<string, string>();
+    const samplePieceIds = new Set<string>();
+    const sampleIdsByTable = new Map<string, Set<string>>();
+    for (const n of effectiveRows) {
+      if (!(SUBJECT_TABLES as readonly string[]).includes(n.subject_table)) continue;
+      const set = sampleIdsByTable.get(n.subject_table) ?? new Set<string>();
+      set.add(n.subject_id);
+      sampleIdsByTable.set(n.subject_table, set);
+    }
+    for (const [table, ids] of sampleIdsByTable) {
+      const { data: subjects } = await supabase.from(table).select("id, piece_id").in("id", [...ids]);
+      for (const row of (subjects ?? []) as Array<{ id: string; piece_id: string }>) {
+        sampleSubjectToPiece.set(`${table}:${row.id}`, row.piece_id);
+        samplePieceIds.add(row.piece_id);
+      }
+    }
+    const { data: samplePieces } = samplePieceIds.size
+      ? await supabase.from("pieces").select("id, title, catalog_number, composer_name").in("id", [...samplePieceIds])
+      : { data: [] };
+    const samplePieceById = new Map<string, PieceRef>();
+    for (const p of (samplePieces ?? []) as PieceRef[]) samplePieceById.set(p.id, p);
+    for (const [id, p] of syntheticPieceById) samplePieceById.set(id, p);
+
+    const firstName = (previewName || "").split(" ")[0] || "there";
+    const html = renderNotificationDigest({
+      recipientId: "preview",
+      recipientName: firstName,
+      count: effectiveRows.length,
+      items: effectiveRows.map((n) => {
+        const pieceId = sampleSubjectToPiece.get(`${n.subject_table}:${n.subject_id}`)
+          ?? (syntheticPieceById.has(n.subject_id) ? n.subject_id : undefined);
+        return {
+          body: n.body,
+          linkPath: n.link_path,
+          piece: pieceId ? samplePieceById.get(pieceId) ?? null : null,
+        };
+      }),
+    });
+
+    const subject = effectiveRows.length === 1
+      ? "[PREVIEW] 1 draft awaits your review"
+      : `[PREVIEW] ${effectiveRows.length} drafts await your review`;
+
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "Irregular Pearl <noreply@irregularpearl.org>",
+        to: [previewTo],
+        subject,
+        html,
+      }),
+    });
+
+    if (res.ok) return { sent: 1, skipped: 0, errors: [] };
+    const errText = await res.text();
+    return { sent: 0, skipped: 0, errors: [`Preview send failed: ${errText}`] };
+  }
 
   // Unsent, un-cleared notifications. One email per notification, ever —
   // the bell + /notifications provide the ongoing nag.
@@ -171,7 +276,7 @@ async function fetchAndSendDigests(): Promise<{ sent: number; skipped: number; e
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          from: "Irregular Pearl <hello@irregularpearl.org>",
+          from: "Irregular Pearl <noreply@irregularpearl.org>",
           to: [authUser.email],
           subject,
           html,
@@ -254,13 +359,23 @@ function renderNotificationDigest(opts: {
   });
 }
 
-Deno.serve(async (_req) => {
+Deno.serve(async (req) => {
   if (!RESEND_API_KEY) {
     return new Response(JSON.stringify({ error: "RESEND_API_KEY not set" }), { status: 500 });
   }
 
+  let previewTo: string | undefined;
+  let previewName: string | undefined;
   try {
-    const result = await fetchAndSendDigests();
+    const body = await req.json();
+    previewTo = body?.preview_to;
+    previewName = body?.preview_name;
+  } catch {
+    // Cron invocation has no body; that's fine.
+  }
+
+  try {
+    const result = await fetchAndSendDigests(previewTo, previewName);
     console.log(
       `Notification digest complete: ${result.sent} sent, ${result.skipped} skipped, ${result.errors.length} errors`,
     );

--- a/supabase/functions/send-weekly-digest/index.ts
+++ b/supabase/functions/send-weekly-digest/index.ts
@@ -98,7 +98,7 @@ function renderWeeklyDigest(opts: {
   });
 }
 
-async function fetchAndSendDigests(): Promise<{ sent: number; skipped: number; errors: string[] }> {
+async function fetchAndSendDigests(previewTo?: string, previewName?: string): Promise<{ sent: number; skipped: number; errors: string[] }> {
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const errors: string[] = [];
   let sent = 0;
@@ -130,6 +130,39 @@ async function fetchAndSendDigests(): Promise<{ sent: number; skipped: number; e
   }
   summaryParts.push(`The catalog now holds ${totalPieces ?? 0} pieces.`);
   const summary = summaryParts.join(" ");
+
+  // Preview mode: render one digest with real prod data and send only to
+  // previewTo. Skips the recipient DB loop and all per-user personalization
+  // beyond the greeting, since a single template render is sufficient for
+  // visual review.
+  if (previewTo) {
+    const firstName = (previewName || "").split(" ")[0] || "there";
+    const html = renderWeeklyDigest({
+      recipientName: firstName,
+      weekRange,
+      summary,
+      piecesHtml,
+      piecesCount: (newPieces || []).length,
+      totalPieces: totalPieces ?? 0,
+      unsubscribeUrl: "https://irregularpearl.org/profile/preview?section=setting#email",
+    });
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "Irregular Pearl <noreply@irregularpearl.org>",
+        to: [previewTo],
+        subject: `[PREVIEW] Your Weekly Digest — ${weekRange}`,
+        html,
+      }),
+    });
+    if (res.ok) return { sent: 1, skipped: 0, errors: [] };
+    const errText = await res.text();
+    return { sent: 0, skipped: 0, errors: [`Preview send failed: ${errText}`] };
+  }
 
   const { data: recipients } = await supabase
     .from("users")
@@ -168,7 +201,7 @@ async function fetchAndSendDigests(): Promise<{ sent: number; skipped: number; e
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          from: "Irregular Pearl <hello@irregularpearl.org>",
+          from: "Irregular Pearl <noreply@irregularpearl.org>",
           to: [authUser.email],
           subject: `Your Weekly Digest — ${weekRange}`,
           html,
@@ -190,13 +223,23 @@ async function fetchAndSendDigests(): Promise<{ sent: number; skipped: number; e
   return { sent, skipped, errors };
 }
 
-Deno.serve(async (_req) => {
+Deno.serve(async (req) => {
   if (!RESEND_API_KEY) {
     return new Response(JSON.stringify({ error: "RESEND_API_KEY not set" }), { status: 500 });
   }
 
+  let previewTo: string | undefined;
+  let previewName: string | undefined;
   try {
-    const result = await fetchAndSendDigests();
+    const body = await req.json();
+    previewTo = body?.preview_to;
+    previewName = body?.preview_name;
+  } catch {
+    // Cron invocation has no body; that's fine.
+  }
+
+  try {
+    const result = await fetchAndSendDigests(previewTo, previewName);
     console.log(`Weekly digest complete: ${result.sent} sent, ${result.skipped} skipped, ${result.errors.length} errors`);
 
     return new Response(JSON.stringify(result), {

--- a/supabase/functions/send-welcome-email/index.ts
+++ b/supabase/functions/send-welcome-email/index.ts
@@ -57,14 +57,40 @@ function renderWelcomeEmail(recipientName: string): string {
 Deno.serve(async (req) => {
   const body = await req.json();
 
-  const record = body.record;
-  if (!record || !record.id) {
-    return new Response(JSON.stringify({ error: "No user record" }), { status: 400 });
-  }
-
   if (!RESEND_API_KEY) {
     console.error("RESEND_API_KEY not set");
     return new Response(JSON.stringify({ error: "No API key" }), { status: 500 });
+  }
+
+  // Preview mode: skip DB lookup entirely and send one copy to preview_to.
+  // Used for reviewing the template against real prod rendering without
+  // tripping the per-INSERT webhook path.
+  if (body.preview_to) {
+    const firstName = (body.preview_name || "").split(" ")[0] || "there";
+    const html = renderWelcomeEmail(firstName);
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "Irregular Pearl <hello@irregularpearl.org>",
+        to: [body.preview_to],
+        subject: "Welcome to Irregular Pearl (preview)",
+        html,
+      }),
+    });
+    const result = await res.json();
+    if (!res.ok) {
+      return new Response(JSON.stringify({ error: result }), { status: 500 });
+    }
+    return new Response(JSON.stringify({ success: true, preview: true, id: result.id }), { status: 200 });
+  }
+
+  const record = body.record;
+  if (!record || !record.id) {
+    return new Response(JSON.stringify({ error: "No user record" }), { status: 400 });
   }
 
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);


### PR DESCRIPTION
## Summary
- Adds `preview_to` / `preview_name` body params to `send-welcome-email`, `send-weekly-digest`, and `send-notification-digest`. When present, the function renders one email against real prod data and delivers only to the preview address — skipping the recipient DB loop and the `last_digest_sent_at` stamp so prod state stays untouched. Enables visual review of shipping templates without waiting for cron or spraying users.
- Notification digest falls back to synthesized items against real pieces when the `notifications` table is empty, so the preview still exercises the shipping layout on a fresh catalog.
- Switches the weekly + notification digest sender from `hello@` to `noreply@irregularpearl.org`. Welcome email unchanged.

> Note: these functions were already deployed to prod during review. This PR catches `main` up to what's running.

## Test plan
- [x] `bun test src/tests/email-template.test.ts` — 20/20 pass
- [x] Invoked all three functions against prod with `preview_to=joseph.kim@irregularpearl.org` — each returned `{sent: 1}` and the mail arrived
- [x] Confirmed prod `notifications` table untouched (no `last_digest_sent_at` stamped by preview path)
- [ ] Manual: verify `From:` header shows `noreply@irregularpearl.org` on digest previews in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)