### PR TITLE
content: refresh about/terms/privacy

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -42,20 +42,14 @@ const jsonLd = {
 
       <h2 class="text-xl md:text-2xl font-medium tracking-tight text-ink pt-4">What we do</h2>
 
-      <ul class="space-y-3 list-none pl-0">
-        <li class="flex gap-3">
-          <span class="text-accent font-semibold flex-shrink-0">Piece pages.</span>
-          <span>Structural landmarks grouped by movement, with flags for the technical challenges in each passage. Signed performer's notes and interpretive schools alongside. Every editorial claim carries a human name.</span>
-        </li>
-        <li class="flex gap-3">
-          <span class="text-accent font-semibold flex-shrink-0">Edition comparison.</span>
-          <span>The same passage side by side across editions — bowings, fingerings, articulation, sources — with signed editorial observations. Makes the edition decision concrete instead of guesswork.</span>
-        </li>
-        <li class="flex gap-3">
-          <span class="text-accent font-semibold flex-shrink-0">Personal library.</span>
-          <span>Pieces currently preparing, upcoming performances, pieces performed, and private reflections attached to specific passages.</span>
-        </li>
-      </ul>
+      <h3 class="text-base md:text-lg font-semibold text-accent pt-2">Piece pages</h3>
+      <p class="pl-4 md:pl-6">Structural landmarks grouped by movement, with flags for the technical challenges in each passage. Signed performer's notes and interpretive schools alongside. Every editorial claim carries a human name.</p>
+
+      <h3 class="text-base md:text-lg font-semibold text-accent pt-2">Edition comparison</h3>
+      <p class="pl-4 md:pl-6">The same passage side by side across editions — bowings, fingerings, articulation, sources — with signed editorial observations. Makes the edition decision concrete instead of guesswork.</p>
+
+      <h3 class="text-base md:text-lg font-semibold text-accent pt-2">Personal library</h3>
+      <p class="pl-4 md:pl-6">Pieces currently preparing, upcoming performances, pieces performed, and private reflections attached to specific passages.</p>
 
       <h2 class="text-xl md:text-2xl font-medium tracking-tight text-ink pt-4">Plurality of voices</h2>
 
@@ -63,13 +57,19 @@ const jsonLd = {
         When two respected musicians hold incompatible views on how a piece should be played, Irregular Pearl shows both, signed, with neither presented as canonical. The site is editorial before it is technical. Interpretive judgment carries a human name — we do not publish anonymous opinions or AI-generated content under false bylines.
       </p>
       <p>
-        Paradoxically, we are a tech-heavy, AI-first organization. We intent to spend most of our fund to artists for their performances, artistic voices, and guidance, not on operating this entity. We intent to spend as little as possible on operations - building out this platform, fundrasing, adminiration - by leaning on the latest technology, including AI.   
+        Paradoxically, we are a tech-heavy, AI-first organization. We intend to spend most of our funds on artists — for their performances, artistic voices, and guidance — not on operating this entity. We intend to spend as little as possible on operations (building out this platform, fundraising, administration) by leaning on the latest technology, including AI.
       </p>
 
       <h2 class="text-xl md:text-2xl font-medium tracking-tight text-ink pt-4">Open and free</h2>
 
       <p>
         Irregular Pearl is a non-profit. All piece data, edition information, and editorial writing are free to access. We describe editions, we do not reproduce them. We reference recordings, we do not host them.
+      </p>
+
+      <h2 class="text-xl md:text-2xl font-medium tracking-tight text-ink pt-4">Contact</h2>
+
+      <p>
+        Questions, corrections, or interest in contributing? Reach us at <a class="text-accent underline" href="mailto:info@irregularpearl.org">info@irregularpearl.org</a>.
       </p>
     </div>
   </main>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -21,16 +21,20 @@ import Navbar from '../components/Navbar.astro';
       <p>Your data is used solely to operate Irregular Pearl: displaying your contributions, attributing your reviews, and showing which pieces you're working on. We use Supabase for authentication and database hosting.</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">4. Third-party services</h2>
+      <p>Services that handle your data:</p>
       <ul class="list-disc pl-5 space-y-1">
-        <li><strong class="text-ink">Supabase</strong> — authentication and database hosting</li>
-        <li><strong class="text-ink">Cloudflare</strong> — website hosting and CDN</li>
+        <li><strong class="text-ink">Supabase</strong> — authentication, database hosting, and Edge Functions for transactional email composition</li>
+        <li><strong class="text-ink">Cloudflare</strong> — website hosting, CDN, and edge runtime</li>
         <li><strong class="text-ink">Google</strong> — optional OAuth sign-in provider</li>
-        <li><strong class="text-ink">YouTube</strong> — embedded recordings (loaded only when you click play)</li>
+        <li><strong class="text-ink">Resend</strong> — transactional email delivery (welcome, weekly digests, contribution notifications)</li>
+        <li><strong class="text-ink">Anthropic (Claude)</strong> — used by staff as a coding and editing assistant. We do not publish anonymous AI-generated content under false bylines.</li>
+        <li><strong class="text-ink">YouTube, Vimeo, Spotify, SoundCloud, Bandcamp, Internet Archive</strong> — embedded recordings</li>
+        <li><strong class="text-ink">IMSLP, Wikipedia</strong> — external reference links</li>
       </ul>
       <p>Each service has its own privacy policy. We encourage you to review them.</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">5. Data retention</h2>
-      <p>Your account data and contributions are retained as long as your account exists. You may request deletion of your account and all associated data by contacting us.</p>
+      <p>Your account data and contributions are retained as long as your account exists. You can account and all associated data using <strong> Delete my account</strong> feature.</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">6. Children</h2>
       <p>Irregular Pearl is not directed at children under 13. We do not knowingly collect data from children under 13.</p>
@@ -39,7 +43,7 @@ import Navbar from '../components/Navbar.astro';
       <p>We may update this policy. Material changes will be noted on this page with an updated effective date.</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">8. Contact</h2>
-      <p>For privacy questions, reach out through our GitHub repository.</p>
+      <p>For privacy questions, email <a class="text-accent underline" href="mailto:info@irregularpearl.org">info@irregularpearl.org</a>.</p>
     </div>
   </main>
 </Layout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -33,7 +33,7 @@ import Navbar from '../components/Navbar.astro';
       <p>We may update these terms. Continued use after changes constitutes acceptance.</p>
 
       <h2 class="text-base font-semibold text-ink pt-4">8. Contact</h2>
-      <p>For questions about these terms, reach out through our GitHub repository.</p>
+      <p>For questions about these terms, email <a class="text-accent underline" href="mailto:info@irregularpearl.org">info@irregularpearl.org</a>.</p>
     </div>
   </main>
 </Layout>


### PR DESCRIPTION
## Summary
- **About**: fixed typos in the "Plurality of voices" paragraph (intent→intend, fundrasing→fundraising, adminiration→administration), restructured "What we do" with purple subheadings and indented descriptions, and added a Contact section linking to `info@irregularpearl.org`.
- **Terms & Privacy**: swapped the "reach out through our GitHub repository" contact lines for `mailto:info@irregularpearl.org`.
- **Privacy / Third-party services**: expanded the list to reflect what's actually in the stack — added Resend (transactional email), Anthropic/Claude (build-time coding + editorial assistance, with the no-anonymous-AI-bylines stance), and the embedded-media + external-reference providers (Vimeo/Spotify/SoundCloud/Bandcamp/Internet Archive, IMSLP, Wikipedia).

Branch was cut fresh off `main` so unrelated WIP from `cleanup-paper-cuts` is not included.

## Test plan
- [x] Verified all three pages render in the local dev server with no console/server errors.
- [x] Confirmed no remaining "github" mentions on terms or privacy; only `info@irregularpearl.org`.
- [ ] Reviewer: please double-check the Privacy §5 ("Data retention") sentence, which references a "Delete my account" feature in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)