### PR TITLE
fix(profile): username chip updates instantly after save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Irregular Pearl are recorded here. Format follows [Keep a
 
 ## [Unreleased]
 
+### Profile username updates instantly without page reload
+
+Saving a username in Profile → Edit wrote to the database but the chip kept showing "Claim your URL" and the Edit form didn't collapse to the new `irregularpearl.org/@<name>` display until a manual refresh. The editor was firing `onUsernameChange?.(trimmed)` on success, but [`ArtistProfile.tsx:98`](src/components/ArtistProfile.tsx) wasn't passing a callback, so the parent's `profile.username` stayed stale and the editor's "view" mode rendered the old prop.
+
+- **Wired the callback** in [`src/components/ArtistProfile.tsx`](src/components/ArtistProfile.tsx): `onUsernameChange={(username) => setProfile(prev => prev ? { ...prev, username } : prev)}`. The View / Change-username affordance now appears the moment Save resolves, no refresh.
+- Tests in [`src/components/UsernameEditor.test.tsx`](src/components/UsernameEditor.test.tsx) already exercise the callback contract; this PR makes the parent honor it.
+
 ### Auth email templates — confirmation, email change, magic link
 
 PR #88 styled the password-reset (`recovery`) email but left the rest of the Supabase Auth templates on their bare defaults. The signup confirmation in particular still rendered as a stark "Confirm your signup / Follow this link to confirm your user:" with no masthead — exactly the kind of low-content shape spam filters flag and new users mistrust.

--- a/src/components/ArtistProfile.tsx
+++ b/src/components/ArtistProfile.tsx
@@ -95,7 +95,13 @@ export default function ArtistProfile({ userId }: { userId: string }) {
         </div>
         <div className="flex-1 min-w-0">
           <h1 className="font-display italic text-2xl md:text-[28px] leading-tight mb-1">{displayName}</h1>
-          {isOwnProfile && <UsernameEditor currentUsername={profile.username} userId={profile.id} />}
+          {isOwnProfile && (
+            <UsernameEditor
+              currentUsername={profile.username}
+              userId={profile.id}
+              onUsernameChange={(username) => setProfile(prev => prev ? { ...prev, username } : prev)}
+            />
+          )}
           <div className="mt-2 flex flex-wrap gap-2 items-center">
             {profile.instrument && profile.instrument.split(',').map(i => i.trim()).filter(Boolean).map(inst => (
               <span key={inst} className="text-[11px] px-2.5 py-1 bg-accent-soft text-accent rounded-full font-medium">{inst}</span>


### PR DESCRIPTION
## Summary
Saving a username in Profile → Edit wrote to the DB but the UI didn't reflect it until a manual page refresh. The editor (`UsernameEditor.tsx`) calls `onUsernameChange?.(trimmed)` on success, but [`ArtistProfile.tsx:98`](src/components/ArtistProfile.tsx) wasn't passing the callback, so the parent's `profile.username` stayed stale and the editor's display view re-rendered the old prop.

Wired the callback to update `profile` state. The "Claim your URL" button collapses into the `@username` chip + View / Change-username links the instant Save resolves.

## Test plan
- [x] `bun test src/components/UsernameEditor.test.tsx` — 5/5 pass
- [x] User signed off locally: chip appears immediately after Save, no refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)