### PR TITLE
feat(email): style remaining auth templates — confirmation, email change, magic link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Irregular Pearl are recorded here. Format follows [Keep a
 
 ## [Unreleased]
 
+### Auth email templates — confirmation, email change, magic link
+
+PR #88 styled the password-reset (`recovery`) email but left the rest of the Supabase Auth templates on their bare defaults. The signup confirmation in particular still rendered as a stark "Confirm your signup / Follow this link to confirm your user:" with no masthead — exactly the kind of low-content shape spam filters flag and new users mistrust.
+
+- **Three new templates**: [`supabase/templates/confirmation.html`](supabase/templates/confirmation.html) (signup), [`supabase/templates/email-change.html`](supabase/templates/email-change.html) (email change, used for both old and new address confirmations), [`supabase/templates/magic-link.html`](supabase/templates/magic-link.html) (passwordless sign-in). All three mirror the recovery template's layout: 600px table-based column, `IrregularPearl` wordmark + "Account" subtitle, ink CTA, accent-purple link fallback, 1px `#E5E3DE` borders, `color-scheme: light` meta to prevent dark-mode inversion.
+- **Branded subject lines** so all four auth emails name the sender on the inbox line: `Confirm your Irregular Pearl signup`, `Reset your Irregular Pearl password`, `Confirm your email change for Irregular Pearl`, `Your Irregular Pearl sign-in link`.
+- **Subject regression fixed**: the recovery subject merged on PR #88 was `"Reset your IrregularPearl password"` (no space) — contradicting the wordmark-vs-prose convention the user had already set. Restored to `Reset your Irregular Pearl password` in the same commit.
+- **Email-change template uses both `{{ .Email }}` and `{{ .NewEmail }}`**: explicit "from X to Y" framing in bold so the recipient can verify the destination and spot tampered-with confirmation requests at a glance.
+- **All four templates wired** under `[auth.email.template.*]` in [`supabase/config.toml`](supabase/config.toml). Push with `bunx supabase config push` (or paste each into the dashboard's Auth → Email Templates pane).
+
 ### Email deliverability hardening — recovery template, List-Unsubscribe, branded subjects
 
 The Supabase-default password-reset email and the two cron-driven digests were all hitting Gmail spam in fresh accounts. Single sweep to bring them in line with the same `renderEmailLayout` masthead the welcome email already uses, and to add the bulk-sender hygiene Gmail/Yahoo started enforcing in early 2024.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -231,9 +231,21 @@ otp_expiry = 3600
 # subject = "You have been invited"
 # content_path = "./supabase/templates/invite.html"
 
+[auth.email.template.confirmation]
+subject = "Confirm your Irregular Pearl signup"
+content_path = "./supabase/templates/confirmation.html"
+
 [auth.email.template.recovery]
-subject = "Reset your IrregularPearl password"
+subject = "Reset your Irregular Pearl password"
 content_path = "./supabase/templates/recovery.html"
+
+[auth.email.template.email_change]
+subject = "Confirm your email change for Irregular Pearl"
+content_path = "./supabase/templates/email-change.html"
+
+[auth.email.template.magic_link]
+subject = "Your Irregular Pearl sign-in link"
+content_path = "./supabase/templates/magic-link.html"
 
 # Uncomment to customize notification email template
 # [auth.email.notification.password_changed]

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<meta name="color-scheme" content="light"/>
+<meta name="supported-color-schemes" content="light"/>
+<title>Confirm your Irregular Pearl signup</title>
+<style>body,table,td,a{-webkit-text-size-adjust:100%}table,td{border-collapse:collapse}body{margin:0;padding:0;background:#FFFFFF}
+@media only screen and (max-width:620px){.w{width:100%!important}.wi{padding:0 16px!important}}</style>
+</head>
+<body style="margin:0;padding:0;background:#FFFFFF;-webkit-font-smoothing:antialiased;">
+<div style="display:none;max-height:0;overflow:hidden;">Confirm your email address to finish signing up for Irregular Pearl. The link expires in one hour.</div>
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background:#FFFFFF;">
+<tr><td align="center" valign="top" style="padding:32px 0 48px;">
+<table role="presentation" class="w" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width:600px;">
+
+<!-- HEADER -->
+<tr><td class="wi" align="center" style="padding:0 24px 20px;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:22px;font-weight:500;color:#1A1A1A;padding:12px 0 0;">
+    <a href="https://irregularpearl.org" style="text-decoration:none;color:#1A1A1A;" target="_blank" rel="noopener">IrregularPearl</a>
+  </div>
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;font-weight:500;color:#9A9A9A;letter-spacing:0.12em;text-transform:uppercase;padding:8px 0 16px;">Account</div>
+  <div style="border-top:1px solid #E5E3DE;"></div>
+</td></tr>
+
+<!-- BODY -->
+<tr><td class="wi" style="padding:20px 24px 0;">
+
+<div style="padding-bottom:16px;">
+  <div style="font-family:'Source Serif 4', Georgia, 'Times New Roman', serif;font-size:22px;color:#1A1A1A;line-height:1.25;">Confirm your email</div>
+</div>
+
+<div style="padding-bottom:16px;">
+  <div style="font-family:'Source Serif 4', Georgia, 'Times New Roman', serif;font-size:15px;color:#1A1A1A;line-height:1.68;">Welcome to Irregular Pearl. Click the button below to confirm this is your email address and finish setting up your account.</div>
+</div>
+
+<div style="padding-bottom:8px;">
+  <div style="font-family:'Source Serif 4', Georgia, 'Times New Roman', serif;font-size:15px;color:#1A1A1A;line-height:1.68;">The link expires in one hour.</div>
+</div>
+
+<div align="center" style="padding:24px 0 8px;">
+  <a href="{{ .ConfirmationURL }}" style="display:inline-block;font-family:Inter, Arial, sans-serif;font-size:14px;font-weight:500;color:#FFFFFF;text-decoration:none;padding:12px 28px;border-radius:8px;background:#1A1A1A;" target="_blank" rel="noopener">Confirm my email</a>
+</div>
+
+<div style="padding:16px 0 6px;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:14px;color:#6F6F6F;line-height:1.55;">Or paste this link into your browser:</div>
+</div>
+<div style="padding-bottom:24px;word-break:break-all;">
+  <a href="{{ .ConfirmationURL }}" style="font-family:Inter, Arial, sans-serif;font-size:13px;color:#6B4E7C;text-decoration:underline;" target="_blank" rel="noopener">{{ .ConfirmationURL }}</a>
+</div>
+
+</td></tr>
+
+<!-- FOOTER -->
+<tr><td class="wi" align="center" style="padding:24px 24px 0;">
+  <div style="border-top:1px solid #E5E3DE;"></div>
+</td></tr>
+<tr><td class="wi" align="center" style="padding:16px 24px 0;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;color:#9A9A9A;line-height:1.6;">Didn&rsquo;t sign up? You can safely ignore this email &mdash; your address won&rsquo;t be added to any account. This is an essential account email and cannot be unsubscribed from.</div>
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;margin-top:6px;">
+    <a href="{{ .SiteURL }}" style="color:#9A9A9A;text-decoration:underline;" target="_blank" rel="noopener">irregularpearl.org</a>
+  </div>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>

--- a/supabase/templates/email-change.html
+++ b/supabase/templates/email-change.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<meta name="color-scheme" content="light"/>
+<meta name="supported-color-schemes" content="light"/>
+<title>Confirm your email change for Irregular Pearl</title>
+<style>body,table,td,a{-webkit-text-size-adjust:100%}table,td{border-collapse:collapse}body{margin:0;padding:0;background:#FFFFFF}
+@media only screen and (max-width:620px){.w{width:100%!important}.wi{padding:0 16px!important}}</style>
+</head>
+<body style="margin:0;padding:0;background:#FFFFFF;-webkit-font-smoothing:antialiased;">
+<div style="display:none;max-height:0;overflow:hidden;">Confirm an email address change on your Irregular Pearl account. The link expires in one hour.</div>
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background:#FFFFFF;">
+<tr><td align="center" valign="top" style="padding:32px 0 48px;">
+<table role="presentation" class="w" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width:600px;">
+
+<!-- HEADER -->
+<tr><td class="wi" align="center" style="padding:0 24px 20px;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:22px;font-weight:500;color:#1A1A1A;padding:12px 0 0;">
+    <a href="https://irregularpearl.org" style="text-decoration:none;color:#1A1A1A;" target="_blank" rel="noopener">IrregularPearl</a>
+  </div>
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;font-weight:500;color:#9A9A9A;letter-spacing:0.12em;text-transform:uppercase;padding:8px 0 16px;">Account</div>
+  <div style="border-top:1px solid #E5E3DE;"></div>
+</td></tr>
+
+<!-- BODY -->
+<tr><td class="wi" style="padding:20px 24px 0;">
+
+<div style="padding-bottom:16px;">
+  <div style="font-family:'Source Serif 4', Georgia, 'Times New Roman', serif;font-size:22px;color:#1A1A1A;line-height:1.25;">Confirm your email change</div>
+</div>
+
+<div style="padding-bottom:16px;">
+  <div style="font-family:'Source Serif 4', Georgia, 'Times New Roman', serif;font-size:15px;color:#1A1A1A;line-height:1.68;">Someone &mdash; hopefully you &mdash; asked to change the email address on an Irregular Pearl account from <strong>{{ .Email }}</strong> to <strong>{{ .NewEmail }}</strong>.</div>
+</div>
+
+<div style="padding-bottom:8px;">
+  <div style="font-family:'Source Serif 4', Georgia, 'Times New Roman', serif;font-size:15px;color:#1A1A1A;line-height:1.68;">Click the button below to confirm. Both addresses receive a confirmation; the change takes effect once both are confirmed. The link expires in one hour.</div>
+</div>
+
+<div align="center" style="padding:24px 0 8px;">
+  <a href="{{ .ConfirmationURL }}" style="display:inline-block;font-family:Inter, Arial, sans-serif;font-size:14px;font-weight:500;color:#FFFFFF;text-decoration:none;padding:12px 28px;border-radius:8px;background:#1A1A1A;" target="_blank" rel="noopener">Confirm email change</a>
+</div>
+
+<div style="padding:16px 0 6px;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:14px;color:#6F6F6F;line-height:1.55;">Or paste this link into your browser:</div>
+</div>
+<div style="padding-bottom:24px;word-break:break-all;">
+  <a href="{{ .ConfirmationURL }}" style="font-family:Inter, Arial, sans-serif;font-size:13px;color:#6B4E7C;text-decoration:underline;" target="_blank" rel="noopener">{{ .ConfirmationURL }}</a>
+</div>
+
+</td></tr>
+
+<!-- FOOTER -->
+<tr><td class="wi" align="center" style="padding:24px 24px 0;">
+  <div style="border-top:1px solid #E5E3DE;"></div>
+</td></tr>
+<tr><td class="wi" align="center" style="padding:16px 24px 0;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;color:#9A9A9A;line-height:1.6;">Didn&rsquo;t request this? You can safely ignore this email &mdash; nothing changes until both addresses confirm. If you&rsquo;re seeing repeated requests you didn&rsquo;t make, reply to this message and we&rsquo;ll take a look. This is an essential account email and cannot be unsubscribed from.</div>
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;margin-top:6px;">
+    <a href="{{ .SiteURL }}" style="color:#9A9A9A;text-decoration:underline;" target="_blank" rel="noopener">irregularpearl.org</a>
+  </div>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<meta name="color-scheme" content="light"/>
+<meta name="supported-color-schemes" content="light"/>
+<title>Your Irregular Pearl sign-in link</title>
+<style>body,table,td,a{-webkit-text-size-adjust:100%}table,td{border-collapse:collapse}body{margin:0;padding:0;background:#FFFFFF}
+@media only screen and (max-width:620px){.w{width:100%!important}.wi{padding:0 16px!important}}</style>
+</head>
+<body style="margin:0;padding:0;background:#FFFFFF;-webkit-font-smoothing:antialiased;">
+<div style="display:none;max-height:0;overflow:hidden;">One-time sign-in link for your Irregular Pearl account. The link expires in one hour.</div>
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background:#FFFFFF;">
+<tr><td align="center" valign="top" style="padding:32px 0 48px;">
+<table role="presentation" class="w" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width:600px;">
+
+<!-- HEADER -->
+<tr><td class="wi" align="center" style="padding:0 24px 20px;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:22px;font-weight:500;color:#1A1A1A;padding:12px 0 0;">
+    <a href="https://irregularpearl.org" style="text-decoration:none;color:#1A1A1A;" target="_blank" rel="noopener">IrregularPearl</a>
+  </div>
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;font-weight:500;color:#9A9A9A;letter-spacing:0.12em;text-transform:uppercase;padding:8px 0 16px;">Account</div>
+  <div style="border-top:1px solid #E5E3DE;"></div>
+</td></tr>
+
+<!-- BODY -->
+<tr><td class="wi" style="padding:20px 24px 0;">
+
+<div style="padding-bottom:16px;">
+  <div style="font-family:'Source Serif 4', Georgia, 'Times New Roman', serif;font-size:22px;color:#1A1A1A;line-height:1.25;">Sign in to Irregular Pearl</div>
+</div>
+
+<div style="padding-bottom:16px;">
+  <div style="font-family:'Source Serif 4', Georgia, 'Times New Roman', serif;font-size:15px;color:#1A1A1A;line-height:1.68;">Click the button below to sign in to your Irregular Pearl account. The link is single-use and expires in one hour.</div>
+</div>
+
+<div align="center" style="padding:24px 0 8px;">
+  <a href="{{ .ConfirmationURL }}" style="display:inline-block;font-family:Inter, Arial, sans-serif;font-size:14px;font-weight:500;color:#FFFFFF;text-decoration:none;padding:12px 28px;border-radius:8px;background:#1A1A1A;" target="_blank" rel="noopener">Sign in</a>
+</div>
+
+<div style="padding:16px 0 6px;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:14px;color:#6F6F6F;line-height:1.55;">Or paste this link into your browser:</div>
+</div>
+<div style="padding-bottom:24px;word-break:break-all;">
+  <a href="{{ .ConfirmationURL }}" style="font-family:Inter, Arial, sans-serif;font-size:13px;color:#6B4E7C;text-decoration:underline;" target="_blank" rel="noopener">{{ .ConfirmationURL }}</a>
+</div>
+
+</td></tr>
+
+<!-- FOOTER -->
+<tr><td class="wi" align="center" style="padding:24px 24px 0;">
+  <div style="border-top:1px solid #E5E3DE;"></div>
+</td></tr>
+<tr><td class="wi" align="center" style="padding:16px 24px 0;">
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;color:#9A9A9A;line-height:1.6;">Didn&rsquo;t request this? You can safely ignore this email &mdash; without clicking the link, no one can sign in. This is an essential account email and cannot be unsubscribed from.</div>
+  <div style="font-family:Inter, Arial, sans-serif;font-size:11px;margin-top:6px;">
+    <a href="{{ .SiteURL }}" style="color:#9A9A9A;text-decoration:underline;" target="_blank" rel="noopener">irregularpearl.org</a>
+  </div>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>


### PR DESCRIPTION
## Why

[#88](https://github.com/jspkm/irregular-pearl/pull/88) styled the password-reset (`recovery`) email but left every other Supabase Auth template on the bare defaults. The signup confirmation in particular still rendered as a stark "Confirm your signup / Follow this link to confirm your user:" with no masthead — exactly the shape spam filters flag and new users mistrust. Reported in-conversation as still hitting after deploy.

## Summary

- **Three new templates**, mirroring the recovery layout (600px table column, `IrregularPearl` wordmark + "Account" subtitle, ink CTA, accent-purple link fallback, 1px borders, `color-scheme: light` meta):
  - [`supabase/templates/confirmation.html`](supabase/templates/confirmation.html) — signup confirmation
  - [`supabase/templates/email-change.html`](supabase/templates/email-change.html) — email change (uses both `{{ .Email }}` and `{{ .NewEmail }}` in a "from X to Y" framing so the recipient can verify the destination)
  - [`supabase/templates/magic-link.html`](supabase/templates/magic-link.html) — passwordless sign-in (kept for completeness; even if no surface invokes it today, defaults stay styled)
- **Branded subjects** so all four auth emails name the sender on the inbox line:
  - `Confirm your Irregular Pearl signup`
  - `Reset your Irregular Pearl password`
  - `Confirm your email change for Irregular Pearl`
  - `Your Irregular Pearl sign-in link`
- **Subject regression fixed**: the merged recovery subject read `"Reset your IrregularPearl password"` (no space) — contradicting the wordmark-vs-prose convention the user already set ("IrregularPearl just for the text logo at the top, rest should be with space"). Restored.
- All four templates registered under `[auth.email.template.*]` in `supabase/config.toml`.

## Deploy

`bunx supabase config push` to ship all four templates + subjects to the cloud project. Or, if pasting into the dashboard, the four panes in Authentication → Email Templates each take a subject + body — match the values in `supabase/config.toml`.

## Test plan

- [x] Each template visually matches the recovery email's masthead, divider rhythm, button, and footer.
- [x] `IrregularPearl` only as the wordmark; `Irregular Pearl` (with space) everywhere else: subject lines, body prose, footer.
- [x] Email-change body uses bold `{{ .Email }}` and `{{ .NewEmail }}` for clear "from / to" framing.
- [ ] After deploy, send yourself one of each: signup, password reset, email change. Confirm masthead renders in Gmail / Apple Mail / Outlook and that no email lands in spam from a fresh inbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)