### PR TITLE
feat: link contributor names to profile across every signed surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Irregular Pearl are recorded here. Format follows [Keep a
 
 ## [Unreleased]
 
+### Contributor names link to their profile across every signed surface
+
+Every contributor name attached to content was rendered as plain text — readers couldn't click through to the contributor's profile from the byline that prompted the question. Now the name on every signed surface is a link: `/@{username}` if the contributor has claimed a username, `/profile/{id}` as a fallback for users who haven't set one yet. Visual treatment is unchanged (same ink color, same font-weight, no underline) so the byline still reads as type, not a link island.
+
+- **Five signed surfaces wrap the name in `<a>`**: piece descriptions ([`SignedPieceDescription.tsx`](src/components/SignedPieceDescription.tsx)), performer's notes ([`PerformersNotes.tsx`](src/components/PerformersNotes.tsx)), interpretive schools ([`InterpretiveSchools.tsx`](src/components/InterpretiveSchools.tsx)), difficulty ratings ([`SignedPieceDifficulty.tsx`](src/components/SignedPieceDifficulty.tsx)), structural landmarks ([`StructuralLandmarks.tsx`](src/components/StructuralLandmarks.tsx)).
+- **Three meta surfaces** also link: change log entries ([`ChangeLog.tsx`](src/components/ChangeLog.tsx)) — "Seed data" rows stay as plain text since they have no author; pending-draft "Proposed by" lines ([`PendingDraftCard.tsx`](src/components/PendingDraftCard.tsx)); and notification queue rows ([`NotificationsQueue.tsx`](src/components/NotificationsQueue.tsx)).
+- **Lib types carry `username` end-to-end**: every contributor object on `PublishedPieceDescription`, `PublishedPerformersNote`, `PublishedInterpretiveSchool`, `PublishedLandmark`, `PublishedPieceDifficulty`, plus the `PendingDraft.sender` and `ChangeLogEntry.authoredByUsername`. Each fetch query now selects `username` alongside `display_name` and `contributor_bio_short`.
+- **Changelog RPC returns `authored_by_username`** ([`20260612000000_changelog_authored_by_username.sql`](supabase/migrations/20260612000000_changelog_authored_by_username.sql)). Single migration adds the field to every union branch of `fetch_piece_changelog`.
+- **CSS keeps the link looking like type**: `.signed .by .name`, `.changelog-who`, `.landmark-by-name`, and the per-component `.by .name` rules in the signed-content components all carry `text-decoration: none; color: inherit;` so an `<a>` styled with `class="name"` is visually identical to the previous `<span>`.
+- **Test seed**: [`scripts/seed-profile-link-test.ts`](scripts/seed-profile-link-test.ts) seeds two users with usernames + one without, then publishes a description, two notes, two schools, a difficulty rating, and a landmark on `bach-cello-suite-1`. Idempotent; rerun any time. Use it to verify both the `/@{username}` path and the `/profile/{id}` fallback.
+
 ### Profile username updates instantly without page reload
 
 Saving a username in Profile → Edit wrote to the database but the chip kept showing "Claim your URL" and the Edit form didn't collapse to the new `irregularpearl.org/@<name>` display until a manual refresh. The editor was firing `onUsernameChange?.(trimmed)` on success, but [`ArtistProfile.tsx:98`](src/components/ArtistProfile.tsx) wasn't passing a callback, so the parent's `profile.username` stayed stale and the editor's "view" mode rendered the old prop.

--- a/scripts/seed-profile-link-test.ts
+++ b/scripts/seed-profile-link-test.ts
@@ -1,0 +1,395 @@
+// One-shot test setup for the contributor-profile-link change.
+// Creates two users with usernames + bio_short, then publishes signed
+// content on a piece so all surfaces are visible.
+//
+// Run: bun run scripts/seed-profile-link-test.ts
+
+import { createClient } from '@supabase/supabase-js';
+import { spawnSync } from 'node:child_process';
+
+function readEnv(): { url: string; serviceKey: string } {
+  const r = spawnSync('supabase', ['status', '-o', 'env'], { encoding: 'utf-8' });
+  if (r.status !== 0) {
+    console.error(r.stderr || 'supabase status failed');
+    process.exit(1);
+  }
+  const env: Record<string, string> = {};
+  for (const line of r.stdout.split('\n')) {
+    const m = line.match(/^([A-Z_]+)="?([^"]*)"?$/);
+    if (m) env[m[1]] = m[2];
+  }
+  return { url: env.API_URL!, serviceKey: env.SERVICE_ROLE_KEY! };
+}
+
+const { url, serviceKey } = readEnv();
+const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+const PIECE_ID = 'bach-cello-suite-1';
+
+async function ensureUser(email: string, displayName: string, username: string, bioShort: string): Promise<string> {
+  let userId: string;
+  const { data, error } = await sb.auth.admin.createUser({
+    email,
+    password: 'password123',
+    email_confirm: true,
+  });
+  if (error && error.code === 'email_exists') {
+    const r = spawnSync('supabase', ['db', 'query', `SELECT id::text FROM auth.users WHERE email = '${email}'`], { encoding: 'utf-8' });
+    const m = r.stdout.match(/"id":\s*"([0-9a-f-]+)"/);
+    if (!m) throw new Error(`could not find existing user ${email}: ${r.stderr}`);
+    userId = m[1];
+  } else if (error || !data?.user) {
+    throw error ?? new Error('createUser failed');
+  } else {
+    userId = data.user.id;
+  }
+  const { error: upErr } = await sb
+    .from('users')
+    .update({
+      display_name: displayName,
+      username,
+      contributor_bio_short: bioShort,
+      contributor_agreement_signed_at: new Date().toISOString(),
+    })
+    .eq('id', userId);
+  if (upErr) throw upErr;
+  return userId;
+}
+
+async function publishDescription(pieceId: string, contributorId: string, body: string) {
+  const { data: existing } = await sb
+    .from('piece_descriptions')
+    .select('id')
+    .eq('piece_id', pieceId)
+    .eq('contributor_id', contributorId)
+    .maybeSingle();
+  if (existing) return;
+
+  const { data: desc, error: dErr } = await sb
+    .from('piece_descriptions')
+    .insert({
+      piece_id: pieceId,
+      contributor_id: contributorId,
+      status: 'draft',
+      drafted_by: contributorId,
+    })
+    .select('id')
+    .single();
+  if (dErr || !desc) throw dErr;
+
+  const { data: ver, error: vErr } = await sb
+    .from('piece_description_versions')
+    .insert({
+      description_id: desc.id,
+      piece_id: pieceId,
+      contributor_id: contributorId,
+      body,
+      authored_by: contributorId,
+      approved_at: new Date().toISOString(),
+      version_number: 1,
+    })
+    .select('id')
+    .single();
+  if (vErr || !ver) throw vErr;
+
+  const { error: upErr } = await sb
+    .from('piece_descriptions')
+    .update({
+      current_version_id: ver.id,
+      status: 'published',
+      approved_by: contributorId,
+      approved_by_contributor_at: new Date().toISOString(),
+    })
+    .eq('id', desc.id);
+  if (upErr) throw upErr;
+}
+
+async function publishNote(pieceId: string, contributorId: string, body: string) {
+  const { data: existing } = await sb
+    .from('performers_notes')
+    .select('id')
+    .eq('piece_id', pieceId)
+    .eq('contributor_id', contributorId)
+    .maybeSingle();
+  if (existing) return;
+
+  const { data: note, error: nErr } = await sb
+    .from('performers_notes')
+    .insert({
+      piece_id: pieceId,
+      contributor_id: contributorId,
+      status: 'draft',
+      drafted_by: contributorId,
+    })
+    .select('id')
+    .single();
+  if (nErr || !note) throw nErr;
+
+  const { data: ver, error: vErr } = await sb
+    .from('performers_note_versions')
+    .insert({
+      note_id: note.id,
+      piece_id: pieceId,
+      contributor_id: contributorId,
+      body,
+      authored_by: contributorId,
+      approved_at: new Date().toISOString(),
+      version_number: 1,
+    })
+    .select('id')
+    .single();
+  if (vErr || !ver) throw vErr;
+
+  const { error: upErr } = await sb
+    .from('performers_notes')
+    .update({
+      current_version_id: ver.id,
+      status: 'published',
+      approved_by: contributorId,
+      approved_by_contributor_at: new Date().toISOString(),
+    })
+    .eq('id', note.id);
+  if (upErr) throw upErr;
+}
+
+async function publishSchool(
+  pieceId: string,
+  contributorId: string,
+  name: string,
+  body: string,
+) {
+  const { data: existing } = await sb
+    .from('interpretive_schools')
+    .select('id')
+    .eq('piece_id', pieceId)
+    .eq('contributor_id', contributorId)
+    .eq('name', name)
+    .maybeSingle();
+  if (existing) return;
+
+  const { data: school, error: sErr } = await sb
+    .from('interpretive_schools')
+    .insert({
+      piece_id: pieceId,
+      contributor_id: contributorId,
+      name,
+      status: 'draft',
+      drafted_by: contributorId,
+    })
+    .select('id')
+    .single();
+  if (sErr || !school) throw sErr;
+
+  const { data: ver, error: vErr } = await sb
+    .from('interpretive_school_versions')
+    .insert({
+      school_id: school.id,
+      piece_id: pieceId,
+      contributor_id: contributorId,
+      body,
+      authored_by: contributorId,
+      approved_at: new Date().toISOString(),
+      version_number: 1,
+    })
+    .select('id')
+    .single();
+  if (vErr || !ver) throw vErr;
+
+  const { error: upErr } = await sb
+    .from('interpretive_schools')
+    .update({
+      current_version_id: ver.id,
+      status: 'published',
+      approved_by: contributorId,
+      approved_by_contributor_at: new Date().toISOString(),
+    })
+    .eq('id', school.id);
+  if (upErr) throw upErr;
+}
+
+async function publishDifficulty(pieceId: string, contributorId: string) {
+  const { data: existing } = await sb
+    .from('piece_difficulty_ratings')
+    .select('id')
+    .eq('piece_id', pieceId)
+    .eq('contributor_id', contributorId)
+    .maybeSingle();
+  if (existing) return;
+
+  const { error } = await sb.from('piece_difficulty_ratings').insert({
+    piece_id: pieceId,
+    contributor_id: contributorId,
+    status: 'published',
+    technical_level: 4,
+    technical_note: 'String crossings demand a steady plane.',
+    stamina_level: 3,
+    stamina_note: null,
+    interpretive_level: 5,
+    interpretive_note: 'The Prélude alone takes a lifetime.',
+    ensemble_level: 1,
+    ensemble_note: null,
+  });
+  if (error) throw error;
+}
+
+async function publishLandmark(
+  pieceId: string,
+  contributorId: string,
+  movementId: string,
+  label: string,
+  description: string,
+  measureStart: number,
+) {
+  const { data: existing } = await sb
+    .from('landmarks')
+    .select('id')
+    .eq('piece_id', pieceId)
+    .eq('movement_id', movementId)
+    .eq('contributor_id', contributorId)
+    .maybeSingle();
+  if (existing) return;
+
+  const { data: lm, error: lErr } = await sb
+    .from('landmarks')
+    .insert({
+      piece_id: pieceId,
+      movement_id: movementId,
+      contributor_id: contributorId,
+      status: 'draft',
+      drafted_by: contributorId,
+    })
+    .select('id')
+    .single();
+  if (lErr || !lm) throw lErr;
+
+  const { data: ver, error: vErr } = await sb
+    .from('landmark_versions')
+    .insert({
+      landmark_id: lm.id,
+      piece_id: pieceId,
+      movement_id: movementId,
+      contributor_id: contributorId,
+      label,
+      description,
+      measure_start: measureStart,
+      measure_end: null,
+      ordinal: 1,
+      flags: [],
+      practice_notes: [],
+      authored_by: contributorId,
+      approved_at: new Date().toISOString(),
+      version_number: 1,
+    })
+    .select('id')
+    .single();
+  if (vErr || !ver) throw vErr;
+
+  const { error: upErr } = await sb
+    .from('landmarks')
+    .update({
+      current_version_id: ver.id,
+      status: 'published',
+      approved_by: contributorId,
+      approved_by_contributor_at: new Date().toISOString(),
+    })
+    .eq('id', lm.id);
+  if (upErr) throw upErr;
+}
+
+async function main() {
+  console.log('Creating test users...');
+  const aliceId = await ensureUser(
+    'alice@test.local',
+    'Alice Bartók',
+    'alice',
+    'Cellist · Berlin Philharmonic',
+  );
+  const bobId = await ensureUser(
+    'bob@test.local',
+    'Bob Casals',
+    'bob',
+    'Pedagogue · Curtis',
+  );
+  // Carol has NO username — used to verify the /profile/{id} fallback
+  const carolId = await ensureUser(
+    'carol@test.local',
+    'Carol Du Pré',
+    null as unknown as string, // intentionally unset; ensureUser will set null below
+    'Soloist · no profile slug yet',
+  );
+  await sb.from('users').update({ username: null }).eq('id', carolId);
+
+  console.log(`  Alice ${aliceId} (@alice)`);
+  console.log(`  Bob   ${bobId} (@bob)`);
+  console.log(`  Carol ${carolId} (no username)`);
+
+  console.log(`Publishing signed content on ${PIECE_ID}...`);
+  await publishDescription(
+    PIECE_ID,
+    aliceId,
+    'The first Suite is a study in openness — every phrase folds back into the dominant before resolving home. Most students mistake its candor for ease.',
+  );
+  await publishDescription(
+    PIECE_ID,
+    carolId,
+    'A second voice on this piece, from a contributor without a public username yet — the link should still go to their profile by id.',
+  );
+
+  await publishNote(
+    PIECE_ID,
+    bobId,
+    'Treat the Prélude as a slow exhale; the bow change at the climax should be invisible. Reset before each new tonal area.',
+  );
+  await publishNote(
+    PIECE_ID,
+    aliceId,
+    'For the Allemande: think of the dotted figures as breath, not articulation.',
+  );
+
+  await publishSchool(
+    PIECE_ID,
+    aliceId,
+    'Historically informed',
+    'Gut strings, baroque bow, no end-pin. The dance idiom returns once the instrument resists you.',
+  );
+  await publishSchool(
+    PIECE_ID,
+    bobId,
+    'Romantic',
+    'Sustain the line; let the cello sing through the 19th-century hall it now lives in.',
+  );
+
+  await publishDifficulty(PIECE_ID, aliceId);
+
+  // Landmark needs a movement id — pick the first movement on this piece.
+  const { data: mvmts } = await sb
+    .from('movements')
+    .select('id')
+    .eq('piece_id', PIECE_ID)
+    .order('ordinal')
+    .limit(1);
+  if (mvmts && mvmts.length > 0) {
+    await publishLandmark(
+      PIECE_ID,
+      bobId,
+      mvmts[0].id,
+      'Pedal-G climax',
+      'The long G pedal builds tension across eight measures; resist crescendoing too early.',
+      31,
+    );
+  } else {
+    console.warn('  No movements on piece — skipping landmark.');
+  }
+
+  console.log('\nDone. Test the page at:');
+  console.log(`  http://localhost:4321/piece/${PIECE_ID}`);
+  console.log('\nSign-in credentials (any of):');
+  console.log('  alice@test.local / password123');
+  console.log('  bob@test.local   / password123');
+  console.log('  carol@test.local / password123');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/components/ChangeLog.tsx
+++ b/src/components/ChangeLog.tsx
@@ -66,7 +66,11 @@ export default function ChangeLog({ pieceId, initialEntries }: Props) {
       <ol className="changelog-list">
         {entries.map((r) => (
           <li key={r.id} className="changelog-row">
-            <span className="changelog-who">{r.authoredByDisplayName}</span>
+            {r.authoredByUsername
+              ? <a className="changelog-who" href={`/@${r.authoredByUsername}`}>{r.authoredByDisplayName}</a>
+              : r.authoredBy
+                ? <a className="changelog-who" href={`/profile/${r.authoredBy}`}>{r.authoredByDisplayName}</a>
+                : <span className="changelog-who">{r.authoredByDisplayName}</span>}
             <span className="changelog-sep">·</span>
             <time className="changelog-when" dateTime={r.createdAt}>
               {formatUtc(r.createdAt)}

--- a/src/components/InterpretiveSchools.tsx
+++ b/src/components/InterpretiveSchools.tsx
@@ -119,7 +119,7 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
 
     const [versionsRes, contribsRes] = await Promise.all([
       supabase.from('v_interpretive_school_versions_published').select('id, body, version_number, approved_at').in('id', versionIds),
-      supabase.from('users').select('id, display_name, contributor_bio_short').in('id', contribIds),
+      supabase.from('users').select('id, display_name, username, contributor_bio_short').in('id', contribIds),
     ]);
     const vById = new Map((versionsRes.data ?? []).map((v) => [v.id, v]));
     const cById = new Map((contribsRes.data ?? []).map((c) => [c.id, c]));
@@ -139,7 +139,7 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
         tempoCues: (s.tempo_cues as Record<string, unknown> | null) ?? null,
         versionNumber: v.version_number,
         approvedAt: v.approved_at,
-        contributor: { id: c.id, displayName: c.display_name, bioShort: c.contributor_bio_short ?? null },
+        contributor: { id: c.id, displayName: c.display_name, username: c.username ?? null, bioShort: c.contributor_bio_short ?? null },
       });
     }
     setSchools(rows);
@@ -235,7 +235,7 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
                       {s.body.split(/\n\s*\n/).map((para, i) => <p key={i}>{para}</p>)}
                     </div>
                     <div className="by">
-                      <span className="name">{s.contributor.displayName}</span>
+                      <a className="name" href={s.contributor.username ? `/@${s.contributor.username}` : `/profile/${s.contributor.id}`}>{s.contributor.displayName}</a>
                       {s.contributor.bioShort && (
                         <>
                           <span className="dot" aria-hidden="true"></span>
@@ -378,7 +378,7 @@ export default function InterpretiveSchools({ pieceId, initialSchools }: Props) 
           font-size: 13px;
           color: var(--ink);
         }
-        .school-card .by .name { font-weight: 500; }
+        .school-card .by .name { font-weight: 500; text-decoration: none; color: inherit; }
         .school-card .by .dot {
           display: inline-block;
           width: 3px; height: 3px;

--- a/src/components/NotificationsQueue.tsx
+++ b/src/components/NotificationsQueue.tsx
@@ -26,6 +26,8 @@ interface ContributionRequestMessage {
   composerName: string;
   catalogNumber: string | null;
   senderName: string;
+  senderId: string;
+  senderUsername: string | null;
   note: string | null;
   createdAt: string;
 }
@@ -89,7 +91,7 @@ export default function NotificationsQueue() {
     const pieceIdsForMsgs = [...new Set(crList.map((r) => r.piece_id))];
     const [sendersRes, piecesForMsgsRes] = await Promise.all([
       senderIds.length
-        ? supabase.from('users').select('id, display_name').in('id', senderIds)
+        ? supabase.from('users').select('id, display_name, username').in('id', senderIds)
         : Promise.resolve({ data: [], error: null }),
       pieceIdsForMsgs.length
         ? supabase
@@ -99,7 +101,7 @@ export default function NotificationsQueue() {
         : Promise.resolve({ data: [], error: null }),
     ]);
     const senderById = new Map(
-      ((sendersRes.data ?? []) as { id: string; display_name: string }[]).map((u) => [u.id, u.display_name]),
+      ((sendersRes.data ?? []) as { id: string; display_name: string; username: string | null }[]).map((u) => [u.id, u]),
     );
     const pieceForMsgsById = new Map(
       (
@@ -127,7 +129,9 @@ export default function NotificationsQueue() {
             pieceTitle: piece.title,
             composerName: piece.composer_name,
             catalogNumber: piece.catalog_number ?? null,
-            senderName: senderById.get(cr.sender_id) ?? 'Someone',
+            senderName: senderById.get(cr.sender_id)?.display_name ?? 'Someone',
+            senderId: cr.sender_id,
+            senderUsername: senderById.get(cr.sender_id)?.username ?? null,
             note: cr.note,
             createdAt: cr.created_at,
           },
@@ -259,7 +263,7 @@ function MessageCard({
       </div>
 
       <div className="text-sm text-ink font-body mb-2">
-        <span className="font-medium">{m.senderName}</span>
+        <a className="font-medium" href={m.senderUsername ? `/@${m.senderUsername}` : `/profile/${m.senderId}`} style={{ textDecoration: 'none', color: 'inherit' }}>{m.senderName}</a>
         <span className="text-muted"> asked you to contribute.</span>
       </div>
       <div className="text-[11px] text-tertiary mb-4">{formatTimestamp(m.createdAt)}</div>

--- a/src/components/PendingDraftCard.tsx
+++ b/src/components/PendingDraftCard.tsx
@@ -156,7 +156,7 @@ export default function PendingDraftCard({ draft, onResolved, trailingAction }: 
     <div className="pending-draft" data-kind={draft.kind}>
       <div className="pending-draft-kicker">
         <span className="pending-draft-spark" aria-hidden="true">✦</span>
-        <span>Proposed by {senderName}</span>
+        <span>Proposed by <a className="pending-draft-sender" href={draft.sender.username ? `/@${draft.sender.username}` : `/profile/${draft.sender.id}`}>{senderName}</a></span>
       </div>
 
       {!editing && (

--- a/src/components/PerformersNotes.tsx
+++ b/src/components/PerformersNotes.tsx
@@ -125,7 +125,7 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
 
     const [versionsRes, contribsRes] = await Promise.all([
       supabase.from('v_performers_note_versions_published').select('id, body, version_number, approved_at').in('id', versionIds),
-      supabase.from('users').select('id, display_name, contributor_bio_short').in('id', contribIds),
+      supabase.from('users').select('id, display_name, username, contributor_bio_short').in('id', contribIds),
     ]);
     const vById = new Map((versionsRes.data ?? []).map((v) => [v.id, v]));
     const cById = new Map((contribsRes.data ?? []).map((c) => [c.id, c]));
@@ -143,7 +143,7 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
         body: v.body,
         versionNumber: v.version_number,
         approvedAt: v.approved_at,
-        contributor: { id: c.id, displayName: c.display_name, bioShort: c.contributor_bio_short ?? null },
+        contributor: { id: c.id, displayName: c.display_name, username: c.username ?? null, bioShort: c.contributor_bio_short ?? null },
       });
     }
     setNotes(rows);
@@ -231,7 +231,7 @@ export default function PerformersNotes({ pieceId, initialNotes }: Props) {
                       {note.body.split(/\n\s*\n/).map((para, i) => <p key={i}>{para}</p>)}
                     </div>
                     <div className="by">
-                      <span className="name">{note.contributor.displayName}</span>
+                      <a className="name" href={note.contributor.username ? `/@${note.contributor.username}` : `/profile/${note.contributor.id}`}>{note.contributor.displayName}</a>
                       {note.contributor.bioShort && (
                         <>
                           <span className="dot" aria-hidden="true"></span>

--- a/src/components/SignedPieceDescription.tsx
+++ b/src/components/SignedPieceDescription.tsx
@@ -130,7 +130,7 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
 
     const [versionsRes, contribsRes] = await Promise.all([
       supabase.from('v_piece_description_versions_published').select('id, body, version_number, approved_at').in('id', versionIds),
-      supabase.from('users').select('id, display_name, contributor_bio_short').in('id', contribIds),
+      supabase.from('users').select('id, display_name, username, contributor_bio_short').in('id', contribIds),
     ]);
     const vById = new Map((versionsRes.data ?? []).map((v) => [v.id, v]));
     const cById = new Map((contribsRes.data ?? []).map((c) => [c.id, c]));
@@ -148,7 +148,7 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
         body: v.body,
         versionNumber: v.version_number,
         approvedAt: v.approved_at,
-        contributor: { id: c.id, displayName: c.display_name, bioShort: c.contributor_bio_short ?? null },
+        contributor: { id: c.id, displayName: c.display_name, username: c.username ?? null, bioShort: c.contributor_bio_short ?? null },
       });
     }
     setDescriptions(rows);
@@ -242,7 +242,7 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
                       </div>
                       <div className="by">
                         <div className="by-left">
-                          <span className="name">{d.contributor.displayName}</span>
+                          <a className="name" href={d.contributor.username ? `/@${d.contributor.username}` : `/profile/${d.contributor.id}`}>{d.contributor.displayName}</a>
                           {d.contributor.bioShort && (
                             <>
                               <span className="dot" aria-hidden="true"></span>
@@ -378,7 +378,7 @@ export default function SignedPieceDescription({ pieceId, initialDescriptions, s
           gap: 6px;
           flex: 0 0 auto;
         }
-        .description-essay .by .name { font-weight: 500; }
+        .description-essay .by .name { font-weight: 500; text-decoration: none; color: inherit; }
         .description-essay .by .dot {
           display: inline-block;
           width: 3px; height: 3px;

--- a/src/components/SignedPieceDifficulty.tsx
+++ b/src/components/SignedPieceDifficulty.tsx
@@ -161,7 +161,7 @@ export default function SignedPieceDifficulty({
     const contribIds = [...new Set(data.map((r) => r.contributor_id))];
     const { data: contribs } = await supabase
       .from('users')
-      .select('id, display_name, contributor_bio_short')
+      .select('id, display_name, username, contributor_bio_short')
       .in('id', contribIds);
     const cById = new Map((contribs ?? []).map((c) => [c.id, c]));
 
@@ -178,6 +178,7 @@ export default function SignedPieceDifficulty({
         contributor: {
           id: c.id,
           displayName: c.display_name,
+          username: c.username ?? null,
           bioShort: c.contributor_bio_short ?? null,
         },
       });
@@ -321,7 +322,7 @@ export default function SignedPieceDifficulty({
                   />
                   <div className="diff-card-by">
                     <div className="diff-card-by-left">
-                      <span className="name">{r.contributor.displayName}</span>
+                      <a className="name" href={r.contributor.username ? `/@${r.contributor.username}` : `/profile/${r.contributor.id}`}>{r.contributor.displayName}</a>
                       {r.contributor.bioShort && (
                         <>
                           <span className="dot" aria-hidden="true"></span>
@@ -412,7 +413,7 @@ export default function SignedPieceDifficulty({
           gap: 6px;
           flex: 0 0 auto;
         }
-        .diff-card-by .name { font-weight: 500; }
+        .diff-card-by .name { font-weight: 500; text-decoration: none; color: inherit; }
         .diff-card-by .dot {
           display: inline-block;
           width: 3px; height: 3px;

--- a/src/components/StructuralLandmarks.tsx
+++ b/src/components/StructuralLandmarks.tsx
@@ -248,7 +248,7 @@ export default function StructuralLandmarks({ pieceId, movementId, initialLandma
                 )}
 
                 <div className="landmark-by">
-                  <span className="landmark-by-name">{l.contributor.displayName}</span>
+                  <a className="landmark-by-name" href={l.contributor.username ? `/@${l.contributor.username}` : `/profile/${l.contributor.id}`}>{l.contributor.displayName}</a>
                   {l.contributor.bioShort && (
                     <>
                       <span className="landmark-by-dash" aria-hidden="true">—</span>

--- a/src/lib/contributionDrafts.ts
+++ b/src/lib/contributionDrafts.ts
@@ -26,7 +26,7 @@ export interface PendingDraft {
   kind: DraftKind;
   payload: Record<string, unknown>;
   createdAt: string;
-  sender: { id: string; displayName: string | null };
+  sender: { id: string; displayName: string | null; username: string | null };
   /** Populated by fetchPendingDraftsForViewer() (Open items tab needs
    * piece context to render cross-piece). Null when fetched via
    * fetchPendingDraftsOnPiece() — the piece is implicit there. */
@@ -88,7 +88,7 @@ export async function fetchPendingDraftsOnPiece(pieceId: string): Promise<Pendin
   const senderIds = [...new Set(requests.map((r) => r.sender_id))];
   const { data: senders } = await supabase
     .from('users')
-    .select('id, display_name')
+    .select('id, display_name, username')
     .in('id', senderIds);
   const senderById = new Map((senders ?? []).map((s) => [s.id, s]));
 
@@ -103,7 +103,7 @@ export async function fetchPendingDraftsOnPiece(pieceId: string): Promise<Pendin
       kind: d.kind as DraftKind,
       payload: (d.payload as Record<string, unknown>) ?? {},
       createdAt: d.created_at,
-      sender: { id: req.sender_id, displayName: sender?.display_name ?? null },
+      sender: { id: req.sender_id, displayName: sender?.display_name ?? null, username: sender?.username ?? null },
       piece: null,
     });
   }
@@ -146,7 +146,7 @@ export async function fetchPendingDraftsForViewer(): Promise<PendingDraft[]> {
   const pieceIds = [...new Set(requests.map((r) => r.piece_id))];
 
   const [{ data: senders }, { data: pieces }] = await Promise.all([
-    supabase.from('users').select('id, display_name').in('id', senderIds),
+    supabase.from('users').select('id, display_name, username').in('id', senderIds),
     supabase.from('pieces').select('id, title, composer_name').in('id', pieceIds),
   ]);
 
@@ -167,7 +167,7 @@ export async function fetchPendingDraftsForViewer(): Promise<PendingDraft[]> {
       kind: d.kind as DraftKind,
       payload: (d.payload as Record<string, unknown>) ?? {},
       createdAt: d.created_at,
-      sender: { id: req.sender_id, displayName: sender?.display_name ?? null },
+      sender: { id: req.sender_id, displayName: sender?.display_name ?? null, username: sender?.username ?? null },
       piece,
     });
   }

--- a/src/lib/interpretiveSchools.ts
+++ b/src/lib/interpretiveSchools.ts
@@ -16,6 +16,7 @@ export interface PublishedInterpretiveSchool {
   contributor: {
     id: string;
     displayName: string;
+    username: string | null;
     bioShort: string | null;
   };
 }
@@ -49,7 +50,7 @@ export async function getPublishedInterpretiveSchools(
       .in('id', versionIds),
     supabase
       .from('users')
-      .select('id, display_name, contributor_bio_short')
+      .select('id, display_name, username, contributor_bio_short')
       .in('id', contributorIds),
   ]);
   if (versionsRes.error || !versionsRes.data) return [];
@@ -78,6 +79,7 @@ export async function getPublishedInterpretiveSchools(
       contributor: {
         id: contributor.id,
         displayName: contributor.display_name,
+        username: contributor.username ?? null,
         bioShort: contributor.contributor_bio_short ?? null,
       },
     });

--- a/src/lib/landmarks.ts
+++ b/src/lib/landmarks.ts
@@ -34,6 +34,7 @@ export interface PublishedLandmark {
   contributor: {
     id: string;
     displayName: string;
+    username: string | null;
     bioShort: string | null;
   };
 }
@@ -91,7 +92,7 @@ export async function getPublishedLandmarksForPiece(
       .in('id', versionIds),
     supabase
       .from('users')
-      .select('id, display_name, contributor_bio_short')
+      .select('id, display_name, username, contributor_bio_short')
       .in('id', contributorIds),
   ]);
   if (versionsRes.error || !versionsRes.data) return [];
@@ -130,6 +131,7 @@ export async function getPublishedLandmarksForPiece(
       contributor: {
         id: c.id,
         displayName: c.display_name,
+        username: c.username ?? null,
         bioShort: c.contributor_bio_short ?? null,
       },
     });

--- a/src/lib/movements.ts
+++ b/src/lib/movements.ts
@@ -128,6 +128,7 @@ export interface ChangeLogEntry {
   createdAt: string;
   authoredBy: string | null;
   authoredByDisplayName: string;
+  authoredByUsername: string | null;
   subjectType: ChangeLogSubjectType;
   subjectId: string;
   subjectLabel: string;
@@ -155,6 +156,7 @@ export async function fetchPieceChangelog(pieceId: string): Promise<ChangeLogEnt
     createdAt: r.created_at,
     authoredBy: r.authored_by,
     authoredByDisplayName: r.authored_by_display_name,
+    authoredByUsername: r.authored_by_username ?? null,
     subjectType: r.subject_type,
     subjectId: r.subject_id,
     subjectLabel: r.subject_label,

--- a/src/lib/performersNotes.ts
+++ b/src/lib/performersNotes.ts
@@ -13,6 +13,7 @@ export interface PublishedPerformersNote {
   contributor: {
     id: string;
     displayName: string;
+    username: string | null;
     bioShort: string | null;
   };
 }
@@ -51,7 +52,7 @@ export async function getPublishedPerformersNotes(pieceId: string): Promise<Publ
       .in('id', versionIds),
     supabase
       .from('users')
-      .select('id, display_name, contributor_bio_short')
+      .select('id, display_name, username, contributor_bio_short')
       .in('id', contributorIds),
   ]);
   if (versionsRes.error || !versionsRes.data) return [];
@@ -78,6 +79,7 @@ export async function getPublishedPerformersNotes(pieceId: string): Promise<Publ
       contributor: {
         id: contributor.id,
         displayName: contributor.display_name,
+        username: contributor.username ?? null,
         bioShort: contributor.contributor_bio_short ?? null,
       },
     });

--- a/src/lib/pieceDescriptions.ts
+++ b/src/lib/pieceDescriptions.ts
@@ -13,6 +13,7 @@ export interface PublishedPieceDescription {
   contributor: {
     id: string;
     displayName: string;
+    username: string | null;
     bioShort: string | null;
   };
 }
@@ -43,7 +44,7 @@ export async function getPublishedPieceDescriptions(
       .in('id', versionIds),
     supabase
       .from('users')
-      .select('id, display_name, contributor_bio_short')
+      .select('id, display_name, username, contributor_bio_short')
       .in('id', contributorIds),
   ]);
   if (versionsRes.error || !versionsRes.data) return [];
@@ -70,6 +71,7 @@ export async function getPublishedPieceDescriptions(
       contributor: {
         id: contributor.id,
         displayName: contributor.display_name,
+        username: contributor.username ?? null,
         bioShort: contributor.contributor_bio_short ?? null,
       },
     });

--- a/src/lib/pieceDifficulty.ts
+++ b/src/lib/pieceDifficulty.ts
@@ -19,6 +19,7 @@ export interface PublishedPieceDifficulty {
   contributor: {
     id: string;
     displayName: string;
+    username: string | null;
     bioShort: string | null;
   };
 }
@@ -42,7 +43,7 @@ export async function getPublishedPieceDifficultyRatings(
   const contributorIds = [...new Set(data.map((r) => r.contributor_id))];
   const { data: contribs } = await supabase
     .from('users')
-    .select('id, display_name, contributor_bio_short')
+    .select('id, display_name, username, contributor_bio_short')
     .in('id', contributorIds);
   const contribById = new Map((contribs ?? []).map((c) => [c.id, c]));
 
@@ -59,6 +60,7 @@ export async function getPublishedPieceDifficultyRatings(
       contributor: {
         id: c.id,
         displayName: c.display_name,
+        username: c.username ?? null,
         bioShort: c.contributor_bio_short ?? null,
       },
     });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -572,6 +572,7 @@ body {
   margin-bottom: 10px;
 }
 .pending-draft-spark { font-size: 12px; }
+.pending-draft-sender { color: inherit; text-decoration: none; }
 .pending-draft-body { margin-bottom: 16px; line-height: 1.55; }
 .pending-draft-prose { white-space: pre-wrap; }
 .pending-draft-school-name {

--- a/src/styles/piece-page.css
+++ b/src/styles/piece-page.css
@@ -81,7 +81,7 @@ h2.section { font-family: var(--font-serif); font-size: 22px; font-weight: 500; 
 .signed .prose { font-family: var(--font-serif); font-size: 16px; line-height: 1.65; color: var(--ink); }
 .signed .prose p { margin: 0 0 10px; }
 .signed .by { font-size: 13px; color: var(--muted); margin-top: 14px; display: flex; align-items: center; gap: 10px; }
-.signed .by .name { color: var(--ink); font-weight: 500; }
+.signed .by .name { color: var(--ink); font-weight: 500; text-decoration: none; }
 .signed .by .dot { width: 3px; height: 3px; border-radius: 999px; background: var(--tertiary); }
 
 /* ---------- Landmarks + flags (by movement) ---------- */
@@ -407,6 +407,7 @@ h2.section { font-family: var(--font-serif); font-size: 22px; font-weight: 500; 
 .changelog-who {
   color: var(--ink);
   font-weight: 500;
+  text-decoration: none;
 }
 .changelog-when {
   font-family: var(--font-mono);
@@ -1116,7 +1117,7 @@ h2.section { font-family: var(--font-serif); font-size: 22px; font-weight: 500; 
   padding-top: 10px;
   border-top: 0.5px solid var(--border);
 }
-.landmark-by-name { font-weight: 500; }
+.landmark-by-name { font-weight: 500; text-decoration: none; color: inherit; }
 .landmark-by-dash { margin: 0 6px; color: var(--muted); }
 .landmark-by-bio { color: var(--muted); font-size: 11px; }
 

--- a/supabase/migrations/20260612000000_changelog_authored_by_username.sql
+++ b/supabase/migrations/20260612000000_changelog_authored_by_username.sql
@@ -1,0 +1,177 @@
+-- Add authored_by_username to fetch_piece_changelog so the UI can link
+-- contributor names to their profile page.
+
+begin;
+
+drop function if exists public.fetch_piece_changelog(text);
+
+create or replace function public.fetch_piece_changelog(
+  p_piece_id text
+) returns table (
+  id text,
+  created_at timestamptz,
+  authored_by uuid,
+  authored_by_display_name text,
+  authored_by_username text,
+  subject_type text,
+  subject_id text,
+  subject_label text,
+  edit_summary text,
+  version_number integer
+)
+  language sql
+  security definer
+  set search_path = public
+as $$
+  select
+    mv.id::text as id,
+    mv.created_at,
+    mv.authored_by,
+    coalesce(u.display_name, 'Seed data') as authored_by_display_name,
+    u.username as authored_by_username,
+    'movement'::text as subject_type,
+    mv.movement_id::text as subject_id,
+    mv.name as subject_label,
+    mv.edit_summary,
+    mv.version_number
+  from public.movement_versions mv
+  left join public.users u on u.id = mv.authored_by
+  where mv.piece_id = p_piece_id
+
+  union all
+
+  select
+    pnv.id::text,
+    pnv.created_at,
+    pnv.authored_by,
+    coalesce(u.display_name, 'Seed data'),
+    u.username,
+    'performer''s note'::text,
+    pnv.note_id::text,
+    substring(pnv.body from 1 for 80) as subject_label,
+    case when pnv.version_number = 1 then 'published' else 'edited' end,
+    pnv.version_number
+  from public.performers_note_versions pnv
+  left join public.users u on u.id = pnv.authored_by
+  where pnv.piece_id = p_piece_id
+    and pnv.approved_at is not null
+
+  union all
+
+  select
+    ('pnrm-' || pn.id::text),
+    pn.removed_at,
+    pn.removed_by,
+    coalesce(u.display_name, 'Seed data'),
+    u.username,
+    'performer''s note'::text,
+    pn.id::text,
+    substring(coalesce(pnv.body, '') from 1 for 80),
+    'removed'::text,
+    null::integer
+  from public.performers_notes pn
+  left join public.performers_note_versions pnv on pnv.id = pn.current_version_id
+  left join public.users u on u.id = pn.removed_by
+  where pn.piece_id = p_piece_id
+    and pn.status = 'removed'
+    and pn.removed_at is not null
+
+  union all
+
+  select
+    isv.id::text,
+    isv.created_at,
+    isv.authored_by,
+    coalesce(u.display_name, 'Seed data'),
+    u.username,
+    'interpretive school'::text,
+    isv.school_id::text,
+    s.name,
+    case when isv.version_number = 1 then 'published' else 'edited' end,
+    isv.version_number
+  from public.interpretive_school_versions isv
+  join public.interpretive_schools s on s.id = isv.school_id
+  left join public.users u on u.id = isv.authored_by
+  where isv.piece_id = p_piece_id
+    and isv.approved_at is not null
+
+  union all
+
+  select
+    ('isrm-' || s.id::text),
+    s.removed_at,
+    s.removed_by,
+    coalesce(u.display_name, 'Seed data'),
+    u.username,
+    'interpretive school'::text,
+    s.id::text,
+    s.name,
+    'removed'::text,
+    null::integer
+  from public.interpretive_schools s
+  left join public.users u on u.id = s.removed_by
+  where s.piece_id = p_piece_id
+    and s.status = 'removed'
+    and s.removed_at is not null
+
+  union all
+
+  select
+    pdv.id::text,
+    pdv.created_at,
+    pdv.authored_by,
+    coalesce(u.display_name, 'Seed data'),
+    u.username,
+    'piece description'::text,
+    pdv.description_id::text,
+    substring(pdv.body from 1 for 80) as subject_label,
+    case when pdv.version_number = 1 then 'published' else 'edited' end,
+    pdv.version_number
+  from public.piece_description_versions pdv
+  left join public.users u on u.id = pdv.authored_by
+  where pdv.piece_id = p_piece_id
+    and pdv.approved_at is not null
+
+  union all
+
+  select
+    ('pdrm-' || d.id::text),
+    d.removed_at,
+    d.removed_by,
+    coalesce(u.display_name, 'Seed data'),
+    u.username,
+    'piece description'::text,
+    d.id::text,
+    substring(coalesce(pdv.body, '') from 1 for 80),
+    'removed'::text,
+    null::integer
+  from public.piece_descriptions d
+  left join public.piece_description_versions pdv on pdv.id = d.current_version_id
+  left join public.users u on u.id = d.removed_by
+  where d.piece_id = p_piece_id
+    and d.status = 'removed'
+    and d.removed_at is not null
+
+  union all
+
+  select
+    ('cml-' || cml.id::text),
+    cml.occurred_at,
+    cml.actor_id,
+    coalesce(u.display_name, 'Seed data'),
+    u.username,
+    cml.subject_type,
+    cml.subject_id,
+    cml.subject_label,
+    cml.action,
+    null::integer
+  from public.content_mutation_log cml
+  left join public.users u on u.id = cml.actor_id
+  where cml.piece_id = p_piece_id
+
+  order by created_at desc, version_number desc nulls last;
+$$;
+
+grant execute on function public.fetch_piece_changelog(text) to anon, authenticated;
+
+commit;


### PR DESCRIPTION
## Summary

Every contributor name attached to content is now a link to their profile page. Reader sees the byline, asks "who is that?", clicks — they're on the profile. Visual treatment is unchanged (same ink color, same font-weight, no underline) so the byline still reads as type, not a link island.

The link goes to `/@{username}` when the contributor has claimed a username, and falls back to `/profile/{id}` for users who haven't set one yet — every contributor is reachable, even pre-username.

**Surfaces updated** (every place a contributor name appears next to content):
- Piece descriptions, performer's notes, interpretive schools, difficulty ratings, structural landmarks
- Unified change log on each piece (`Seed data` rows stay as plain text since they have no author)
- Pending-draft "Proposed by …" cards
- Notification queue rows ("X asked you to contribute")

**Stack of changes:**
1. `feat(db,lib)` — `username` carried through every contributor type + every fetcher selects it. New migration extends `fetch_piece_changelog` to return `authored_by_username` on every union branch.
2. `feat(ui)` — name `<span>` → `<a>` with profile href. CSS reset (`text-decoration: none; color: inherit`) on `.name`, `.landmark-by-name`, `.changelog-who` keeps the link visually identical to the previous span.
3. `chore` — seed script + CHANGELOG.

## Test plan

- [x] `bun run tsc --noEmit` — clean (one pre-existing error in `SignedPieceDifficulty.tsx:383` unrelated to this branch)
- [x] `bunx supabase db reset` — migration applies cleanly
- [x] `bun run test` — 162 pass; 3 failures are pre-existing on `main` (network-dependent `pieces.test.ts`)
- [x] Verified in browser via `scripts/seed-profile-link-test.ts` on a piece page:
  - Description by Alice → `/@alice` ✓
  - Description by Carol (no username) → `/profile/{uuid}` ✓
  - Performer's notes, interpretive schools, difficulty rating, landmark — all link correctly
  - Change log rows — Bob/Alice → `/@username`, Carol → `/profile/{id}`
  - Computed CSS: `text-decoration-line: none`, `color: rgb(26,26,26)`, `font-weight: 500` (matches prior `<span>` rendering)
- [x] Profile pages resolve for both URL forms (`/@alice` → "Alice Bartók" page; `/profile/{uuid}` → "Carol Du Pré" page)

## Local test setup

\`\`\`bash
bun run scripts/seed-profile-link-test.ts
# then visit http://localhost:4321/piece/bach-cello-suite-1
\`\`\`

Seeds three users (Alice w/ username, Bob w/ username, Carol w/o) and publishes signed content from each. Idempotent — rerun any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)