### PR TITLE
feat(notifications): bell links straight to Messages page

### DIFF
--- a/src/components/NavbarBell.test.tsx
+++ b/src/components/NavbarBell.test.tsx
@@ -1,0 +1,113 @@
+// Component-level tests for the navbar bell. The bell now renders as a
+// direct link to the Messages page (no popover). These tests pin that
+// contract so it can't silently regress back to a dialog.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!globalThis.document) GlobalRegistrator.register();
+import { afterEach, beforeEach, describe, test, expect, mock } from 'bun:test';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+
+const BELL_LAST_VIEWED_KEY = 'ip.bell.lastViewedAt';
+
+// In-memory mock for the supabase client. Each test seeds these before
+// importing the component (via dynamic import in the test body).
+type NotifRow = { created_at: string };
+const supabaseState: {
+  session: { user: { id: string } } | null;
+  notifications: NotifRow[];
+} = {
+  session: null,
+  notifications: [],
+};
+
+const supabaseStub = {
+  auth: {
+    getSession: async () => ({ data: { session: supabaseState.session } }),
+    onAuthStateChange: () => ({ data: { subscription: { unsubscribe() {} } } }),
+  },
+  from: (_table: string) => ({
+    select: (_cols: string) => ({
+      is: (_col: string, _val: null) => ({
+        order: async (_col: string, _opts: unknown) => ({
+          data: supabaseState.notifications,
+        }),
+      }),
+    }),
+  }),
+};
+
+mock.module('../lib/supabase', () => ({
+  supabase: supabaseStub,
+  hasSupabase: true,
+}));
+
+describe('NavbarBell', () => {
+  beforeEach(() => {
+    supabaseState.session = { user: { id: 'user-1' } };
+    supabaseState.notifications = [];
+    window.localStorage.clear();
+  });
+  afterEach(() => cleanup());
+
+  test('hides for anon viewers', async () => {
+    supabaseState.session = null;
+    const { default: NavbarBell } = await import('./NavbarBell');
+    const { container } = render(<NavbarBell />);
+    // Anon: nothing rendered. Wait one tick for the async getSession() to
+    // resolve and the component to re-render with signedIn=false.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.querySelector('a[aria-label^="Notifications"]')).toBeNull();
+    expect(container.querySelector('button[aria-label^="Notifications"]')).toBeNull();
+  });
+
+  test('signed-in: renders as a link to /notifications, not a button', async () => {
+    const { default: NavbarBell } = await import('./NavbarBell');
+    const { container } = render(<NavbarBell />);
+    const link = await waitFor(() => {
+      const el = container.querySelector('a[aria-label^="Notifications"]');
+      if (!el) throw new Error('bell link not yet rendered');
+      return el as HTMLAnchorElement;
+    });
+    expect(link.tagName).toBe('A');
+    expect(link.getAttribute('href')).toBe('/notifications');
+    // No dialog/popover surface anywhere.
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(container.querySelector('button[aria-label^="Notifications"]')).toBeNull();
+  });
+
+  test('badge reflects unviewed-notification count', async () => {
+    supabaseState.notifications = [
+      { created_at: '2026-01-03T00:00:00Z' },
+      { created_at: '2026-01-02T00:00:00Z' },
+      { created_at: '2026-01-01T00:00:00Z' },
+    ];
+    const { default: NavbarBell } = await import('./NavbarBell');
+    const { container } = render(<NavbarBell />);
+    await waitFor(() => {
+      const badge = container.querySelector('a[aria-label^="Notifications"] span');
+      if (!badge) throw new Error('badge not yet rendered');
+      expect(badge.textContent).toBe('3');
+    });
+    expect(container.querySelector('a[aria-label^="Notifications"]')?.getAttribute('aria-label')).toBe(
+      'Notifications (3)',
+    );
+  });
+
+  test('clicking the bell stamps the ack watermark in localStorage', async () => {
+    supabaseState.notifications = [{ created_at: '2026-01-01T00:00:00Z' }];
+    const { default: NavbarBell } = await import('./NavbarBell');
+    const { container } = render(<NavbarBell />);
+    const link = await waitFor(() => {
+      const el = container.querySelector('a[aria-label^="Notifications"]');
+      if (!el) throw new Error('bell link not yet rendered');
+      return el as HTMLAnchorElement;
+    });
+
+    expect(window.localStorage.getItem(BELL_LAST_VIEWED_KEY)).toBeNull();
+    fireEvent.click(link);
+    const stamp = window.localStorage.getItem(BELL_LAST_VIEWED_KEY);
+    expect(stamp).toBeTruthy();
+    // Stamp is a valid ISO timestamp.
+    expect(Number.isNaN(Date.parse(stamp!))).toBe(false);
+  });
+});

--- a/src/components/NavbarBell.tsx
+++ b/src/components/NavbarBell.tsx
@@ -1,34 +1,12 @@
-// Navbar bell — un-cleared notifications count + popover list. Poll-only
-// for Slice A (no realtime subscription). Listens to a `notifications:changed`
-// window event so components that mutate notifications can trigger a
-// refresh without reaching into this component.
+// Navbar bell — un-cleared notifications count + direct link to the
+// Messages page. Poll-only for Slice A (no realtime subscription). Listens
+// to a `notifications:changed` window event so components that mutate
+// notifications can trigger a refresh without reaching into this component.
 //
 // Only renders when the viewer is signed in; invisible to anon.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { supabase, hasSupabase } from '../lib/supabase';
-import { SUBJECT_CONFIG, isSubjectTable, type SubjectTable } from '../lib/contributorSubjects';
-
-interface NotificationRow {
-  id: string;
-  body: string;
-  link_path: string;
-  subject_table: string;
-  subject_id: string;
-  created_at: string;
-}
-
-interface PieceRef {
-  id: string;
-  title: string;
-  catalog_number: string | null;
-}
-
-interface NotificationItem extends NotificationRow {
-  piece: PieceRef | null;
-  /** Present on contribution_requested rows when the sender left a note. */
-  note: string | null;
-}
 
 /** Badge-text rule per plan: hidden at 0, exact 1–9, "9+" at 10+. */
 export function bellBadgeText(count: number): string | null {
@@ -37,13 +15,12 @@ export function bellBadgeText(count: number): string | null {
   return String(count);
 }
 
-// Bell acknowledgement: clicking any notification in the popover counts
-// as "I've seen the bell for now" across all current items. Stamped in
-// localStorage so subsequent loads hide anything created before the last
-// interaction. Device-local by design — clicking on the laptop doesn't
-// clear the phone's bell, which matches the bell's semantics (it's a
-// surface for the current session, not a persistent inbox). The real
-// inbox is the Messages page.
+// Bell acknowledgement: clicking the bell counts as "I've seen the bell
+// for now" across all current items. Stamped in localStorage so subsequent
+// loads hide anything created before the last interaction. Device-local
+// by design — clicking on the laptop doesn't clear the phone's bell, which
+// matches the bell's semantics (it's a surface for the current session,
+// not a persistent inbox). The real inbox is the Messages page.
 const BELL_LAST_VIEWED_KEY = 'ip.bell.lastViewedAt';
 
 function readBellLastViewed(): string | null {
@@ -64,101 +41,22 @@ function writeBellLastViewed(iso: string) {
 
 export default function NavbarBell() {
   const [signedIn, setSignedIn] = useState<boolean | null>(null);
-  const [hasQueueAccess, setHasQueueAccess] = useState(false);
-  const [items, setItems] = useState<NotificationItem[]>([]);
+  const [createdAts, setCreatedAts] = useState<string[]>([]);
   const [lastViewedAt, setLastViewedAt] = useState<string | null>(() => readBellLastViewed());
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const refresh = useCallback(async () => {
     if (!hasSupabase) { setSignedIn(false); return; }
 
     const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { setSignedIn(false); setItems([]); setHasQueueAccess(false); return; }
+    if (!session?.user) { setSignedIn(false); setCreatedAts([]); return; }
     setSignedIn(true);
-
-    // Queue access: active signed contributors only. Non-contributors get
-    // a reduced popover (no "Open queue" footer, since the queue page just
-    // tells them they don't belong there).
-    const { data: profile } = await supabase
-      .from('users')
-      .select('is_contributor, contributor_active')
-      .eq('id', session.user.id)
-      .single();
-    const canQueue = Boolean(
-      (profile as { is_contributor?: boolean; contributor_active?: boolean } | null)?.is_contributor &&
-        (profile as { is_contributor?: boolean; contributor_active?: boolean } | null)?.contributor_active,
-    );
-    setHasQueueAccess(canQueue);
 
     const { data: notifRows } = await supabase
       .from('notifications')
-      .select('id, body, link_path, subject_table, subject_id, created_at')
+      .select('created_at')
       .is('cleared_at', null)
       .order('created_at', { ascending: false });
-    if (!notifRows || notifRows.length === 0) { setItems([]); return; }
-
-    // Batch-fetch subjects per subject_table (O(tables) round trips). Signed-
-    // content subjects have a `piece_id` column; contribution_requests has
-    // both piece_id and a `note` we want to render inline.
-    const idsByTable = new Map<SubjectTable, string[]>();
-    const contribRequestIds: string[] = [];
-    for (const n of notifRows) {
-      if (n.subject_table === 'contribution_requests') {
-        contribRequestIds.push(n.subject_id);
-        continue;
-      }
-      if (!isSubjectTable(n.subject_table)) continue;
-      const arr = idsByTable.get(n.subject_table) ?? [];
-      arr.push(n.subject_id);
-      idsByTable.set(n.subject_table, arr);
-    }
-
-    const subjectResults = await Promise.all(
-      [...idsByTable.entries()].map(([table, ids]) =>
-        supabase.from(SUBJECT_CONFIG[table].table).select('id, piece_id').in('id', ids),
-      ),
-    );
-    const pieceIdBySubjectKey = new Map<string, string>();
-    const noteByRequestId = new Map<string, string>();
-    const pieceIdSet = new Set<string>();
-    for (const [idx, [table]] of [...idsByTable.entries()].entries()) {
-      const res = subjectResults[idx];
-      for (const row of (res.data ?? []) as { id: string; piece_id: string }[]) {
-        pieceIdBySubjectKey.set(`${table}:${row.id}`, row.piece_id);
-        pieceIdSet.add(row.piece_id);
-      }
-    }
-
-    if (contribRequestIds.length > 0) {
-      const { data: crRows } = await supabase
-        .from('contribution_requests')
-        .select('id, piece_id, note')
-        .in('id', contribRequestIds);
-      for (const row of (crRows ?? []) as {
-        id: string;
-        piece_id: string;
-        note: string | null;
-      }[]) {
-        pieceIdBySubjectKey.set(`contribution_requests:${row.id}`, row.piece_id);
-        pieceIdSet.add(row.piece_id);
-        if (row.note) noteByRequestId.set(row.id, row.note);
-      }
-    }
-
-    const { data: piecesData } = pieceIdSet.size
-      ? await supabase.from('pieces').select('id, title, catalog_number').in('id', [...pieceIdSet])
-      : { data: [] };
-    const pieceById = new Map((piecesData ?? []).map((p) => [p.id, p as PieceRef]));
-
-    setItems(
-      notifRows.map((n) => {
-        const pieceId = pieceIdBySubjectKey.get(`${n.subject_table}:${n.subject_id}`);
-        const note =
-          n.subject_table === 'contribution_requests' ? noteByRequestId.get(n.subject_id) ?? null : null;
-        return { ...n, piece: pieceId ? pieceById.get(pieceId) ?? null : null, note };
-      }),
-    );
+    setCreatedAts((notifRows ?? []).map((n) => n.created_at as string));
   }, []);
 
   useEffect(() => {
@@ -182,32 +80,16 @@ export default function NavbarBell() {
     };
   }, [refresh]);
 
-  // Close popover on outside click / escape
-  useEffect(() => {
-    if (!open) return;
-    const onClick = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
-    document.addEventListener('mousedown', onClick);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onClick);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
-
   // Invisible when not signed in (loading or anon).
   if (signedIn !== true) return null;
 
-  // Filter items by the bell acknowledgement watermark: anything created
-  // before the last bell interaction is considered "seen" in the bell
-  // context and hidden from both count and list. The underlying
-  // notifications are still live on the Messages page.
-  const visibleItems = lastViewedAt
-    ? items.filter((n) => n.created_at > lastViewedAt)
-    : items;
-  const count = visibleItems.length;
+  // Filter by the bell acknowledgement watermark: anything created before
+  // the last bell interaction is considered "seen" in the bell context and
+  // hidden from the count. The underlying notifications are still live on
+  // the Messages page.
+  const count = lastViewedAt
+    ? createdAts.filter((c) => c > lastViewedAt).length
+    : createdAts.length;
   const badgeText = bellBadgeText(count);
 
   function acknowledgeBell() {
@@ -217,104 +99,25 @@ export default function NavbarBell() {
   }
 
   return (
-    <div ref={containerRef} className="relative inline-flex">
-      <button
-        type="button"
-        aria-label={badgeText ? `Notifications (${badgeText})` : 'Notifications'}
-        onClick={() => setOpen((o) => !o)}
-        className="bg-transparent border-0 p-0 text-ink hover:text-accent transition-colors cursor-pointer inline-flex items-center relative min-w-0!"
-      >
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-          <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-        </svg>
-        {badgeText && (
-          <span
-            aria-hidden="true"
-            className="absolute -top-1 -right-1.5 min-w-[16px] h-[16px] px-1 text-[10px] leading-[16px] text-center rounded-full font-medium"
-            style={{ background: 'var(--color-accent)', color: 'var(--color-bg)' }}
-          >
-            {badgeText}
-          </span>
-        )}
-      </button>
-
-      {open && (
-        <div
-          className="absolute right-0 top-full mt-2 w-[320px] max-w-[calc(100vw-32px)] rounded-xl bg-surface border-[0.5px] border-border shadow-md overflow-hidden z-50"
-          role="dialog"
-          aria-label="Notifications"
+    <a
+      href="/notifications"
+      aria-label={badgeText ? `Notifications (${badgeText})` : 'Notifications'}
+      onClick={acknowledgeBell}
+      className="relative inline-flex items-center text-ink hover:text-accent transition-colors no-underline"
+    >
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+        <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+      </svg>
+      {badgeText && (
+        <span
+          aria-hidden="true"
+          className="absolute -top-1 -right-1.5 min-w-[16px] h-[16px] px-1 text-[10px] leading-[16px] text-center rounded-full font-medium"
+          style={{ background: 'var(--color-accent)', color: 'var(--color-bg)' }}
         >
-          <div className="px-4 py-3 border-b-[0.5px] border-border">
-            <div className="flex items-baseline justify-between gap-3">
-              <a
-                href="/notifications"
-                onClick={() => {
-                  acknowledgeBell();
-                  setOpen(false);
-                }}
-                className="inline-flex items-center gap-1 text-[11px] uppercase tracking-wider font-medium no-underline hover:underline"
-                style={{ color: 'var(--color-accent)' }}
-              >
-                Go to Messages <span aria-hidden="true">→</span>
-              </a>
-              <span className="text-[11px] text-tertiary">
-                {count === 0 ? 'All clear' : `${count} waiting`}
-              </span>
-            </div>
-          </div>
-
-          {visibleItems.length === 0 ? (
-            <div className="px-4 py-6 text-center text-xs text-muted">Nothing waiting.</div>
-          ) : (
-            <>
-              <ul className="max-h-[360px] overflow-y-auto">
-                {visibleItems.map((n) => {
-                  const pieceLabel = n.piece
-                    ? `${n.piece.title}${n.piece.catalog_number ? ` (${n.piece.catalog_number})` : ''}`
-                    : null;
-                  return (
-                    <li key={n.id} className="border-b-[0.5px] border-border last:border-b-0">
-                      <a
-                        href={n.link_path}
-                        className="block px-4 py-3 text-sm text-ink no-underline hover:bg-bg-tint"
-                        onClick={() => {
-                          acknowledgeBell();
-                          setOpen(false);
-                        }}
-                      >
-                        {pieceLabel && (
-                          <div className="font-display text-[15px] leading-tight mb-0.5">{pieceLabel}</div>
-                        )}
-                        <div className="text-xs text-muted leading-snug">{n.body}</div>
-                        {n.note && (
-                          <div
-                            className="mt-1.5 text-xs text-ink leading-snug italic border-l-2 border-accent pl-2"
-                            style={{ fontFamily: 'var(--font-serif)' }}
-                          >
-                            &ldquo;{n.note}&rdquo;
-                          </div>
-                        )}
-                      </a>
-                    </li>
-                  );
-                })}
-              </ul>
-              {hasQueueAccess && (
-                <div className="px-4 py-2 border-t-[0.5px] border-border bg-bg-tint">
-                  <a
-                    href="/notifications"
-                    className="text-xs text-accent no-underline hover:underline"
-                    onClick={() => setOpen(false)}
-                  >
-                    Open queue &rarr;
-                  </a>
-                </div>
-              )}
-            </>
-          )}
-        </div>
+          {badgeText}
+        </span>
       )}
-    </div>
+    </a>
   );
 }


### PR DESCRIPTION
## Summary
- Removed the navbar bell's popover dialog. Clicking the bell now navigates directly to `/notifications` (the Messages page) instead of opening an in-place summary list.
- Bell click still stamps the device-local `ip.bell.lastViewedAt` watermark, so the badge clears on click just like before.
- Trimmed `NavbarBell.tsx` from ~320 lines to ~115 lines: dropped the popover state, outside-click + escape handlers, and the multi-table batched fetch of subjects / pieces / contribution-request notes that only existed to render rows in the dialog. The remaining query just counts un-cleared notifications for the badge.

## Why
The popover duplicated what the Messages page already does, and forced users to take an extra step before reading anything. One click → inbox is closer to what the bell actually means.

## Tests
Added component tests in `src/components/NavbarBell.test.tsx` pinning the new contract:
- hides for anon viewers
- signed-in: renders as `<a href="/notifications">` (not a button), no `role="dialog"` anywhere
- badge text reflects unviewed-notification count
- click stamps `ip.bell.lastViewedAt` with a valid ISO timestamp

Existing `NavbarBell.test.ts` (5 pure-helper tests for `bellBadgeText`) is untouched.

## Test plan
- [x] Sign in, confirm the navbar bell renders an anchor (not a button) with the notifications icon and badge.
- [x] Click the bell → lands on `/notifications` directly with no intermediate popover.
- [x] Badge clears after the click and stays cleared on reload (until a newer notification arrives).
- [x] Anon viewers still see no bell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)