### PR TITLE
fix(test): clear 4 non-E2E failures from full suite

### DIFF
--- a/src/integration/contributionDraftsClient.test.ts
+++ b/src/integration/contributionDraftsClient.test.ts
@@ -74,7 +74,7 @@ describe('fetchPendingDraftsOnPiece (recipient view)', () => {
     // Recipient queries the table directly — RLS scopes to live drafts addressed to them.
     const { data: rows, error } = await recipient.client
       .from('contribution_request_drafts')
-      .select('id, request_id, kind, payload, created_at, inline_dismissed_at');
+      .select('id, request_id, kind, payload, created_at');
     expect(error).toBeNull();
     expect(rows?.length).toBe(2);
     const kinds = rows!.map((r) => r.kind).sort();
@@ -112,30 +112,6 @@ describe('fetchPendingDraftsOnPiece (recipient view)', () => {
       await deleteTestPiece(otherPieceId);
       await deleteAuthUser(otherRecipient.id);
     }
-  });
-
-  test('inline_dismissed_at set: recipient still sees row but UI filters it', async () => {
-    const { data: requestId } = await staff.client.rpc('create_outbox_request', {
-      p_piece_id: pieceId,
-      p_recipient_id: recipient.id,
-      p_note: null,
-    });
-    const { data: draftId } = await staff.client.rpc('propose_draft', {
-      p_request_id: requestId as string,
-      p_kind: 'piece_description',
-      p_payload: { body: 'For todos.' },
-    });
-    await staff.client.rpc('send_request', { p_request_id: requestId as string });
-    await recipient.client.rpc('dismiss_draft_inline', { p_draft_id: draftId as string });
-
-    const { data } = await recipient.client
-      .from('contribution_request_drafts')
-      .select('id, inline_dismissed_at')
-      .eq('id', draftId as string)
-      .single();
-    expect(data?.inline_dismissed_at).not.toBeNull();
-    // The lib filters out inlineDismissedAt rows from the inline render. Pinned
-    // here so a future "always show" change is intentional.
   });
 
   test('dispositioned drafts disappear from recipient view (RLS)', async () => {
@@ -227,29 +203,6 @@ describe('fetchPendingDraftsForViewer (cross-piece, Drafts tab)', () => {
 
     const pieceIds = [...new Set((rawRequests ?? []).map((r) => r.piece_id))].sort();
     expect(pieceIds).toEqual([piece1, piece2]);
-  });
-
-  test('inline_dismissed_at drafts still appear (Drafts tab includes them)', async () => {
-    const { data: req3 } = await staff.client.rpc('create_outbox_request', {
-      p_piece_id: piece1, p_recipient_id: recipient.id, p_note: null,
-    });
-    const { data: draftId } = await staff.client.rpc('propose_draft', {
-      p_request_id: req3 as string,
-      p_kind: 'interpretive_school',
-      p_payload: { name: 'School', body: 'For todos.' },
-    });
-    await staff.client.rpc('send_request', { p_request_id: req3 as string });
-    await recipient.client.rpc('dismiss_draft_inline', { p_draft_id: draftId as string });
-
-    // Cross-piece query: dismissed-from-inline drafts STILL show on the
-    // Drafts tab (the lib's fetchPendingDraftsForViewer doesn't filter
-    // them out — that's the whole point of "Add to Todo").
-    const { data } = await recipient.client
-      .from('contribution_request_drafts')
-      .select('id, inline_dismissed_at')
-      .eq('id', draftId as string)
-      .single();
-    expect(data?.inline_dismissed_at).not.toBeNull();
   });
 
   test('pieces query exposes title + composer_name for each draft', async () => {

--- a/src/lib/pieces.ts
+++ b/src/lib/pieces.ts
@@ -127,7 +127,11 @@ export async function getPieceBasic(id: string): Promise<PieceBasic | null> {
       .eq('id', id)
       .single();
 
-    if (error || !data) return null;
+    // `.single()` should return one row or an error, but in environments
+    // where the Accept header is mangled (happy-dom in component tests),
+    // postgrest can fall back to returning an empty array — treat that as
+    // "no row".
+    if (error || !data || (Array.isArray(data) && data.length === 0)) return null;
 
     return {
       id: data.id,
@@ -196,7 +200,13 @@ export async function getPieceFull(id: string): Promise<PieceFull | null> {
         .maybeSingle(),
     ]);
 
-    if (pieceResult.error || !pieceResult.data) return null;
+    if (
+      pieceResult.error ||
+      !pieceResult.data ||
+      (Array.isArray(pieceResult.data) && pieceResult.data.length === 0)
+    ) {
+      return null;
+    }
 
     const data = pieceResult.data;
     const has_signed_content = stateResult.data?.has_signed_content ?? false;

--- a/src/tests/draft-note-route.test.ts
+++ b/src/tests/draft-note-route.test.ts
@@ -17,6 +17,18 @@
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
+// Capture the real createClient BEFORE installing the fake. Bun's mock.module
+// is process-global, so once installed the fake leaks into every test file in
+// the run (src/lib/supabase.test.ts and src/lib/pieces.test.ts both saw a
+// createClient stripped of `.from`). We make the fake conditional: when
+// `useFake` is off, calls fall through to the real createClient. This file's
+// describe blocks flip the flag on/off in beforeAll/afterAll, so other test
+// files always see the real implementation. Save the FN reference, not the
+// namespace — `import * as` returns a live binding that follows the mock.
+const realSupabaseModule = await import('@supabase/supabase-js');
+const realCreateClient = realSupabaseModule.createClient;
+let useFake = false;
+
 // ── Programmable Supabase fake ──
 // Each test sets these via seedSupabase({...}); the mock's auth.getUser() and
 // rpc() read them. Default is "everything succeeds" so the happy path is
@@ -38,10 +50,13 @@ function seedSupabase(patch: Partial<SupabaseSeed>): void {
 }
 
 await mock.module('@supabase/supabase-js', () => ({
-  createClient: () => ({
-    auth: { getUser: (...args: unknown[]) => currentSeed.getUser(...(args as [])) },
-    rpc: (...args: unknown[]) => currentSeed.rpc(...(args as [])),
-  }),
+  createClient: (...args: Parameters<typeof realCreateClient>) =>
+    useFake
+      ? {
+          auth: { getUser: (...a: unknown[]) => currentSeed.getUser(...(a as [])) },
+          rpc: (...a: unknown[]) => currentSeed.rpc(...(a as [])),
+        }
+      : realCreateClient(...args),
 }));
 
 // Import the route AFTER mock.module is registered so the handler's
@@ -57,6 +72,7 @@ let fetchImpl: (url: string, init: RequestInit) => Promise<Response> = async () 
 const realFetch = globalThis.fetch;
 
 beforeEach(() => {
+  useFake = true;
   currentSeed = defaultSeed;
   fetchCalls = [];
   fetchImpl = async () =>
@@ -72,6 +88,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  useFake = false;
   globalThis.fetch = realFetch;
 });
 


### PR DESCRIPTION
## Summary
- Removed stale `inline_dismissed_at` references in `src/integration/contributionDraftsClient.test.ts` left over from the destructive-cleanup migration that dropped the column and `dismiss_draft_inline` RPC.
- Made the supabase-js mock in `src/tests/draft-note-route.test.ts` non-leaking: the fake now falls through to the real `createClient` when its `useFake` flag is off, and the flag is flipped on/off per-test so other test files (e.g. `src/lib/supabase.test.ts`) see the real module.
- Defended `getPieceBasic`/`getPieceFull` in `src/lib/pieces.ts` against `.single()` returning `[]` when happy-dom (registered globally by component .test.tsx files) mangles the supabase REST `Accept` header.

## Why
The full suite reported 4 non-E2E failures that masqueraded as a single class of issue. Triage broke them apart:
- 1 stale test (a column + RPC retirement that wasn't fully swept).
- 1 mock-isolation bug (Bun's `mock.module` is process-global; the fake created during one test file's load leaked into every subsequent file).
- 2 environment-quirk bugs in `pieces.ts` triggered only when component tests had already registered happy-dom — `.single()` returns `[]` instead of erroring on no-rows under that fetch implementation, and the existing `if (error || !data)` guard didn't cover that shape.

After the fix: 379 pass / 0 non-E2E fail (the 23 remaining E2E failures are an unrelated cross-origin issue in `src/e2e/routes.test.ts`).

## Test plan
- [x] `bun test` — full suite, confirm 0 non-E2E failures
- [x] `bun test src/integration/contributionDraftsClient.test.ts` — passes (all references to dropped column gone)
- [x] `bun test src/tests/draft-note-route.test.ts src/lib/supabase.test.ts src/lib/pieces.test.ts` — passes (mock no longer leaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)