### PR TITLE
ci(migrations): use --include-all so timestamp-inverted migrations deploy

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -70,7 +70,12 @@ jobs:
       - name: Push migrations
         # `supabase db push` applies only migrations not already recorded in
         # the project's schema_migrations table. Idempotent; safe on re-runs.
-        run: supabase db push
+        # `--include-all` covers the case where a feature branch's migration
+        # has a timestamp older than what's already on prod (timestamp
+        # inversion). Without it, the CLI fails closed and blocks every later
+        # migration too. We've already merged the PR by the time this runs,
+        # so the gating decision was made at review time, not here.
+        run: supabase db push --include-all
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
## What

One-line workflow change: `supabase db push` → `supabase db push --include-all`.

## Why

PR #79 and PR #81 both merged with the Supabase Migrations job failing silently. The CLI refuses out-of-order timestamps and exits 1 — once the first migration is blocked, every later one is gated behind it.

Concrete fallout: `20260526000200_typeahead_grouping_by_signed_content.sql` sat unapplied for ~3 days. The frontend (`SearchTypeahead.tsx`) filters on `result_type` values the new RPC returns, but prod was still running the old RPC, so typing "bach" returned zero rows in the dropdown. `20260609000000_drop_vestigial_contributor_flags.sql` was gated behind it and also stayed unapplied.

The PR review gate is the right place to catch a bad migration. By the time this workflow runs we've already merged — failing closed here just hides the problem instead of preventing it.

## Already done in this session

- Pushed both pending migrations to prod via `supabase db push --include-all` locally
- Verified the prod RPC returns the new `result_type`/`is_materialized` shape and "bach" returns rows
- `supabase migration list --linked` shows everything caught up

## Test plan

- [ ] Merge this PR — workflow runs against an empty migration set, no-op success
- [ ] Next PR with a migration → confirm it applies cleanly even if its timestamp is older than the latest one already on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)